### PR TITLE
Fix wrong filters to show running labs

### DIFF
--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -75,19 +75,22 @@ def running_labs():
 
     labs = []
     for li in lab_instances.all():
-        groups = []
+        show_labinst = False
         current_app.logger.info(f"filter lab_instances {filter_group=} {current_user_groups=} {allowed_groups_by_lab[li.lab_id]=}")
         if filter_group == "all":
-            for group_id in current_user_groups:
-                if group_id in allowed_groups_by_lab[li.lab_id]:
-                    groups.append(allowed_groups_by_lab[li.lab_id][group_id].groupname)
+            if current_user.category == "admin":
+                show_labinst = True
+            else:
+                for group_id in current_user_groups:
+                    if group_id in allowed_groups_by_lab[li.lab_id]:
+                        show_labinst = True
         elif filter_group:
             if filter_group in allowed_groups_by_lab[li.lab_id]:
-                groups.append(allowed_groups_by_lab[li.lab_id][filter_group].groupname)
+                show_labinst = True
         else:
             if li.user_id == current_user.id:
-                groups.append("--")
-        if not groups:
+                show_labinst = True
+        if not show_labinst:
             continue
 
         user = registered_user.get(li.user_id)

--- a/apps/templates/pages/lab_instance_view.html
+++ b/apps/templates/pages/lab_instance_view.html
@@ -296,8 +296,8 @@ word-break: break-all;
         request.fail(function(xhr) {
           $(document).Toasts('create', {
             class: 'bg-danger',
-            title: 'Failure',
-            body: data.result
+            title: 'Failure to save Lab Answers',
+            body: xhr.responseText
           });
         });
       }
@@ -338,12 +338,15 @@ word-break: break-all;
           });
         });
         request.fail(function(xhr) {
+          if (xhr.status == 401) {
+            return;
+          }
           $(document).Toasts('create', {
             class: 'bg-danger',
-            title: 'Failed to load answers',
+            title: 'Failed to load Lab Answers',
             autohide: true,
             delay: 4000,
-            body: data.result
+            body: xhr.responseText
           });
         });
       });

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -16,7 +16,7 @@ def update_running_labs_stats():
     running_labs = cache.get(f"running_labs-{user_id}")
     if running_labs is None:
         running_labs = LabInstances.query.filter_by(is_deleted=False)
-        if user_id != "all" and getattr(current_user, "category", "student") not in ["admin", "teacher"]:
+        if user_id != "all":
             running_labs = running_labs.filter_by(user_id=user_id)
         running_labs = running_labs.count()
         cache.set(f"running_labs-{user_id}", running_labs)


### PR DESCRIPTION
Fix #57 

### Description of the change

This PR fixes three issues: 1) when showing the running labs by a Admin user, the list of All Labs was incorrect; 2) the number of running labs on the sidebar menu was also incorrect for admin users (not being the "Your own labs"); 3) when displaying the Lab Instance for another user, we could not see his/her answers (401 Unauthorized) and that message was being handled incorrectly (data variable was not available) -- I also took the opportunity to hide this unauthorized error message because when a admin/teacher/assistant sees someone else's lab that message would be annoying.