### PR TITLE
refact: add user category check decorator for route access control

### DIFF
--- a/apps/audit_mixin.py
+++ b/apps/audit_mixin.py
@@ -2,6 +2,8 @@ import datetime
 from sqlalchemy import Column, DateTime, Integer, ForeignKey
 from flask_login import current_user
 from flask import request
+from functools import wraps
+from flask import render_template
 
 def utcnow():
     return datetime.datetime.now(datetime.timezone.utc)
@@ -25,3 +27,13 @@ class AuditMixin(object):
     created_at = Column(DateTime, default=utcnow)
     updated_at = Column(DateTime, default=utcnow, onupdate=utcnow)
     updated_by = Column(Integer, ForeignKey("users.id"), default=get_user_id)
+
+def check_user_category(allowed_categories):
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            if current_user.category not in allowed_categories:
+                return render_template("pages/error.html", title="Unauthorized request", msg="You dont have permission to see this page")
+            return f(*args, **kwargs)
+        return decorated_function
+    return decorator

--- a/apps/audit_mixin.py
+++ b/apps/audit_mixin.py
@@ -33,6 +33,9 @@ def check_user_category(allowed_categories):
         @wraps(f)
         def decorated_function(*args, **kwargs):
             if current_user.category not in allowed_categories:
+                if current_user.category == "user":
+                    return render_template('pages/waiting_approval.html')
+                
                 return render_template("pages/error.html", title="Unauthorized request", msg="You dont have permission to see this page")
             return f(*args, **kwargs)
         return decorated_function


### PR DESCRIPTION
This pull request introduces a new decorator function to handle user category permissions and applies it to various routes in the `apps/home/routes.py` file. The most important changes include the addition of the `check_user_category` decorator and its application to multiple route functions to ensure only authorized users can access certain pages.

Fix #65 