### PR TITLE
feat(k8s): add rollback mechanism and improve error handling in lab creation

### DIFF
--- a/apps/controllers/kubernetes.py
+++ b/apps/controllers/kubernetes.py
@@ -14,10 +14,7 @@ import random
 
 from kubernetes import config, client
 from kubernetes.stream import stream
-from kubernetes.utils import create_from_yaml, duration, parse_quantity
-from kubernetes.utils.create_from_yaml import create_from_dict
-from kubernetes import client as k8s_client 
-from types import SimpleNamespace
+from kubernetes.utils import create_from_dict, duration, parse_quantity
 
 from flask import current_app
 from flask_login import current_user
@@ -423,98 +420,36 @@ class K8sController():
         if dry_run:
             return True, "OK"
 
-        created = []  
-        try:
-            for doc in yaml_docs:
-                kind = doc.get("kind")
-                metadata = doc.get("metadata", {}) or {}
-                name = metadata.get("name")
-                if not kind or not name:
-                    raise ValueError(f"Manifest missing kind/name: {doc}")
-
-                create_from_dict(
+        results = []
+        msg_fail = None
+        for doc in yaml_docs:
+            if doc is None:
+                continue
+            try:
+                result = create_from_dict(
                     self.k8s_client,
                     data=doc,
                     namespace=self.namespace,
                 )
+            except Exception as exc:
+                err = traceback.format_exc().replace("\n", ", ")
+                msg_fail = f"Failed to create resources on Kubernentes: {exc}"
+                current_app.logger.error(f"{msg_fail} {err=} {doc=}")
+                break
+            for resource in result:
+                results.append({
+                    "kind": resource.kind,
+                    "name": resource.metadata.name,
+                    "uid": resource.metadata.uid,
+                })
 
-                created.append({"kind": kind, "name": name})
+        if msg_fail:
+            current_app.logger.error(f"Rollback resource creation due to failures! To be removed: {results}")
+            self.delete_resources_by_name(results)
+            self._wait_gone(results, timeout=10)
+            return False, msg_fail
 
-            created_objs = []
-            for res in created:
-                created_objs.append(
-                    SimpleNamespace(
-                        kind=res["kind"],
-                        metadata=SimpleNamespace(name=res["name"])
-                    )
-                )
-            return True, created_objs
-
-        except Exception as exc:
-            msg = f"Failed to create resources on Kubernentes: {exc}"
-            err = traceback.format_exc().replace("\n", ", ")
-            current_app.logger.error(msg + " -- " + err)
-            current_app.logger.error(f"created_so_far={created}")
-            current_app.logger.error(f"yaml_docs={yaml_docs}")
-
-            for res in reversed(created):
-                try:
-                    ok = False
-                    if res["kind"] == "Pod":
-                        ok = self.delete_pod_by_name(res)
-                    elif res["kind"] == "Service":
-                        ok = self.delete_service_by_name(res)
-                    elif res["kind"] == "Deployment":
-                        ok = self.delete_deployment_by_name(res)
-                    elif res["kind"] == "ConfigMap":
-                        ok = self.delete_config_map_by_name(res)
-                    else:
-                        current_app.logger.warning(f"Rollback: unsupported kind {res}")
-                        continue
-
-                    if ok:
-                        gone = self._wait_gone(res["kind"], res["name"], timeout=10)
-                        if not gone:
-                            current_app.logger.warning(
-                                f"Rollback: {res['kind']}/{res['name']} ainda não sumiu após timeout"
-                            )
-                except Exception as dexc:
-                    current_app.logger.warning(f"Rollback failed for {res}: {dexc}")
-
-            try:
-                label_selector = f"app=hackinsdn-dashboard,lab_id={lab_id},user_uid={user_uid}"
-
-                for srv in self.v1_api.list_namespaced_service(
-                    self.namespace, label_selector=label_selector
-                ).items:
-                    try:
-                        self.delete_service_by_name({"name": srv.metadata.name})
-                        self._wait_gone("Service", srv.metadata.name, timeout=10)
-                    except Exception as dexc:
-                        current_app.logger.warning(f"Sweep Service {srv.metadata.name}: {dexc}")
-
-                for dep in self.apps_v1_api.list_namespaced_deployment(
-                    self.namespace, label_selector=label_selector
-                ).items:
-                    try:
-                        self.delete_deployment_by_name({"name": dep.metadata.name})
-                        self._wait_gone("Deployment", dep.metadata.name, timeout=10)
-                    except Exception as dexc:
-                        current_app.logger.warning(f"Sweep Deployment {dep.metadata.name}: {dexc}")
-
-                for cfg in self.v1_api.list_namespaced_config_map(
-                    self.namespace, label_selector=label_selector
-                ).items:
-                    try:
-                        self.delete_config_map_by_name({"name": cfg.metadata.name})
-                        self._wait_gone("ConfigMap", cfg.metadata.name, timeout=10)
-                    except Exception as dexc:
-                        current_app.logger.warning(f"Sweep ConfigMap {cfg.metadata.name}: {dexc}")
-
-            except Exception as sweep_exc:
-                current_app.logger.warning(f"Rollback sweep-by-label falhou: {sweep_exc}")
-
-            return False, msg
+        return True, results
 
     def validate_token(self, token):
         """Check if this token is authorized to access the API."""
@@ -579,50 +514,46 @@ class K8sController():
     def delete_pod_by_name(self, pod):
         """Delete pod by its name."""
         try:
-            body = k8s_client.V1DeleteOptions(propagation_policy="Foreground")
             self.v1_api.delete_namespaced_pod(
-                name=pod["name"], namespace=self.namespace, body=body
+                name=pod["name"], namespace=self.namespace
             )
-            return True
         except Exception as exc:
             current_app.logger.warning(f"Failed to delete pod {pod['name']} {exc}")
             return False
+        return True
 
     def delete_deployment_by_name(self, deployment):
         """Delete deployment by its name."""
         try:
-            body = k8s_client.V1DeleteOptions(propagation_policy="Foreground")
             self.apps_v1_api.delete_namespaced_deployment(
-                name=deployment["name"], namespace=self.namespace, body=body
+                name=deployment["name"], namespace=self.namespace
             )
-            return True
         except Exception as exc:
             current_app.logger.warning(f"Failed to delete deployment {deployment['name']} {exc}")
             return False
+        return True
 
     def delete_service_by_name(self, service):
         """Delete service by its name."""
         try:
-            body = k8s_client.V1DeleteOptions(propagation_policy="Foreground")
             self.v1_api.delete_namespaced_service(
-                name=service["name"], namespace=self.namespace, body=body
+                name=service["name"], namespace=self.namespace
             )
-            return True
         except Exception as exc:
             current_app.logger.warning(f"Failed to delete service {service['name']} {exc}")
             return False
+        return True
 
     def delete_config_map_by_name(self, config_map):
         """Delete config_map by its name."""
         try:
-            body = k8s_client.V1DeleteOptions(propagation_policy="Foreground")
             self.v1_api.delete_namespaced_config_map(
-                name=config_map["name"], namespace=self.namespace, body=body
+                name=config_map["name"], namespace=self.namespace
             )
-            return True
         except Exception as exc:
-            current_app.logger.warning(f"Failed to delete config_map {config_map['name']} {exc}")
+            current_app.logger.warning(f"Failed to delete configmap {config_map['name']} {exc}")
             return False
+        return True
 
     def delete_resources_by_name(self, resources):
         """Delete resources by their name and kind."""
@@ -640,24 +571,20 @@ class K8sController():
                 results.append(False)
         return results
 
-    def _wait_gone(self, kind, name, timeout=10):
-        """Espera até o recurso não existir mais (APIServer) ou estourar timeout (segundos)."""
+    def _wait_gone(self, resources, timeout=10):
+        """Wait for resources to be removed from the APIServer, or timeout to be exceeded."""
         start = time.time()
         while time.time() - start < timeout:
-            try:
-                if kind == "Deployment":
-                    self.apps_v1_api.read_namespaced_deployment(name=name, namespace=self.namespace)
-                elif kind == "Service":
-                    self.v1_api.read_namespaced_service(name=name, namespace=self.namespace)
-                elif kind == "ConfigMap":
-                    self.v1_api.read_namespaced_config_map(name=name, namespace=self.namespace)
-                elif kind == "Pod":
-                    self.v1_api.read_namespaced_pod(name=name, namespace=self.namespace)
-                else:
-                    return True  
-                time.sleep(0.5)
-            except Exception:
+            has_pending = False
+            for resource in resources:
+                try:
+                    self.get_resources_by_name([resource])
+                except Exception:
+                    continue
+                has_pending = True
+            if not has_pending:
                 return True
+            time.sleep(0.5)
         return False
 
     def get_nodes(self):

--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -193,94 +193,26 @@ def run_lab(lab_id):
         return render_template("pages/run_lab.html", lab=lab, msg_fail="Invalid lab duration/expiration, please choose one of the values provided.")
 
     expiration_ts = parse_lab_expiration(lab_expiration)
-    manifest = lab.manifest         
-    allowed_nodes = None             
-    
-    status, msg = k8s.create_lab(
-        lab_id=lab.id,
-        manifest=manifest,
-        dry_run=False,
-        user_uid=current_user.uid,
-        pod_hash=pod_hash,
-        allowed_nodes=allowed_nodes,
-    )
 
-    if not status:
-        err_text = str(msg)
-        current_app.logger.error(
-            f"Run lab failed (lab_id={lab.id}, user={current_user.id}): {err_text}"
-        )
+    status, msg = k8s.create_lab(lab_id, lab.manifest, user_uid=current_user.uid, pod_hash=pod_hash)
 
-        create_lab_log = HomeLogging(
-            ipaddr=get_remote_addr(),
-            action="create_lab",
-            success=False,
-            lab_id=lab.id,
-            user_id=current_user.id
-        )
+    if status:
+        lab_inst = LabInstances(pod_hash, current_user, lab, k8s_resources=msg, expiration_ts=expiration_ts)
+        db.session.add(lab_inst)
+
+        create_lab_log = HomeLogging(ipaddr=get_remote_addr(), action="create_lab", success=True, lab_id=lab.id, user_id=current_user.id)
         db.session.add(create_lab_log)
         db.session.commit()
 
-        return render_template(
-            "pages/run_lab.html",
-            lab=lab,
-            lab_expirations=lab_expirations,
-            msg_fail=f"Oops! Error Running Labs\n{err_text}",
-        )
+        running_labs = LabInstances.query.filter_by(is_deleted=False, user_id=current_user.id).count()
+        cache.set(f"running_labs-{current_user.id}", running_labs)
 
-    resources_basic = []  
-    if isinstance(msg, list):
-        for item in msg:
-            iterable = item if isinstance(item, list) else [item]
-            for r in iterable:
-                kind = getattr(r, "kind", None)
-                meta = getattr(r, "metadata", None)
-                name = getattr(meta, "name", None) if meta is not None else None
-
-                if kind is None and isinstance(r, dict):
-                    kind = r.get("kind")
-                    name = (r.get("metadata") or {}).get("name") or r.get("name")
-
-                if kind and name:
-                    resources_basic.append({"kind": kind, "name": name})
-    elif isinstance(msg, dict):
-        kind = msg.get("kind")
-        name = (msg.get("metadata") or {}).get("name") or msg.get("name")
-        if kind and name:
-            resources_basic.append({"kind": kind, "name": name})
-
-    try:
-        details = k8s.get_resources_by_name(resources_basic)
-    except Exception as exc:
-        current_app.logger.error(f"Failed to fetch created resources: {exc}")
-        details = []
-
-    k8s_resources = []
-    for d in details:
-        meta = d.get("metadata") or {}
-        k8s_resources.append({
-            "kind": d.get("kind") or "unknown",
-            "name": meta.get("name") or d.get("name"),
-            "uid": meta.get("uid") or d.get("uid"),
-        })
-
-    lab_inst = LabInstances(pod_hash, current_user, lab, k8s_resources, expiration_ts=expiration_ts)
-    db.session.add(lab_inst)
-
-    create_lab_log = HomeLogging(
-        ipaddr=get_remote_addr(),
-        action="create_lab",
-        success=True,
-        lab_id=lab.id,
-        user_id=current_user.id
-    )
-    db.session.add(create_lab_log)
-    db.session.commit()
-
-    running_labs = LabInstances.query.filter_by(is_deleted=False, user_id=current_user.id).count()
-    cache.set(f"running_labs-{current_user.id}", running_labs)
-
-    return render_template("pages/run_lab_status.html", resources=k8s_resources, lab_instance_id=pod_hash)
+        return render_template("pages/run_lab_status.html", resources=msg, lab_instance_id=pod_hash)
+    else:
+        create_lab_log_error = HomeLogging(ipaddr=get_remote_addr(), action="create_lab", success=False, lab_id=lab.id, user_id=current_user.id)
+        db.session.add(create_lab_log_error)
+        db.session.commit()
+        return render_template("pages/error.html", title="Error Running Labs", msg=msg)
 
 @blueprint.route('/lab_status/<lab_id>', methods=["GET"])
 @login_required


### PR DESCRIPTION
- Implement atomic creation of Kubernetes resources (create_from_dict).
- Added rollback: if any resource fails, previously created ones are deleted.
- Improved deletion with propagation_policy=Foreground and _wait_gone helper.
- Added extra cleanup by labels (app=hackinsdn-dashboard, lab_id, user_uid).