### PR TITLE
revert: remove unnecessary import (PR #151)

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -42,6 +42,8 @@ def register_blueprints(app):
     for module_name in ('authentication', 'home', 'api', 'k8s', 'cli'):
         module = import_module('apps.{}.routes'.format(module_name))
         app.register_blueprint(module.blueprint)
+    # Load socketio endpoints
+    import_module("apps.events")
 
 
 def configure_database(app):

--- a/apps/home/__init__.py
+++ b/apps/home/__init__.py
@@ -4,7 +4,6 @@ Copyright (c) 2019 - 2024 AppSeed.us
 Copyright (c) 2014 - present HackInSDN team
 """
 
-import apps.events # noqa: F401
 from flask import Blueprint
 
 blueprint = Blueprint(

--- a/apps/home/__init__.py
+++ b/apps/home/__init__.py
@@ -4,6 +4,7 @@ Copyright (c) 2019 - 2024 AppSeed.us
 Copyright (c) 2014 - present HackInSDN team
 """
 
+import apps.events # noqa: F401
 from flask import Blueprint
 
 blueprint = Blueprint(


### PR DESCRIPTION
During the tests for issue #154 I noticed we accidentally removed the import for apps.events, which is responsible for loading all SocketIO endpoints. This PR reverts that change.