### PR TITLE
Add option to hide comments on the Feedback page (admin only)

### DIFF
--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -767,25 +767,26 @@ def add_answer_sheet():
     return render_template("pages/lab_answers_sheet.html", labs=labs, lab_id=lab_id, answers=answers, msg_ok="Lab answer sheet saved!")
 
 @blueprint.route('/feedback/hide', methods=["POST"])
-@check_user_category(["admin", "teacher", "student"])
 @login_required
+@check_user_category(["admin"])
 def hide_feedback():
-    data = request.get_json() if request.is_json else request.form
-    feedback_id = data.get("feedback_id")
-    action = data.get("action")
+    feedback_id = request.form.get("feedback_id")
+    action = request.form.get("action")
     if not feedback_id or action not in ["hide", "unhide"]:
-        return redirect(url_for('home_blueprint.feedback_view', msg='Missing feedback ID or invalid action', category='danger'))
+        return redirect(url_for('home_blueprint.feedback_view'))
 
-    feedback = UserFeedbacks.query.get_or_404(feedback_id)
-    if current_user.category == "admin":
-        if action == "hide":
-            feedback.is_hidden = True
-        else:
-            feedback.is_hidden = False
-        db.session.commit()
-        cache.delete("user_feedbacks")
-        return redirect(request.referrer or url_for('home_blueprint.feedback_view'))
-    return {"status": "fail", "result": "Unauthorized to hide this feedback"}, 403
+    feedback = UserFeedbacks.query.get(feedback_id)
+    if not feedback:
+        return redirect(url_for('home_blueprint.feedback_view'))
+
+    if action == "hide":
+        feedback.is_hidden = True
+    else:
+        feedback.is_hidden = False
+    db.session.commit()
+    cache.delete("user_feedbacks")
+    return redirect(request.referrer or url_for('home_blueprint.feedback_view'))
+
 
 @blueprint.route('/feedback_view', methods=["GET"])
 @login_required

--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -776,7 +776,7 @@ def hide_feedback():
         return {"status": "fail", "result": "Missing feedback_id or invalid action"}, 400
 
     feedback = UserFeedbacks.query.get_or_404(feedback_id)
-    if current_user.category in ["admin"] or feedback.user_id == current_user.id:
+    if current_user.category in ["admin"]:
         if action == "hide":
             feedback.is_hidden = True
         else:

--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -767,16 +767,17 @@ def add_answer_sheet():
     return render_template("pages/lab_answers_sheet.html", labs=labs, lab_id=lab_id, answers=answers, msg_ok="Lab answer sheet saved!")
 
 @blueprint.route('/feedback/hide', methods=["POST"])
+@check_user_category(["admin", "teacher", "student"])
 @login_required
 def hide_feedback():
     data = request.get_json() if request.is_json else request.form
     feedback_id = data.get("feedback_id")
     action = data.get("action")
     if not feedback_id or action not in ["hide", "unhide"]:
-        return {"status": "fail", "result": "Missing feedback_id or invalid action"}, 400
+        return redirect(url_for('home_blueprint.feedback_view', msg='Missing feedback ID or invalid action', category='danger'))
 
     feedback = UserFeedbacks.query.get_or_404(feedback_id)
-    if current_user.category in ["admin"]:
+    if current_user.category == "admin":
         if action == "hide":
             feedback.is_hidden = True
         else:

--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -771,12 +771,16 @@ def add_answer_sheet():
 def hide_feedback():
     data = request.get_json() if request.is_json else request.form
     feedback_id = data.get("feedback_id")
-    if not feedback_id:
-        return {"status": "fail", "result": "Missing feedback_id"}, 400
+    action = data.get("action")
+    if not feedback_id or action not in ["hide", "unhide"]:
+        return {"status": "fail", "result": "Missing feedback_id or invalid action"}, 400
 
     feedback = UserFeedbacks.query.get_or_404(feedback_id)
     if current_user.category in ["admin"] or feedback.user_id == current_user.id:
