### PR TITLE
making dynamic analytics loader specific to google tags to avoid risks

### DIFF
--- a/apps/config.py
+++ b/apps/config.py
@@ -91,8 +91,7 @@ class Config(object):
     CACHE_DEFAULT_TIMEOUT = int(os.getenv("CACHE_DEFAULT_TIMEOUT", 300))
 
     # Analytics measurement
-    ANALYTICS_JSFILE = os.getenv("ANALYTICS_JSFILE", "")
-    ANALYTICS_SCRIPT = os.getenv("ANALYTICS_SCRIPT", "")
+    GTAG = os.getenv("GTAG", "")
 
 class ProductionConfig(Config):
     DEBUG = False

--- a/apps/templates/layouts/base.html
+++ b/apps/templates/layouts/base.html
@@ -30,12 +30,10 @@
 {% block javascripts %}{% endblock javascripts %}
 
 <!-- Analytics measurements -->
-{% if config.ANALYTICS_JSFILE %}
-<script async src="{{config.ANALYTICS_JSFILE}}"></script>
-{% endif %}
-{% if config.ANALYTICS_SCRIPT %}
+{% if config.GTAG %}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{config.GTAG}}"></script>
 <script>
-{{config.ANALYTICS_SCRIPT|safe}}
+window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);};gtag('js',new Date());gtag('config', '{{config.GTAG}}');
 </script>
 {% endif %}
 


### PR DESCRIPTION
Enhancement on PR #59 to be more specific to google analytics and avoid risks