### PR TITLE
Using forked Authlib version to temporary workaround problem on CILogon+ORCID

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ flask-sqlalchemy
 sqlalchemy
 email_validator
 flask-restx
-authlib
+authlib @ git+https://github.com/italovalcy/authlib@v1.5.1-p1
 requests
 python-dotenv
 gunicorn


### PR DESCRIPTION
Fix #87 

### Description of the change

This is a temporary solution for the problem with authenticating via CILogon + ORCID.