-        feedback.is_hidden = True
+        if action == "hide":
+            feedback.is_hidden = True
+        else:
+            feedback.is_hidden = False
         db.session.commit()
         cache.delete("user_feedbacks")
         return redirect(request.referrer or url_for('home_blueprint.feedback_view'))

--- a/apps/templates/pages/feedback_view.html
+++ b/apps/templates/pages/feedback_view.html
@@ -74,7 +74,6 @@
                   </div>
                 {% if current_user.category == "admin" %}
                   <div style="color: gray">
-                    <p>{{ feedback.comment }}</p>
                     {% if feedback.is_hidden %}
                     <em>(Hidden Comment)</em>
                     <form action="{{ url_for('home_blueprint.hide_feedback') }}" method="POST" style="display:inline;">
@@ -92,7 +91,6 @@
                   </div>
                 {% else %}
                   {% if not feedback.is_hidden %}
-                    <p>{{ feedback.comment }}</p>
                   {% endif %}
                 {% endif %}
                 {% endfor %}

--- a/apps/templates/pages/feedback_view.html
+++ b/apps/templates/pages/feedback_view.html
@@ -56,7 +56,7 @@
                   <div class="media mb-4 p-3 rounded bg-light shadow-sm">
                     <div class="media-body">
                       <div class="d-flex justify-content-between align-items-center mb-2">
-			<h5 class="mb-0 text-primary font-weight-bold">{{ feedback.user.name }}</h5>
+                        <h5 class="mb-0 text-primary font-weight-bold">{{ feedback.user.name }}</h5>
                         <div class="text-warning">
                           {% for i in range(feedback.stars) %}
                             <i class="fas fa-star"></i>
@@ -67,32 +67,28 @@
                         </div>
                       </div>
                       <p class="mb-2 text-dark"><i class="fas fa-quote-left mr-2 text-muted"></i>{{ feedback.comment }}</p>
+                      {% if current_user.category == "admin" %}
+                      <div class="float-right">
+                        {% if feedback.is_hidden %}
+                        <form action="{{ url_for('home_blueprint.hide_feedback') }}" method="POST" class="d-inline">
+                          <input type="hidden" name="feedback_id" value="{{ feedback.id }}">
+                          <input type="hidden" name="action" value="unhide">
+                          <button type="submit" class="btn btn-info btn-sm">Unhide</button>
+                        </form>
+                        {% else %}
+                        <form action="{{ url_for('home_blueprint.hide_feedback') }}" method="POST" class="d-inline">
+                          <input type="hidden" name="feedback_id" value="{{ feedback.id }}">
+                          <input type="hidden" name="action" value="hide">
+                          <button type="submit" class="btn btn-warning btn-sm">Hide</button>
+                        </form>
+                        {% endif %}
+                      </div>
+                      {% endif %}
                       <p class="text-muted mb-0 small">
                         <i class="far fa-clock mr-1"></i><span class="fmt-date-time">{{ feedback.created_at_str }}</span>
                       </p>
                     </div>
                   </div>
-                {% if current_user.category == "admin" %}
-                  <div class="text-muted">
-                    {% if feedback.is_hidden %}
-                    <em>(Hidden Comment)</em>
-                    <form action="{{ url_for('home_blueprint.hide_feedback') }}" method="POST" class="d-inline">
-                      <input type="hidden" name="feedback_id" value="{{ feedback.id }}">
-                      <input type="hidden" name="action" value="unhide">
-                      <button type="submit" class="btn btn-warning btn-sm">Unhide</button>
-                    </form>
-                  {% else %}
-                    <form action="{{ url_for('home_blueprint.hide_feedback') }}" method="POST" class="d-inline">
-                      <input type="hidden" name="feedback_id" value="{{ feedback.id }}">
-                      <input type="hidden" name="action" value="hide">
-                      <button type="submit" class="btn btn-warning btn-sm">Hide</button>
-                    </form>
-                  {% endif %}
-                  </div>
-                {% else %}
-                  {% if not feedback.is_hidden %}
-                  {% endif %}
-                {% endif %}
                 {% endfor %}
               {% else %}
                 <p class="text-center text-muted">No feedbacks available yet.</p>

