### PR TITLE
Display issuer in user visualization as read-only

### DIFF
--- a/apps/authentication/routes.py
+++ b/apps/authentication/routes.py
@@ -163,6 +163,13 @@ def register():
 
         # else we can create the user
         user = Users(**request.form)
+        
+        form_data = request.form.to_dict()
+        form_data["issuer"] = "LOCAL"
+        
+        user = Users(**form_data)
+        db.session.add(user)
+        db.session.commit()
 
         confirmation_token = str(uuid.uuid4().int)[:6]
         session['confirmation_token'] = confirmation_token

--- a/apps/authentication/routes.py
+++ b/apps/authentication/routes.py
@@ -161,15 +161,12 @@ def register():
                                    success=False,
                                    form=create_account_form)
 
-        # else we can create the user
-        user = Users(**request.form)
-        
-        form_data = request.form.to_dict()
-        form_data["issuer"] = "LOCAL"
-        
-        user = Users(**form_data)
-        db.session.add(user)
-        db.session.commit()
+        # else: send confirmation e-mail if configured or create user
+        if not app.config['MAIL_SERVER']:
+            user = Users(**request.form, issuer="LOCAL")
+            db.session.add(user)
+            db.session.commit()
+            return redirect(url_for('authentication_blueprint.login'))
 
         confirmation_token = str(uuid.uuid4().int)[:6]
         session['confirmation_token'] = confirmation_token

--- a/apps/authentication/routes.py
+++ b/apps/authentication/routes.py
@@ -170,7 +170,8 @@ def register():
 
         confirmation_token = str(uuid.uuid4().int)[:6]
         session['confirmation_token'] = confirmation_token
-        session['user'] = request.form
+        session['user'] = request.form.to_dict()
+        session['user']['issuer'] = "LOCAL"
         session['datetime'] = utcnow()
 
         # Send email

--- a/apps/templates/pages/edit_user.html
+++ b/apps/templates/pages/edit_user.html
@@ -78,7 +78,7 @@
                 <!-- /.form-group -->
                 <div class="form-group">
                   <label>E-mail</label>
-                  <input name="email" type="text" class="form-control" value="{{user.email}}" {{'disabled' if user.id != current_user.id and current_user.category != 'admin' else ''}}/>
+                  <input name="email" type="text" class="form-control" value="{{user.email|default('', true)}}" {{'disabled' if user.id != current_user.id and current_user.category != 'admin' else ''}}/>
                 </div>
                 <!-- /.form-group -->
                 <div class="form-group">
@@ -113,6 +113,12 @@
                 </div>
               </div>
               <div class="col-md-6">
+                <!-- /.form-group -->
+                <div class="form-group">
+                  <label>Issuer</label>
+                  <input type="text" class="form-control" value="{{user.issuer|default('LOCAL', true)}}" disabled/>
+                </div>
+                <!-- /.form-group -->
                 <div class="form-group">
                   <label>Member of groups:</label>
                   <select name="member_of_groups" multiple class="form-control" disabled>

--- a/apps/templates/pages/users.html
+++ b/apps/templates/pages/users.html
@@ -69,6 +69,7 @@
                     <th>Full name</th>
                     <th>E-mail</th>
                     <th>Category</th>
+                    <th>Issuer</th>
                     <th>Actions</th>
                   </tr>
                 </thead>
@@ -85,6 +86,7 @@
                   <td>{{ user.name }}</td>
                   <td>{{ user.email }}</td>
                   <td>{{ user.category }}</td>
+                  <td>{{ user.issuer }}</td>
                   <td><a href="{{url_for('home_blueprint.edit_user', user_id=user.id)}}" class="btn btn-outline-dark" role="button" aria-pressed="true"><i class="fa fa-pen"></i> Edit</a></td>
                 </tr>
                 {% endfor %}

--- a/apps/templates/pages/users.html
+++ b/apps/templates/pages/users.html
@@ -84,9 +84,9 @@
                   </td>
             	  <td>{{ user.username }}</td>
                   <td>{{ user.name }}</td>
-                  <td>{{ user.email }}</td>
+                  <td>{{ user.email|default('', true) }}</td>
                   <td>{{ user.category }}</td>
-                  <td>{{ user.issuer }}</td>
+                  <td>{{ user.issuer|default('LOCAL', true) }}</td>
                   <td><a href="{{url_for('home_blueprint.edit_user', user_id=user.id)}}" class="btn btn-outline-dark" role="button" aria-pressed="true"><i class="fa fa-pen"></i> Edit</a></td>
                 </tr>
                 {% endfor %}
@@ -201,6 +201,7 @@
           { name: 'name' },
           { name: 'email' },
           { name: 'category' },
+          { name: 'issuer' },
           {
             orderable: false,
             name: 'actions',


### PR DESCRIPTION
This PR adds the issuer field to the user visualization view (/users/<userid>) in read-only mode, allowing admins to distinguish between LOCAL and Federated users.

The issuer is automatically set to LOCAL if the user was registered locally, helping to identify the origin of the user's account without allowing manual modifications.

Close #105