### PR TITLE
feat(labs_edit): add image size check in summernote

### DIFF
--- a/apps/templates/pages/labs_edit.html
+++ b/apps/templates/pages/labs_edit.html
@@ -450,19 +450,8 @@
         height: 500,
         maximumImageFileSize: 358400,
         callbacks: {
-          onImageUpload: function(files) {
-            const maxImageSize = 358400; // 350 KB
-            const file = files[0];
-            if (file.size > maxImageSize) {
-              alert('The image is too large! The maximum allowed size is 350 KB.');
-              return false;
-            }
-            const reader = new FileReader();
-            reader.onload = function(e) {
-              const base64Image = e.target.result;
-              $('#lab-editor').summernote('insertImage', base64Image);
-            };
-            reader.readAsDataURL(file);
+          onImageUploadError: function(msg) {
+            alert('Image upload failed: ' + msg + ' (Maximum size: 350KB)');
           }
         }
       });


### PR DESCRIPTION
Sets the maximumImageFileSize attribute in summernote to 350KB and adds an alert if the image is larger than the allowed size.