### PR TITLE
Changes for K8S_AVOID_NODES configuration

### DIFF
--- a/apps/config.py
+++ b/apps/config.py
@@ -69,7 +69,7 @@ class Config(object):
     # Kubernetes
     K8S_NAMESPACE = os.getenv('K8S_NAMESPACE', "")
     K8S_CONFIG = os.path.expanduser(os.getenv("KUBECONFIG", "~/.kube/config"))
-    K8S_AVOID_NODES = ["whx-rn", "ids-pb", "ids-pe", "vm1-ac", "vm1-mt", "whx-pb", "whx-rn"]
+    K8S_AVOID_NODES = os.getenv("K8S_AVOID_NODES", "").split(",")
 
     # Base URL
     BASE_URL = os.getenv("BASE_URL", 'https://dashboard.hackinsdn.ufba.br')

--- a/apps/controllers/kubernetes.py
+++ b/apps/controllers/kubernetes.py
@@ -54,7 +54,7 @@ class K8sController():
         self.v1_api = client.CoreV1Api()
         self.apps_v1_api = client.AppsV1Api()
         self.k8s_client = client.ApiClient()
-        self.k8s_avoid_nodes = app_config.K8S_AVOID_NODES
+        self.k8s_avoid_nodes = set(app_config.K8S_AVOID_NODES)
 
         self.identifiers = {
             "pod_hash": self.get_pod_hash,


### PR DESCRIPTION
- Changing K8S_AVOID_NODES to be an environment variable in the format of a string with a comma-separated list of Kubernetes nodes to avoid
- Using `set` type instead of `list` to improve time complexity during `in` operations