### PR TITLE
Add cancel button to lab edit page and redirect after successful edit

### DIFF
--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -417,7 +417,7 @@ def edit_lab(lab_id):
     db.session.commit()
 
     if status:
-        return render_template("pages/labs_edit.html", lab=lab, lab_categories=lab_categories, msg_ok=msg, segment="/labs/edit", groups=groups, allowed_groups=lab.allowed_groups)
+        return redirect(url_for('home_blueprint.view_labs', lab_id=lab.id))
     else:
         return render_template("pages/labs_edit.html", lab=lab, lab_categories=lab_categories, msg_fail=msg, segment="/labs/edit", groups=groups, allowed_groups=lab.allowed_groups)
 

--- a/apps/templates/pages/labs_edit.html
+++ b/apps/templates/pages/labs_edit.html
@@ -405,6 +405,7 @@
         <div class="row">
           <div class="col-md-12 mb-2">
             <button type="submit" class="btn btn-primary">Submit</button>
+            <a href="{{ url_for('home_blueprint.view_labs', lab_id=lab.id) if lab.id else url_for('home_blueprint.view_labs') }}" class="btn btn-secondary mx-2" role="button" aria-pressed="true">Cancel</a>
           </div>
         </div>
       </div><!-- /.container-fluid -->


### PR DESCRIPTION
This pull request introduces a change to improve user navigation by redirecting to the labs view page after editing a lab and adding a "Cancel" button to the lab edit page.

Closes #128 