--- a/apps/templates/pages/feedback_view.html
+++ b/apps/templates/pages/feedback_view.html
@@ -73,16 +73,16 @@
                     </div>
                   </div>
                 {% if current_user.category == "admin" %}
-                  <div style="color: gray">
+                  <div class="text-muted">
                     {% if feedback.is_hidden %}
                     <em>(Hidden Comment)</em>
-                    <form action="{{ url_for('home_blueprint.hide_feedback') }}" method="POST" style="display:inline;">
+                    <form action="{{ url_for('home_blueprint.hide_feedback') }}" method="POST" class="d-inline">
                       <input type="hidden" name="feedback_id" value="{{ feedback.id }}">
                       <input type="hidden" name="action" value="unhide">
                       <button type="submit" class="btn btn-warning btn-sm">Unhide</button>
                     </form>
                   {% else %}
-                    <form action="{{ url_for('home_blueprint.hide_feedback') }}" method="POST" style="display:inline;">
+                    <form action="{{ url_for('home_blueprint.hide_feedback') }}" method="POST" class="d-inline">
                       <input type="hidden" name="feedback_id" value="{{ feedback.id }}">
                       <input type="hidden" name="action" value="hide">
                       <button type="submit" class="btn btn-warning btn-sm">Hide</button>

--- a/apps/templates/pages/feedback_view.html
+++ b/apps/templates/pages/feedback_view.html
@@ -76,13 +76,19 @@
                   <div style="color: gray">
                     <p>{{ feedback.comment }}</p>
                     {% if feedback.is_hidden %}
-                      <em>(Hidden Comment)</em>
-                    {% else %}
-                      <form action="{{ url_for('home_blueprint.hide_feedback') }}" method="POST" style="display:inline;">
-                        <input type="hidden" name="feedback_id" value="{{ feedback.id }}">
-                        <button type="submit" class="btn btn-warning btn-sm">Hide</button>
-                      </form>
-                    {% endif %}
+                    <em>(Hidden Comment)</em>
+                    <form action="{{ url_for('home_blueprint.hide_feedback') }}" method="POST" style="display:inline;">
+                      <input type="hidden" name="feedback_id" value="{{ feedback.id }}">
+                      <input type="hidden" name="action" value="unhide">
+                      <button type="submit" class="btn btn-warning btn-sm">Unhide</button>
+                    </form>
+                  {% else %}
+                    <form action="{{ url_for('home_blueprint.hide_feedback') }}" method="POST" style="display:inline;">
+                      <input type="hidden" name="feedback_id" value="{{ feedback.id }}">
+                      <input type="hidden" name="action" value="hide">
+                      <button type="submit" class="btn btn-warning btn-sm">Hide</button>
+                    </form>
+                  {% endif %}
                   </div>
                 {% else %}
                   {% if not feedback.is_hidden %}

--- a/apps/templates/pages/feedback_view.html
+++ b/apps/templates/pages/feedback_view.html
@@ -72,6 +72,23 @@
                       </p>
                     </div>
                   </div>
+                {% if current_user.category == "admin" %}
+                  <div style="color: gray">
+                    <p>{{ feedback.comment }}</p>
+                    {% if feedback.is_hidden %}
+                      <em>(Hidden Comment)</em>
+                    {% else %}
+                      <form action="{{ url_for('home_blueprint.hide_feedback') }}" method="POST" style="display:inline;">
+                        <input type="hidden" name="feedback_id" value="{{ feedback.id }}">
+                        <button type="submit" class="btn btn-warning btn-sm">Hide</button>
+                      </form>
+                    {% endif %}
+                  </div>
+                {% else %}
+                  {% if not feedback.is_hidden %}
+                    <p>{{ feedback.comment }}</p>
+                  {% endif %}
+                {% endif %}
                 {% endfor %}
               {% else %}
                 <p class="text-center text-muted">No feedbacks available yet.</p>


### PR DESCRIPTION
This PR introduces the following improvements to the feedback page for admin users:
Adds an option for admin users to hide specific comments.
Enables admin users to view all comments, including the hidden ones.
Enable viewing hidden comments

Close #120