### PR TITLE
Feature/containerlabs menu and upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 
 # venv
 venv
+*.venv
 
 # .env variables file
 .env

--- a/apps/apps/data/clabs_state.json
+++ b/apps/apps/data/clabs_state.json
@@ -1,0 +1,73 @@
+{
+  "clabs": [
+    {
+      "id": "clab-sample-1",
+      "name": "Sample Topology",
+      "owner": "demo@example.com",
+      "status": "Running",
+      "created_at": "2025-09-20 12:00:00",
+      "nodes": 2
+    },
+    {
+      "lab_instance_id": "clab-20250921023818",
+      "user": "admin",
+      "title": "mano pivas",
+      "name": "mano pivas",
+      "created": "2025-09-21 02:38:18",
+      "status": "Running",
+      "nodes": 0
+    }
+  ],
+  "details": {
+    "clab-sample-1": {
+      "lab_instance_id": "clab-sample-1",
+      "title": "Sample Topology",
+      "user": "demo@example.com",
+      "created": "2025-09-20 12:00:00",
+      "expires_at": null,
+      "resources": [
+        {
+          "kind": "node",
+          "name": "r1",
+          "ready": "Running",
+          "node_name": "linux",
+          "pod_ip": "172.20.20.2",
+          "age": "--",
+          "services": [],
+          "links": []
+        },
+        {
+          "kind": "node",
+          "name": "r2",
+          "ready": "Running",
+          "node_name": "linux",
+          "pod_ip": "172.20.20.3",
+          "age": "--",
+          "services": [],
+          "links": []
+        }
+      ],
+      "files": []
+    },
+    "clab-20250921023818": {
+      "lab_instance_id": "clab-20250921023818",
+      "title": "mano pivas",
+      "user": "admin",
+      "created": "2025-09-21 02:38:18",
+      "expires_at": null,
+      "resources": [],
+      "files": [
+        {
+          "name": "teste/Novo(a) Documento de Texto.txt",
+          "mimetype": "text/plain",
+          "size": 0
+        },
+        {
+          "name": "teste/teste 1/Novo(a) Documento de Texto2.txt",
+          "mimetype": "text/plain",
+          "size": 0
+        }
+      ]
+    }
+  }
+}

--- a/apps/clabs/__init__.py
+++ b/apps/clabs/__init__.py
@@ -1,0 +1,10 @@
+# -*- encoding: utf-8 -*-
+from flask import Blueprint
+
+blueprint = Blueprint(
+    "clabs_blueprint",
+    __name__,
+    url_prefix="/containerlabs",
+    template_folder="templates",
+    static_folder="static",
+)

--- a/apps/clabs/mock_data.py
+++ b/apps/clabs/mock_data.py
@@ -1,0 +1,89 @@
+# -*- encoding: utf-8 -*-
+
+# Lista simples (usada na página de Running CLabs)
+CLABS = [
+    {
+        "id": "clab-001",
+        "name": "Edge Fabric",
+        "owner": "alice@example.com",
+        "status": "running",
+        "created_at": "2025-09-10 14:32",
+        "nodes": 6,
+    },
+    {
+        "id": "clab-002",
+        "name": "Core BGP",
+        "owner": "bob@example.com",
+        "status": "running",
+        "created_at": "2025-09-12 09:05",
+        "nodes": 4,
+    },
+]
+
+# Recursos detalhados por CLab (para a página Open CLab)
+# Estrutura inspirada em view_lab_instance: uma lista de "resources" por nó/serviço
+CLABS_DETAILS = {
+    "clab-001": {
+        "title": "Edge Fabric",
+        "lab_instance_id": "clab-001",
+        "user": "Alice (alice@example.com)",
+        "created": "2025-09-10 14:32",
+        "expires_at": None,  # PoC: sem expiração
+        "resources": [
+            {
+                "kind": "node",
+                "name": "leaf1",
+                "ready": "Running",
+                "links": [
+                    {"label": "Console", "href": "#"},
+                ],
+                "services": [
+                    {"name": "Mgmt SSH", "url": "#"},
+                    {"name": "gNMI", "url": "#"},
+                ],
+                "age": "1d",
+                "node_name": "edge-host-01",
+                "pod_ip": "10.0.0.11",
+            },
+            {
+                "kind": "node",
+                "name": "leaf2",
+                "ready": "Running",
+                "links": [{"label": "Console", "href": "#"}],
+                "services": [{"name": "Mgmt SSH", "url": "#"}],
+                "age": "1d",
+                "node_name": "edge-host-02",
+                "pod_ip": "10.0.0.12",
+            },
+        ],
+    },
+    "clab-002": {
+        "title": "Core BGP",
+        "lab_instance_id": "clab-002",
+        "user": "Bob (bob@example.com)",
+        "created": "2025-09-12 09:05",
+        "expires_at": None,
+        "resources": [
+            {
+                "kind": "node",
+                "name": "r1",
+                "ready": "Running",
+                "links": [{"label": "Console", "href": "#"}],
+                "services": [{"name": "Mgmt SSH", "url": "#"}],
+                "age": "2h",
+                "node_name": "core-host-01",
+                "pod_ip": "10.1.0.21",
+            },
+            {
+                "kind": "node",
+                "name": "r2",
+                "ready": "Running",
+                "links": [{"label": "Console", "href": "#"}],
+                "services": [{"name": "Mgmt SSH", "url": "#"}],
+                "age": "2h",
+                "node_name": "core-host-02",
+                "pod_ip": "10.1.0.22",
+            },
+        ],
+    },
+}

--- a/apps/clabs/mock_data.py
+++ b/apps/clabs/mock_data.py
@@ -2,31 +2,9 @@ from typing import List, Dict
 from .store import load_state, default_state_path
 
 # mocks padrão (usados se não houver estado persistido)
-CLABS: List[dict] = [
-    {
-        "id": "clab-sample-1",
-        "name": "Sample Topology",
-        "owner": "demo@example.com",
-        "status": "Running",
-        "created_at": "2025-09-20 12:00:00",
-        "nodes": 2,
-    }
-]
+CLABS: List[dict] = []
 
-CLABS_DETAILS: Dict[str, dict] = {
-    "clab-sample-1": {
-        "lab_instance_id": "clab-sample-1",
-        "title": "Sample Topology",
-        "user": "demo@example.com",
-        "created": "2025-09-20 12:00:00",
-        "expires_at": None,
-        "resources": [
-            {"kind": "node", "name": "r1", "ready": "Running", "node_name": "linux", "pod_ip": "172.20.20.2", "age": "--", "services": [], "links": []},
-            {"kind": "node", "name": "r2", "ready": "Running", "node_name": "linux", "pod_ip": "172.20.20.3", "age": "--", "services": [], "links": []},
-        ],
-        "files": []
-    }
-}
+CLABS_DETAILS: Dict[str, dict] = {}
 
 # tenta carregar estado persistido
 try:

--- a/apps/clabs/mock_data.py
+++ b/apps/clabs/mock_data.py
@@ -1,89 +1,41 @@
-# -*- encoding: utf-8 -*-
+from typing import List, Dict
+from .store import load_state, default_state_path
 
-# Lista simples (usada na página de Running CLabs)
-CLABS = [
+# mocks padrão (usados se não houver estado persistido)
+CLABS: List[dict] = [
     {
-        "id": "clab-001",
-        "name": "Edge Fabric",
-        "owner": "alice@example.com",
-        "status": "running",
-        "created_at": "2025-09-10 14:32",
-        "nodes": 6,
-    },
-    {
-        "id": "clab-002",
-        "name": "Core BGP",
-        "owner": "bob@example.com",
-        "status": "running",
-        "created_at": "2025-09-12 09:05",
-        "nodes": 4,
-    },
+        "id": "clab-sample-1",
+        "name": "Sample Topology",
+        "owner": "demo@example.com",
+        "status": "Running",
+        "created_at": "2025-09-20 12:00:00",
+        "nodes": 2,
+    }
 ]
 
-# Recursos detalhados por CLab (para a página Open CLab)
-# Estrutura inspirada em view_lab_instance: uma lista de "resources" por nó/serviço
-CLABS_DETAILS = {
-    "clab-001": {
-        "title": "Edge Fabric",
-        "lab_instance_id": "clab-001",
-        "user": "Alice (alice@example.com)",
-        "created": "2025-09-10 14:32",
-        "expires_at": None,  # PoC: sem expiração
-        "resources": [
-            {
-                "kind": "node",
-                "name": "leaf1",
-                "ready": "Running",
-                "links": [
-                    {"label": "Console", "href": "#"},
-                ],
-                "services": [
-                    {"name": "Mgmt SSH", "url": "#"},
-                    {"name": "gNMI", "url": "#"},
-                ],
-                "age": "1d",
-                "node_name": "edge-host-01",
-                "pod_ip": "10.0.0.11",
-            },
-            {
-                "kind": "node",
-                "name": "leaf2",
-                "ready": "Running",
-                "links": [{"label": "Console", "href": "#"}],
-                "services": [{"name": "Mgmt SSH", "url": "#"}],
-                "age": "1d",
-                "node_name": "edge-host-02",
-                "pod_ip": "10.0.0.12",
-            },
-        ],
-    },
-    "clab-002": {
-        "title": "Core BGP",
-        "lab_instance_id": "clab-002",
-        "user": "Bob (bob@example.com)",
-        "created": "2025-09-12 09:05",
+CLABS_DETAILS: Dict[str, dict] = {
+    "clab-sample-1": {
+        "lab_instance_id": "clab-sample-1",
+        "title": "Sample Topology",
+        "user": "demo@example.com",
+        "created": "2025-09-20 12:00:00",
         "expires_at": None,
         "resources": [
-            {
-                "kind": "node",
-                "name": "r1",
-                "ready": "Running",
-                "links": [{"label": "Console", "href": "#"}],
-                "services": [{"name": "Mgmt SSH", "url": "#"}],
-                "age": "2h",
-                "node_name": "core-host-01",
-                "pod_ip": "10.1.0.21",
-            },
-            {
-                "kind": "node",
-                "name": "r2",
-                "ready": "Running",
-                "links": [{"label": "Console", "href": "#"}],
-                "services": [{"name": "Mgmt SSH", "url": "#"}],
-                "age": "2h",
-                "node_name": "core-host-02",
-                "pod_ip": "10.1.0.22",
-            },
+            {"kind": "node", "name": "r1", "ready": "Running", "node_name": "linux", "pod_ip": "172.20.20.2", "age": "--", "services": [], "links": []},
+            {"kind": "node", "name": "r2", "ready": "Running", "node_name": "linux", "pod_ip": "172.20.20.3", "age": "--", "services": [], "links": []},
         ],
-    },
+        "files": []
+    }
 }
+
+# tenta carregar estado persistido
+try:
+    path = default_state_path()  # --> .../apps/data/clabs_state.json
+    _clabs, _details = load_state(path)
+    if _clabs or _details:
+        CLABS[:] = _clabs
+        CLABS_DETAILS.clear()
+        CLABS_DETAILS.update(_details)
+except Exception:
+    # mantém mocks se falhar
+    pass

--- a/apps/clabs/routes.py
+++ b/apps/clabs/routes.py
@@ -1,0 +1,159 @@
+# -*- encoding: utf-8 -*-
+from flask import render_template, request, jsonify
+from flask_login import current_user
+from datetime import datetime
+
+from . import blueprint
+from .mock_data import CLABS, CLABS_DETAILS
+
+# Tentamos usar PyYAML; se não estiver instalado, seguimos sem quebrar
+try:
+    import yaml  # PyYAML
+except Exception:
+    yaml = None
+
+@blueprint.route("/running")
+def running():
+    labs = []
+    for c in CLABS:
+        labs.append({
+            "lab_instance_id": c["id"],        
+            "user": c.get("owner", "--"),      
+            "title": c.get("name", "--"),      
+            "created": c.get("created_at", "--"), 
+        })
+    return render_template("clabs/running.html", labs=labs)
+
+
+@blueprint.route("/open/<clab_id>")
+def open_clab(clab_id):
+    lab = CLABS_DETAILS.get(clab_id)
+    if not lab:
+        return render_template("pages/error.html", title="Open CLab", msg="CLab not found")
+
+    return render_template("clabs/open.html", lab=lab)
+
+def _resources_from_clab_yaml(yaml_text: str):
+    """
+    Constrói a lista de 'resources' (nós) a partir de um YAML ContainerLab.
+    Se PyYAML não estiver disponível ou o YAML estiver inválido, retorna [].
+    """
+    if not yaml or not yaml_text:
+        return []
+
+    try:
+        data = yaml.safe_load(yaml_text)
+    except Exception:
+        return []
+
+    if not isinstance(data, dict):
+        return []
+
+    topo = data.get("topology") or {}
+    nodes = topo.get("nodes") or {}
+    if not isinstance(nodes, dict):
+        return []
+
+    resources = []
+    for name, cfg in nodes.items():
+        # cfg costuma ser dict com 'kind', 'image', 'mgmt_ipv4' etc.
+        kind = "node"
+        ready = "Running"  # PoC: considera subido
+        pod_ip = None
+        node_name = None
+        links = [{"label": "Console", "href": "#"}]  # placeholder
+        services = []
+
+        if isinstance(cfg, dict):
+            pod_ip = cfg.get("mgmt_ipv4")
+            node_name = cfg.get("kind") or cfg.get("image") or "--"
+
+        resources.append({
+            "kind": kind,
+            "name": str(name),
+            "ready": ready,
+            "links": links,
+            "services": services,
+            "age": "--",
+            "node_name": node_name or "--",
+            "pod_ip": pod_ip or "--",
+        })
+
+    return resources
+
+@blueprint.route("/create", methods=["GET", "POST"])
+def create():
+    if request.method == "GET":
+        return render_template("clabs/create.html")
+
+    # --- POST (PoC) ---
+    # Recebe dados do formulário e arquivos (mock – não persiste em disco)
+    name = (request.form.get("clab_name") or "").strip()
+    namespace = (request.form.get("clab_namespace") or "").strip()
+    yaml_manifest = (request.form.get("clab_yaml") or "").strip()
+
+    # Conta arquivos enviados (arquivos soltos + pastas via webkitdirectory)
+    files_count = 0
+    files_list = []  # Vamos armazenar os nomes dos arquivos enviados aqui
+    try:
+        # Adiciona arquivos individuais
+        files_list.extend(request.files.getlist("clab_files") or [])
+
+        # Adiciona arquivos de pastas com caminho completo
+        for file in request.files.getlist("clab_folders"):
+            # O caminho completo da pasta será adicionado, evitando duplicação
+            files_list.append(file)
+
+        files_count = len(files_list)
+    except Exception:
+        files_count = 0
+
+    # Validação mínima (PoC): exigir YAML ou ao menos 1 arquivo
+    if not yaml_manifest and files_count == 0:
+        return jsonify({"ok": False, "result": "Provide YAML and/or files"}), 400
+
+    # ---- Monta recursos a partir do YAML (se possível) ----
+    resources = _resources_from_clab_yaml(yaml_manifest)
+    nodes_count = len(resources)
+
+    # ---- Atualiza os mocks para aparecer em Running CLabs e Open CLab ----
+    new_id = f"clab-{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
+    created_str = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+
+    # Dados do "owner" a partir do usuário logado (fallbacks seguros)
+    owner_name = getattr(current_user, "name", None) or getattr(current_user, "username", "User")
+    owner_email = getattr(current_user, "email", None) or "user@example.com"
+    owner_display = f"{owner_name} ({owner_email})"
+
+    # Lista simples (Running CLabs)
+    CLABS.append({
+        "id": new_id,
+        "name": name or "Unnamed",
+        "owner": owner_email,
+        "status": "running",
+        "created_at": created_str,
+        "nodes": nodes_count,
+    })
+
+    # Detalhes (Open CLab) — Incluindo os arquivos enviados
+    CLABS_DETAILS[new_id] = {
+        "title": name or "Unnamed",
+        "lab_instance_id": new_id,
+        "user": owner_display,
+        "created": created_str,
+        "expires_at": None,
+        "resources": resources,  # agora populado a partir do YAML
+        "files": files_list,  # Armazena os arquivos enviados com o caminho completo
+    }
+
+    return jsonify({
+        "ok": True,
+        "result": f"CLab '{name or 'Unnamed'}' created (mock).",
+        "received": {
+            "id": new_id,
+            "namespace": namespace or "--",
+            "has_yaml": bool(yaml_manifest),
+            "files": files_count,
+            "resources": nodes_count,
+        }
+    }), 201

--- a/apps/clabs/routes.py
+++ b/apps/clabs/routes.py
@@ -12,6 +12,19 @@ try:
 except Exception:
     yaml = None
 
+def _norm_lab_row(c: dict) -> dict:
+    """Normaliza um item de CLABS para exibição na tabela."""
+    lab_id  = c.get("id") or c.get("lab_instance_id") or c.get("lab_id")
+    user    = c.get("owner") or c.get("user") or "--"
+    title   = c.get("name")  or c.get("title") or "--"
+    created = c.get("created_at") or c.get("created") or "--"
+    return {
+        "lab_instance_id": lab_id,
+        "user": user,
+        "title": title,
+        "created": created,
+    }
+
 @blueprint.route("/running")
 def running():
     labs = []
@@ -180,3 +193,32 @@ def create():
         }
     }), 201
 
+@blueprint.route("/api/list", methods=["GET"])
+def api_list():
+    """Retorna a lista normalizada de CLabs em execução (mock)."""
+    items = []
+    for c in CLABS:
+        row = _norm_lab_row(c)
+        if row["lab_instance_id"]:
+            items.append(row)
+    return jsonify({"items": items})
+
+
+@blueprint.route("/api/delete/<clab_id>", methods=["DELETE"])
+def api_delete(clab_id):
+    """Remove (mock) o CLab da memória."""
+    # remove de CLABS
+    removed = False
+    for i in range(len(CLABS) - 1, -1, -1):
+        _id = CLABS[i].get("id") or CLABS[i].get("lab_instance_id") or CLABS[i].get("lab_id")
+        if _id == clab_id:
+            CLABS.pop(i)
+            removed = True
+    # remove detalhe
+    if clab_id in CLABS_DETAILS:
+        CLABS_DETAILS.pop(clab_id, None)
+        removed = True
+
+    if not removed:
+        return jsonify({"ok": False, "result": "not found"}), 404
+    return jsonify({"ok": True})

--- a/apps/clabs/store.py
+++ b/apps/clabs/store.py
@@ -1,0 +1,61 @@
+import os
+import json
+from typing import Tuple, Dict, List, Optional
+
+def _ensure_dir(path: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+
+def default_state_path(cfg_path: Optional[str] = None) -> str:
+    if cfg_path:
+        return cfg_path
+    base = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))  # .../apps
+    return os.path.join(base, "data", "clabs_state.json")
+
+def load_state(state_path: str) -> Tuple[List[dict], Dict[str, dict]]:
+    """
+    Carrega estado do disco. Se não existir ou falhar, retorna ([], {}).
+    """
+    try:
+        if not os.path.exists(state_path):
+            return [], {}
+        with open(state_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        clabs = data.get("clabs", [])
+        details = data.get("details", {})
+        if not isinstance(clabs, list): clabs = []
+        if not isinstance(details, dict): details = {}
+        return clabs, details
+    except Exception:
+        return [], {}
+
+def save_state(state_path: str, clabs: List[dict], details: Dict[str, dict]) -> None:
+    """
+    Salva estado de forma atômica (JSON). Cria a pasta se não existir.
+    """
+    _ensure_dir(state_path)
+    tmp = state_path + ".tmp"
+    payload = {"clabs": clabs, "details": details}
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, state_path)
+
+def prune_inplace(clabs: List[dict], details: Dict[str, dict], max_days: int = 0) -> int:
+    """
+    Remoção simplificada (PoC). max_days=0 desativa. Aqui só remove status 'expired'/'deleted'.
+    """
+    if not max_days or max_days <= 0:
+        return 0
+    ids = []
+    for c in clabs:
+        status = (c.get("status") or "").lower()
+        if status in {"expired", "deleted"}:
+            _id = c.get("id") or c.get("lab_instance_id") or c.get("lab_id")
+            if _id:
+                ids.append(_id)
+    if not ids: return 0
+    idset = set(ids)
+    clabs[:] = [c for c in clabs if (c.get("id") or c.get("lab_instance_id") or c.get("lab_id")) not in idset]
+    for k in list(details.keys()):
+        if k in idset:
+            details.pop(k, None)
+    return len(ids)

--- a/apps/clabs/templates/clabs/create.html
+++ b/apps/clabs/templates/clabs/create.html
@@ -143,18 +143,29 @@
     referrerpolicy="no-referrer"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.17/mode/yaml/yaml.min.js"
     referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js" integrity="" crossorigin="anonymous"
+    referrerpolicy="no-referrer"></script>
 
 <script>
     (function () {
+        // ------- helpers para UI/Toasts -------
+        function showToast(type, title, body) {
+            if (window.$ && $(document).Toasts) {
+                $(document).Toasts('create', { class: type, title: title, body: body });
+            } else {
+                // fallback simples
+                console[type === 'bg-danger' ? 'error' : 'log'](title + ': ' + body);
+                alert(title + ': ' + body);
+            }
+        }
+
+        // ------- CodeMirror init -------
+        var cm = null;
         if (typeof CodeMirror === 'undefined') {
             console.error('CodeMirror failed to load');
-            $(document).Toasts && $(document).Toasts('create', {
-                class: 'bg-danger',
-                title: 'Failure',
-                body: 'Failed to load editor. You can still upload files/folders and submit.'
-            });
+            showToast('bg-danger', 'Failure', 'Failed to load editor. You can still upload files/folders and submit.');
         } else {
-            var cm = CodeMirror.fromTextArea(document.getElementById('clab_yaml'), {
+            cm = CodeMirror.fromTextArea(document.getElementById('clab_yaml'), {
                 mode: 'yaml',
                 lineNumbers: true,
                 lineWrapping: true,
@@ -164,139 +175,284 @@
             });
         }
 
-        // ======= Upload helpers =======
+        // ------- elementos -------
         var drop = document.getElementById('dropzone');
         var fileInput = document.getElementById('clab_files');
         var folderInput = document.getElementById('clab_folders');
         var filesList = document.getElementById('files_list');
+        var btn = document.getElementById('btnSubmit');
+        var form = document.getElementById('clab-form');
 
-        // DataTransfer store para permitir adicionar/remover arquivos
+        // Data store: DataTransfer para manter arquivos selecionados (com remoção)
         var store = new DataTransfer();
 
-        drop.addEventListener('click', function () { fileInput.click(); });
+        // Para trackear linhas marcadas no CodeMirror (limpar marcações antes)
+        var markedLines = [];
 
-        // Impede que arrastos/soltas fora da dropzone naveguem a página
+        // Set para evitar duplicatas por caminho (nome ou caminho relativo)
+        var seenPaths = new Set();
+
+        // Click na dropzone -> abre fileInput
+        drop && drop.addEventListener('click', function () { fileInput && fileInput.click(); });
+
+        // impede navegação em dragover/drop na página
         ['dragover', 'drop'].forEach(function (evt) {
-            document.addEventListener(evt, function (e) {
-                e.preventDefault();
-            }, false);
+            document.addEventListener(evt, function (e) { e.preventDefault(); }, false);
         });
 
-        // Renderiza lista com botões "remover"
+        // Renderiza lista de arquivos + botões remover
         function renderFilesList() {
-            filesList.innerHTML = '';  // Limpa a lista de arquivos
+            filesList.innerHTML = '';
             if (!store.files.length) {
                 filesList.innerHTML = '<small>No files selected</small>';
                 return;
             }
             var ul = document.createElement('ul');
-            ul.className = 'mb-0';  // Classe para formatação da lista
+            ul.className = 'mb-0 list-unstyled';
             for (let i = 0; i < store.files.length; i++) {
                 const f = store.files[i];
                 var li = document.createElement('li');
-                li.className = 'd-flex align-items-center justify-content-between';  // Para alinhar os itens horizontalmente
+                li.className = 'd-flex align-items-center justify-content-between py-1';
                 var name = document.createElement('span');
-                name.textContent = f.webkitRelativePath || f.name;  // Mostra o nome ou o path relativo
-                var btn = document.createElement('button');
-                btn.type = 'button';
-                btn.className = 'btn btn-xs btn-outline-danger ml-2';  // Botão de remoção
-                btn.innerHTML = '<i class="fas fa-times"></i>';
-                btn.addEventListener('click', function () {
-                    // Remover o arquivo da lista
-                    var newStore = new DataTransfer();  // Cria um novo DataTransfer
-                    for (let j = 0; j < store.files.length; j++) {
-                        if (j !== i) newStore.items.add(store.files[j]);  // Só adiciona arquivos que não foram removidos
-                    }
-                    store = newStore;  // Atualiza o DataTransfer
-                    fileInput.files = store.files;  // Atualiza o campo de arquivos
-                    renderFilesList();  // Re-renderiza a lista de arquivos
-                });
-                li.appendChild(name);  // Adiciona o nome do arquivo
-                li.appendChild(btn);  // Adiciona o botão de remoção
-                ul.appendChild(li);  // Adiciona o item da lista
+                name.textContent = f.name; // aqui eu guardarei o path relativo dentro de name (ex: 'subdir/file.txt')
+                var btnRem = document.createElement('button');
+                btnRem.type = 'button';
+                btnRem.className = 'btn btn-xs btn-outline-danger ml-2';
+                btnRem.innerHTML = '<i class="fas fa-times"></i>';
+                btnRem.addEventListener('click', (function (index) {
+                    return function () {
+                        var newStore = new DataTransfer();
+                        for (let j = 0; j < store.files.length; j++) {
+                            if (j !== index) newStore.items.add(store.files[j]);
+                        }
+                        // atualizar seenPaths
+                        seenPaths.clear();
+                        for (let k = 0; k < newStore.files.length; k++) {
+                            seenPaths.add(newStore.files[k].name);
+                        }
+                        store = newStore;
+                        fileInput.files = store.files;
+                        renderFilesList();
+                    };
+                })(i));
+                li.appendChild(name);
+                li.appendChild(btnRem);
+                ul.appendChild(li);
             }
-            filesList.appendChild(ul);  // Adiciona a lista à seção de arquivos
+            filesList.appendChild(ul);
         }
 
-        // Adiciona arquivos ao store
+        // limpa marcações no CodeMirror
+        function clearCmMarks() {
+            if (!cm) return;
+            while (markedLines.length) {
+                var ln = markedLines.pop();
+                cm.removeLineClass(ln, 'background', 'cm-error-line');
+                cm.setGutterMarker(ln, 'error-gutter', null);
+            }
+        }
+
+        // adiciona marcação de erro no CodeMirror (linha: zero-indexed)
+        function markCmError(line, message) {
+            if (!cm) return;
+            cm.addLineClass(line, 'background', 'cm-error-line');
+            var marker = document.createElement('div');
+            marker.className = 'error-gutter-marker';
+            marker.title = message || 'YAML error';
+            marker.innerHTML = '●';
+            cm.setGutterMarker(line, 'error-gutter', marker);
+            markedLines.push(line);
+            // scroll to line
+            cm.scrollIntoView({ line: line, ch: 0 }, 100);
+        }
+
+        // adiciona CSS runtime para highlight de erro e gutter (se preferir leve para CSS)
+        (function addRuntimeCss() {
+            var css = document.createElement('style');
+            css.type = 'text/css';
+            css.innerHTML = "\
+        .cm-error-line { background: rgba(255, 0, 0, 0.06) !important; }\
+        .error-gutter-marker { color: #c0392b; font-weight: bold; }";
+            document.head.appendChild(css);
+            // garante gutter 'error-gutter' existe
+            if (cm) cm.setOption('gutters', ['CodeMirror-linenumbers', 'error-gutter']);
+        })();
+
+        // ====== Validação YAML ======
+        function validateYaml(yamlText) {
+            clearCmMarks();
+            if (!yamlText || !yamlText.trim()) return true; // vazio permitido (se backend aceitar) — ajustável
+            if (typeof jsyaml === 'undefined') {
+                showToast('bg-danger', 'Validation error', 'js-yaml not loaded. Cannot validate YAML client-side.');
+                return false;
+            }
+            try {
+                // jsyaml.load utiliza exception com mark {line, column}
+                jsyaml.load(yamlText);
+                return true;
+            } catch (err) {
+                var msg = err && err.message ? err.message : String(err);
+                // marca linha se disponível (js-yaml usa err.mark.line zero-indexed? geralmente 0-based)
+                if (err && err.mark && typeof err.mark.line === 'number') {
+                    var lineNo = err.mark.line; // já zero-index em muitas versões
+                    markCmError(lineNo, msg);
+                }
+                showToast('bg-danger', 'YAML error', msg);
+                return false;
+            }
+        }
+
+        // ====== Adição / deduplicação de arquivos ao store ======
         function addFiles(fileList) {
             if (!fileList || !fileList.length) return;
-
             for (let i = 0; i < fileList.length; i++) {
-                const f = fileList[i];
-                // Ignora diretórios em DnD (para pastas use o input webkitdirectory)
-                if (typeof f.type === 'undefined' && !f.name) continue;
-                store.items.add(f);
+                let f = fileList[i];
+                // f.name já pode conter caminho relativo (se criado assim)
+                var key = f.name || f.webkitRelativePath || f.fileName || f.path || (i + ':' + f.size);
+                if (seenPaths.has(key)) continue;
+                // Se for um File vindo sem path, usamos name; se tiver webkitRelativePath (ex: folder input) preferimos ela
+                // Mas no fluxo abaixo, quando criarmos Files para pastas, já nomearemos com 'subdir/file'
+                seenPaths.add(key);
+                try {
+                    store.items.add(f);
+                } catch (e) {
+                    // falha ao adicionar (browser restrição) -> ignorar e logar
+                    console.warn('Could not add file to DataTransfer:', e, f);
+                }
             }
-            fileInput.files = store.files;
+            // sincroniza input visível com store para consistência (opcional)
+            try { fileInput.files = store.files; } catch (e) { /* some browsers don't allow */ }
             renderFilesList();
         }
 
-        // Input de arquivos (múltiplos)
-        fileInput.addEventListener('change', function (e) {
-            addFiles(e.target.files);
-            // limpa seleção original para permitir selecionar os mesmos nomes de novo
-            fileInput.value = '';
-        });
-
-        // Input de pastas (webkitdirectory) -> adiciona tudo ao store
-        if (folderInput) {
-            folderInput.addEventListener('change', function (e) {
-                addFiles(e.target.files);
-                // não limpamos para manter paths; opcional:
-                // folderInput.value = '';
+        // ====== Leitura recursiva de pastas via DataTransferItem.webkitGetAsEntry ======
+        function traverseFileTree(entry, path) {
+            return new Promise(function (resolve) {
+                if (entry.isFile) {
+                    entry.file(function (file) {
+                        // criamos novo File com nome que inclui o path relativo (para backend receber o path)
+                        var relPath = path + file.name;
+                        var newFile = new File([file], relPath, { type: file.type });
+                        resolve([newFile]);
+                    }, function () { resolve([]); });
+                } else if (entry.isDirectory) {
+                    var dirReader = entry.createReader();
+                    var entries = [];
+                    var readEntries = function () {
+                        dirReader.readEntries(function (results) {
+                            if (!results.length) {
+                                // processar todas as entradas
+                                var promises = entries.map(function (ent) {
+                                    return traverseFileTree(ent, path + entry.name + '/');
+                                });
+                                Promise.all(promises).then(function (arrays) {
+                                    // flatten
+                                    var flat = [].concat.apply([], arrays);
+                                    resolve(flat);
+                                });
+                            } else {
+                                entries = entries.concat(Array.prototype.slice.call(results || []));
+                                readEntries();
+                            }
+                        }, function () {
+                            resolve([]);
+                        });
+                    };
+                    readEntries();
+                } else {
+                    resolve([]);
+                }
             });
         }
 
-        // Dropzone visual
-        ['dragenter', 'dragover'].forEach(function (evt) {
-            drop.addEventListener(evt, function (e) {
-                e.preventDefault(); e.stopPropagation();
-                drop.classList.add('dragover');
-            }, false);
-        });
-        ['dragleave', 'drop'].forEach(function (evt) {
-            drop.addEventListener(evt, function (e) {
-                e.preventDefault(); e.stopPropagation();
-                drop.classList.remove('dragover');
-            }, false);
-        });
+        // ====== Drop handler com suporte a pastas ======
+        if (drop) {
+            // efeitos visuais
+            ['dragenter', 'dragover'].forEach(function (evt) {
+                drop.addEventListener(evt, function (e) {
+                    e.preventDefault(); e.stopPropagation();
+                    drop.classList.add('dragover');
+                }, false);
+            });
+            ['dragleave', 'drop'].forEach(function (evt) {
+                drop.addEventListener(evt, function (e) {
+                    e.preventDefault(); e.stopPropagation();
+                    drop.classList.remove('dragover');
+                }, false);
+            });
 
-        drop.addEventListener('drop', function (e) {
-            var dt = e.dataTransfer;
-            if (!dt) return;
-
-            // Alguns browsers expõem items com diretórios; ignoramos diretórios e avisamos
-            if (dt.items && dt.items.length) {
-                var hadDir = false;
-                var files = [];
-                for (let i = 0; i < dt.items.length; i++) {
-                    var item = dt.items[i];
-                    if (typeof item.webkitGetAsEntry === 'function') {
-                        var entry = item.webkitGetAsEntry();
-                        if (entry && entry.isDirectory) { hadDir = true; continue; }
+            // drop
+            drop.addEventListener('drop', function (e) {
+                var dt = e.dataTransfer;
+                if (!dt) return;
+                if (dt.items && dt.items.length) {
+                    // quando houver items, podemos examinar diretórios
+                    var promises = [];
+                    var filesToAdd = [];
+                    for (let i = 0; i < dt.items.length; i++) {
+                        var item = dt.items[i];
+                        if (typeof item.webkitGetAsEntry === 'function') {
+                            var entry = item.webkitGetAsEntry();
+                            if (entry) {
+                                // traverseFileTree -> retorna promise de array de Files (com nomes relativos)
+                                promises.push(traverseFileTree(entry, entry.isDirectory ? entry.name + '/' : ''));
+                            } else {
+                                // fallback: item.getAsFile
+                                var f = item.getAsFile && item.getAsFile();
+                                if (f) filesToAdd.push(f);
+                            }
+                        } else {
+                            // fallback: item.getAsFile
+                            var f2 = item.getAsFile && item.getAsFile();
+                            if (f2) filesToAdd.push(f2);
+                        }
                     }
-                    var f = item.getAsFile && item.getAsFile();
-                    if (f) files.push(f);
-                }
-                if (files.length) addFiles(files);
-                if (hadDir) {
-                    $(document).Toasts('create', {
-                        class: 'bg-info',
-                        title: 'Heads up',
-                        body: 'Folder drops are not supported here. Use "Upload folders" abaixo.'
+                    // processar promises
+                    Promise.all(promises).then(function (results) {
+                        var flat = [].concat.apply([], results || []);
+                        if (filesToAdd.length) flat = flat.concat(filesToAdd);
+                        if (flat.length) addFiles(flat);
+                    }).catch(function (err) {
+                        console.warn('Error reading dropped folder:', err);
+                        // fallback para dt.files
+                        if (dt.files && dt.files.length) addFiles(dt.files);
+                        showToast('bg-info', 'Heads up', 'Folder drops may not be fully supported in this browser. Use "Upload folders" abaixo.');
                     });
+                } else if (dt.files && dt.files.length) {
+                    addFiles(dt.files);
                 }
-            } else if (dt.files && dt.files.length) {
-                addFiles(dt.files);
-            }
-        });
+            }, false);
+        }
 
-        // ======= Submit (PoC) via fetch -> JSON -> toast + redirect =======
-        var btn = document.getElementById('btnSubmit');
-        var form = document.getElementById('clab-form');
+        // ====== Input file change ======
+        if (fileInput) {
+            fileInput.addEventListener('change', function (e) {
+                addFiles(e.target.files);
+                // limpar seleção original para permitir re-seleção dos mesmos nomes
+                fileInput.value = '';
+            });
+        }
 
-        btn.addEventListener('click', function () {
+        // ====== Input folder change ======
+        if (folderInput) {
+            folderInput.addEventListener('change', function (e) {
+                // folderInput.files já vem com webkitRelativePath em Chrome; convertê-los para Files com name==relativePath
+                var arr = [];
+                for (let i = 0; i < e.target.files.length; i++) {
+                    var f = e.target.files[i];
+                    var rel = f.webkitRelativePath || f.name;
+                    // criar novo File com nome contendo o caminho relativo (facilita envio com caminho)
+                    var newF = new File([f], rel, { type: f.type });
+                    arr.push(newF);
+                }
+                addFiles(arr);
+                // limpamos o input para evitar duplicação posterior (se o usuário reabrir)
+                folderInput.value = '';
+            });
+        }
+
+        // ====== Submit refinado (async/await) ======
+        async function handleSubmit() {
             var btnText = btn.querySelector('.btn-text');
             var spinner = btn.querySelector('.spinner-border');
             btn.disabled = true; btnText.classList.add('d-none'); spinner.classList.remove('d-none');
@@ -304,46 +460,88 @@
             // sincroniza editor -> textarea
             if (typeof CodeMirror !== 'undefined' && cm) { cm.save(); }
 
-            var fd = new FormData(form);
-
-            // Repassa arquivos do store (pois fileInput.files foi sobrescrito pelo store)
-            for (let i = 0; i < store.files.length; i++) {
-                fd.append('clab_files', store.files[i], store.files[i].webkitRelativePath || store.files[i].name);
-            }
-
-            // Também repassa os de pastas (se quiser distinguir no backend)
-            if (folderInput && folderInput.files && folderInput.files.length) {
-                for (let i = 0; i < folderInput.files.length; i++) {
-                    fd.append('clab_folders', folderInput.files[i], folderInput.files[i].webkitRelativePath || folderInput.files[i].name);
-                }
-            }
-
-            // Validação mínima client-side: YAML ou arquivos
-            var hasYaml = (fd.get('clab_yaml') || '').trim().length > 0;
-            var filesLen = store.files.length + (folderInput.files ? folderInput.files.length : 0);
-            if (!hasYaml && filesLen === 0) {
-                $(document).Toasts('create', { class: 'bg-danger', title: 'Failure', body: 'Provide YAML and/or files' });
-                btn.disabled = false; btnText.classList.remove('d-none'); spinner.classList.add('d-none');
+            // Valida o YAML (através de jsyaml)
+            var yamlText = document.getElementById('clab_yaml').value;
+            if (!validateYaml(yamlText)) {
+                btn.disabled = false;
+                btnText.classList.remove('d-none');
+                spinner.classList.add('d-none');
                 return;
             }
 
-            fetch('{{ url_for("clabs_blueprint.create") }}', {
-                method: 'POST',
-                body: fd
-            }).then(function (resp) {
-                if (!resp.ok) return resp.json().then(function (j) { throw (j && j.result) || 'Failed'; });
-                return resp.json();
-            }).then(function (j) {
-                sessionStorage.setItem('msgSuccess', j.result || 'CLab created (mock).');
-                window.location = '{{ url_for("clabs_blueprint.running") }}';
-            }).catch(function (err) {
-                sessionStorage.setItem('msgFail', (err && err.toString()) || 'Failed to create CLab.');
-                window.location = '{{ url_for("clabs_blueprint.running") }}';
-            });
-        });
+            // FormData a partir do form
+            var fd = new FormData(form);
 
-        // Render inicial
+            // Repassa arquivos do store (já com nomes relativos em store.files[].name)
+            for (let i = 0; i < store.files.length; i++) {
+                var file = store.files[i];
+                // usa file.name como caminho relativo (se existir) no parâmetro filename do append
+                fd.append('clab_files', file, file.name);
+            }
+
+            // Validação mínima: YAML ou arquivos
+            var hasYaml = (fd.get('clab_yaml') || '').trim().length > 0;
+            var filesLen = store.files.length;
+            if (!hasYaml && filesLen === 0) {
+                showToast('bg-danger', 'Failure', 'Provide YAML and/or files');
+                btn.disabled = false;
+                btnText.classList.remove('d-none');
+                spinner.classList.add('d-none');
+                return;
+            }
+
+            try {
+                var resp = await fetch('{{ url_for("clabs_blueprint.create") }}', {
+                    method: 'POST',
+                    body: fd
+                });
+
+                // tentar parsear JSON, mas fallback se não for JSON
+                var resultText;
+                try {
+                    var j = await resp.json();
+                    if (!resp.ok) {
+                        console.error('Erro no servidor:', j);
+                        throw (j && j.result) || 'Failed';
+                    }
+                    resultText = j.result || 'CLab created (mock).';
+                    sessionStorage.setItem('msgSuccess', resultText);
+                    showToast('bg-success', 'Success', resultText);
+                    // redireciona
+                    window.location = '{{ url_for("clabs_blueprint.running") }}';
+                } catch (innerErr) {
+                    if (!resp.ok) {
+                        // servidor retornou erro e não JSON
+                        throw innerErr;
+                    } else {
+                        // resp ok mas não JSON -> success textual
+                        resultText = await resp.text();
+                        sessionStorage.setItem('msgSuccess', resultText || 'CLab created.');
+                        showToast('bg-success', 'Success', sessionStorage.getItem('msgSuccess'));
+                        window.location = '{{ url_for("clabs_blueprint.running") }}';
+                    }
+                }
+            } catch (err) {
+                sessionStorage.setItem('msgFail', (err && err.toString()) || 'Failed to create CLab.');
+                showToast('bg-danger', 'Failure', sessionStorage.getItem('msgFail'));
+                // opcional: não redirecionar em falha? você redirecionava antes; mantive redirecionamento
+                window.location = '{{ url_for("clabs_blueprint.running") }}';
+            } finally {
+                // garante reabilitar UI se o código ficar na mesma página
+                btn.disabled = false;
+                btnText.classList.remove('d-none');
+                spinner.classList.add('d-none');
+                // renderiza lista atualizada
+                renderFilesList();
+            }
+        }
+
+        // attach handler
+        if (btn) btn.addEventListener('click', handleSubmit);
+
+        // render inicial
         renderFilesList();
+
     })();
 </script>
 {% endblock javascripts %}

--- a/apps/clabs/templates/clabs/create.html
+++ b/apps/clabs/templates/clabs/create.html
@@ -183,24 +183,18 @@
         var btn = document.getElementById('btnSubmit');
         var form = document.getElementById('clab-form');
 
-        // Data store: DataTransfer para manter arquivos selecionados (com remoção)
         var store = new DataTransfer();
 
-        // Para trackear linhas marcadas no CodeMirror (limpar marcações antes)
         var markedLines = [];
 
-        // Set para evitar duplicatas por caminho (nome ou caminho relativo)
         var seenPaths = new Set();
 
-        // Click na dropzone -> abre fileInput
         drop && drop.addEventListener('click', function () { fileInput && fileInput.click(); });
 
-        // impede navegação em dragover/drop na página
         ['dragover', 'drop'].forEach(function (evt) {
             document.addEventListener(evt, function (e) { e.preventDefault(); }, false);
         });
 
-        // Renderiza lista de arquivos + botões remover
         function renderFilesList() {
             filesList.innerHTML = '';
             if (!store.files.length) {
@@ -242,7 +236,6 @@
             filesList.appendChild(ul);
         }
 
-        // limpa marcações no CodeMirror
         function clearCmMarks() {
             if (!cm) return;
             while (markedLines.length) {
@@ -252,7 +245,6 @@
             }
         }
 
-        // adiciona marcação de erro no CodeMirror (linha: zero-indexed)
         function markCmError(line, message) {
             if (!cm) return;
             cm.addLineClass(line, 'background', 'cm-error-line');
@@ -262,11 +254,9 @@
             marker.innerHTML = '●';
             cm.setGutterMarker(line, 'error-gutter', marker);
             markedLines.push(line);
-            // scroll to line
             cm.scrollIntoView({ line: line, ch: 0 }, 100);
         }
 
-        // adiciona CSS runtime para highlight de erro e gutter (se preferir leve para CSS)
         (function addRuntimeCss() {
             var css = document.createElement('style');
             css.type = 'text/css';
@@ -274,27 +264,27 @@
         .cm-error-line { background: rgba(255, 0, 0, 0.06) !important; }\
         .error-gutter-marker { color: #c0392b; font-weight: bold; }";
             document.head.appendChild(css);
-            // garante gutter 'error-gutter' existe
             if (cm) cm.setOption('gutters', ['CodeMirror-linenumbers', 'error-gutter']);
         })();
 
         // ====== Validação YAML ======
+        <!-- dentro de <script> ... -->
         function validateYaml(yamlText) {
             clearCmMarks();
-            if (!yamlText || !yamlText.trim()) return true; // vazio permitido (se backend aceitar) — ajustável
+            if (!yamlText || !yamlText.trim()) return true; 
+
             if (typeof jsyaml === 'undefined') {
-                showToast('bg-danger', 'Validation error', 'js-yaml not loaded. Cannot validate YAML client-side.');
-                return false;
+                showToast('bg-info', 'Heads up', 'js-yaml não carregou; validação será feita no servidor.');
+                return true; 
             }
+
             try {
-                // jsyaml.load utiliza exception com mark {line, column}
                 jsyaml.load(yamlText);
                 return true;
             } catch (err) {
                 var msg = err && err.message ? err.message : String(err);
-                // marca linha se disponível (js-yaml usa err.mark.line zero-indexed? geralmente 0-based)
                 if (err && err.mark && typeof err.mark.line === 'number') {
-                    var lineNo = err.mark.line; // já zero-index em muitas versões
+                    var lineNo = err.mark.line; 
                     markCmError(lineNo, msg);
                 }
                 showToast('bg-danger', 'YAML error', msg);
@@ -302,35 +292,29 @@
             }
         }
 
+
         // ====== Adição / deduplicação de arquivos ao store ======
         function addFiles(fileList) {
             if (!fileList || !fileList.length) return;
             for (let i = 0; i < fileList.length; i++) {
                 let f = fileList[i];
-                // f.name já pode conter caminho relativo (se criado assim)
                 var key = f.name || f.webkitRelativePath || f.fileName || f.path || (i + ':' + f.size);
                 if (seenPaths.has(key)) continue;
-                // Se for um File vindo sem path, usamos name; se tiver webkitRelativePath (ex: folder input) preferimos ela
-                // Mas no fluxo abaixo, quando criarmos Files para pastas, já nomearemos com 'subdir/file'
                 seenPaths.add(key);
                 try {
                     store.items.add(f);
                 } catch (e) {
-                    // falha ao adicionar (browser restrição) -> ignorar e logar
                     console.warn('Could not add file to DataTransfer:', e, f);
                 }
             }
-            // sincroniza input visível com store para consistência (opcional)
             try { fileInput.files = store.files; } catch (e) { /* some browsers don't allow */ }
             renderFilesList();
         }
 
-        // ====== Leitura recursiva de pastas via DataTransferItem.webkitGetAsEntry ======
         function traverseFileTree(entry, path) {
             return new Promise(function (resolve) {
                 if (entry.isFile) {
                     entry.file(function (file) {
-                        // criamos novo File com nome que inclui o path relativo (para backend receber o path)
                         var relPath = path + file.name;
                         var newFile = new File([file], relPath, { type: file.type });
                         resolve([newFile]);
@@ -365,7 +349,6 @@
             });
         }
 
-        // ====== Drop handler com suporte a pastas ======
         if (drop) {
             // efeitos visuais
             ['dragenter', 'dragover'].forEach(function (evt) {
@@ -381,12 +364,10 @@
                 }, false);
             });
 
-            // drop
             drop.addEventListener('drop', function (e) {
                 var dt = e.dataTransfer;
                 if (!dt) return;
                 if (dt.items && dt.items.length) {
-                    // quando houver items, podemos examinar diretórios
                     var promises = [];
                     var filesToAdd = [];
                     for (let i = 0; i < dt.items.length; i++) {
@@ -394,27 +375,22 @@
                         if (typeof item.webkitGetAsEntry === 'function') {
                             var entry = item.webkitGetAsEntry();
                             if (entry) {
-                                // traverseFileTree -> retorna promise de array de Files (com nomes relativos)
                                 promises.push(traverseFileTree(entry, entry.isDirectory ? entry.name + '/' : ''));
                             } else {
-                                // fallback: item.getAsFile
                                 var f = item.getAsFile && item.getAsFile();
                                 if (f) filesToAdd.push(f);
                             }
                         } else {
-                            // fallback: item.getAsFile
                             var f2 = item.getAsFile && item.getAsFile();
                             if (f2) filesToAdd.push(f2);
                         }
                     }
-                    // processar promises
                     Promise.all(promises).then(function (results) {
                         var flat = [].concat.apply([], results || []);
                         if (filesToAdd.length) flat = flat.concat(filesToAdd);
                         if (flat.length) addFiles(flat);
                     }).catch(function (err) {
                         console.warn('Error reading dropped folder:', err);
-                        // fallback para dt.files
                         if (dt.files && dt.files.length) addFiles(dt.files);
                         showToast('bg-info', 'Heads up', 'Folder drops may not be fully supported in this browser. Use "Upload folders" abaixo.');
                     });
@@ -424,11 +400,9 @@
             }, false);
         }
 
-        // ====== Input file change ======
         if (fileInput) {
             fileInput.addEventListener('change', function (e) {
                 addFiles(e.target.files);
-                // limpar seleção original para permitir re-seleção dos mesmos nomes
                 fileInput.value = '';
             });
         }
@@ -436,31 +410,25 @@
         // ====== Input folder change ======
         if (folderInput) {
             folderInput.addEventListener('change', function (e) {
-                // folderInput.files já vem com webkitRelativePath em Chrome; convertê-los para Files com name==relativePath
                 var arr = [];
                 for (let i = 0; i < e.target.files.length; i++) {
                     var f = e.target.files[i];
                     var rel = f.webkitRelativePath || f.name;
-                    // criar novo File com nome contendo o caminho relativo (facilita envio com caminho)
                     var newF = new File([f], rel, { type: f.type });
                     arr.push(newF);
                 }
                 addFiles(arr);
-                // limpamos o input para evitar duplicação posterior (se o usuário reabrir)
                 folderInput.value = '';
             });
         }
 
-        // ====== Submit refinado (async/await) ======
         async function handleSubmit() {
             var btnText = btn.querySelector('.btn-text');
             var spinner = btn.querySelector('.spinner-border');
             btn.disabled = true; btnText.classList.add('d-none'); spinner.classList.remove('d-none');
 
-            // sincroniza editor -> textarea
             if (typeof CodeMirror !== 'undefined' && cm) { cm.save(); }
 
-            // Valida o YAML (através de jsyaml)
             var yamlText = document.getElementById('clab_yaml').value;
             if (!validateYaml(yamlText)) {
                 btn.disabled = false;
@@ -469,17 +437,10 @@
                 return;
             }
 
-            // FormData a partir do form
+            try { fileInput.files = store.files; } catch (e) {}
+
             var fd = new FormData(form);
 
-            // Repassa arquivos do store (já com nomes relativos em store.files[].name)
-            for (let i = 0; i < store.files.length; i++) {
-                var file = store.files[i];
-                // usa file.name como caminho relativo (se existir) no parâmetro filename do append
-                fd.append('clab_files', file, file.name);
-            }
-
-            // Validação mínima: YAML ou arquivos
             var hasYaml = (fd.get('clab_yaml') || '').trim().length > 0;
             var filesLen = store.files.length;
             if (!hasYaml && filesLen === 0) {
@@ -496,7 +457,6 @@
                     body: fd
                 });
 
-                // tentar parsear JSON, mas fallback se não for JSON
                 var resultText;
                 try {
                     var j = await resp.json();
@@ -507,14 +467,11 @@
                     resultText = j.result || 'CLab created (mock).';
                     sessionStorage.setItem('msgSuccess', resultText);
                     showToast('bg-success', 'Success', resultText);
-                    // redireciona
                     window.location = '{{ url_for("clabs_blueprint.running") }}';
                 } catch (innerErr) {
                     if (!resp.ok) {
-                        // servidor retornou erro e não JSON
                         throw innerErr;
                     } else {
-                        // resp ok mas não JSON -> success textual
                         resultText = await resp.text();
                         sessionStorage.setItem('msgSuccess', resultText || 'CLab created.');
                         showToast('bg-success', 'Success', sessionStorage.getItem('msgSuccess'));
@@ -524,22 +481,17 @@
             } catch (err) {
                 sessionStorage.setItem('msgFail', (err && err.toString()) || 'Failed to create CLab.');
                 showToast('bg-danger', 'Failure', sessionStorage.getItem('msgFail'));
-                // opcional: não redirecionar em falha? você redirecionava antes; mantive redirecionamento
                 window.location = '{{ url_for("clabs_blueprint.running") }}';
             } finally {
-                // garante reabilitar UI se o código ficar na mesma página
                 btn.disabled = false;
                 btnText.classList.remove('d-none');
                 spinner.classList.add('d-none');
-                // renderiza lista atualizada
                 renderFilesList();
             }
         }
 
-        // attach handler
         if (btn) btn.addEventListener('click', handleSubmit);
 
-        // render inicial
         renderFilesList();
 
     })();

--- a/apps/clabs/templates/clabs/create.html
+++ b/apps/clabs/templates/clabs/create.html
@@ -1,0 +1,349 @@
+{% extends "layouts/base.html" %}
+
+{% block title %} Create CLabs {% endblock %}
+
+{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
+
+{% block stylesheets %}
+<!-- Google Font: Source Sans Pro -->
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
+<!-- Font Awesome -->
+<link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+<!-- AdminLTE -->
+<link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+<!-- CodeMirror (CDN para PoC) -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.17/codemirror.min.css"
+    referrerpolicy="no-referrer" />
+<style>
+    .dropzone {
+        border: 2px dashed #adb5bd;
+        border-radius: .25rem;
+        padding: 1.25rem;
+        text-align: center;
+        color: #6c757d;
+        cursor: pointer;
+    }
+
+    .dropzone.dragover {
+        border-color: #3c8dbc;
+        color: #3c8dbc;
+        background: #f8fbff;
+    }
+
+    .file-list small {
+        display: block;
+        color: #6c757d;
+    }
+</style>
+{% endblock stylesheets %}
+
+{% block content %}
+
+<div class="content-wrapper">
+
+    <section class="content-header">
+        <div class="container-fluid">
+            <div class="row mb-2">
+                <div class="col-sm-6">
+                    <h1>Create CLabs</h1>
+                    <small class="text-muted">Paste your containerlab YAML and/or upload files/folders</small>
+                </div>
+                <div class="col-sm-6">
+                    <ol class="breadcrumb float-sm-right">
+                        <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
+                        <li class="breadcrumb-item"><a href="{{ url_for('clabs_blueprint.running') }}">ContainerLabs</a>
+                        </li>
+                        <li class="breadcrumb-item active">Create</li>
+                    </ol>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="content">
+
+        <div class="row">
+            <div class="col-md-12">
+                <form id="clab-form" class="card" enctype="multipart/form-data" onsubmit="return true;">
+                    <div class="card-header">
+                        <h3 class="card-title">New ContainerLab</h3>
+                    </div>
+                    <div class="card-body">
+                        <div class="form-row">
+                            <div class="form-group col-md-6">
+                                <label for="clab_name">Name</label>
+                                <input type="text" class="form-control" id="clab_name" name="clab_name"
+                                    placeholder="e.g., Edge Fabric PoC">
+                            </div>
+                            <div class="form-group col-md-6">
+                                <label for="clab_namespace">Namespace/Project</label>
+                                <input type="text" class="form-control" id="clab_namespace" name="clab_namespace"
+                                    placeholder="optional">
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="clab_yaml">ContainerLab YAML</label>
+                            <textarea id="clab_yaml" name="clab_yaml" class="form-control" rows="10"
+                                placeholder="Paste your containerlab YAML here"></textarea>
+                            <small class="form-text text-muted">Use the same style of editor we já utilizamos para
+                                Kubernetes Manifest (CodeMirror).</small>
+                        </div>
+
+                        <div class="form-group">
+                            <label>Upload files</label>
+                            <div id="dropzone" class="dropzone">
+                                <i class="fas fa-cloud-upload-alt"></i>
+                                <div>Drag & drop files here, or click to select</div>
+                                <small>Accepted: multiple files</small>
+                            </div>
+                            <input id="clab_files" name="clab_files" type="file" multiple class="d-none">
+                            <div class="file-list mt-2" id="files_list"></div>
+                        </div>
+
+                        <div class="form-group">
+                            <label>Upload folders (experimental)</label>
+                            <input id="clab_folders" name="clab_folders" type="file" webkitdirectory directory multiple
+                                class="form-control-file">
+                            <small class="form-text text-muted">
+                                Folder upload works on Chromium-based browsers (Chrome/Edge). Firefox não suporta; como
+                                alternativa, compacte em ZIP e envie nos arquivos acima.
+                            </small>
+                        </div>
+
+                    </div>
+                    <div class="card-footer">
+                        <button id="btnSubmit" type="button" class="btn btn-primary">
+                            <span class="btn-text">Create (PoC)</span>
+                            <span class="spinner-border spinner-border-sm d-none" role="status"
+                                aria-hidden="true"></span>
+                        </button>
+                        <a href="{{ url_for('clabs_blueprint.running') }}" class="btn btn-default">Cancel</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+    </section>
+
+</div>
+
+{% endblock content %}
+
+{% block javascripts %}
+<!-- jQuery -->
+<script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+<!-- Bootstrap 4 -->
+<script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+<!-- AdminLTE -->
+<script src="/static/assets/js/adminlte.min.js"></script>
+
+<!-- CodeMirror (CDN para PoC) -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.17/codemirror.min.js"
+    referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.17/mode/yaml/yaml.min.js"
+    referrerpolicy="no-referrer"></script>
+
+<script>
+    (function () {
+        if (typeof CodeMirror === 'undefined') {
+            console.error('CodeMirror failed to load');
+            $(document).Toasts && $(document).Toasts('create', {
+                class: 'bg-danger',
+                title: 'Failure',
+                body: 'Failed to load editor. You can still upload files/folders and submit.'
+            });
+        } else {
+            var cm = CodeMirror.fromTextArea(document.getElementById('clab_yaml'), {
+                mode: 'yaml',
+                lineNumbers: true,
+                lineWrapping: true,
+                indentUnit: 2,
+                tabSize: 2,
+                autofocus: false,
+            });
+        }
+
+        // ======= Upload helpers =======
+        var drop = document.getElementById('dropzone');
+        var fileInput = document.getElementById('clab_files');
+        var folderInput = document.getElementById('clab_folders');
+        var filesList = document.getElementById('files_list');
+
+        // DataTransfer store para permitir adicionar/remover arquivos
+        var store = new DataTransfer();
+
+        drop.addEventListener('click', function () { fileInput.click(); });
+
+        // Impede que arrastos/soltas fora da dropzone naveguem a página
+        ['dragover', 'drop'].forEach(function (evt) {
+            document.addEventListener(evt, function (e) {
+                e.preventDefault();
+            }, false);
+        });
+
+        // Renderiza lista com botões "remover"
+        function renderFilesList() {
+            filesList.innerHTML = '';  // Limpa a lista de arquivos
+            if (!store.files.length) {
+                filesList.innerHTML = '<small>No files selected</small>';
+                return;
+            }
+            var ul = document.createElement('ul');
+            ul.className = 'mb-0';  // Classe para formatação da lista
+            for (let i = 0; i < store.files.length; i++) {
+                const f = store.files[i];
+                var li = document.createElement('li');
+                li.className = 'd-flex align-items-center justify-content-between';  // Para alinhar os itens horizontalmente
+                var name = document.createElement('span');
+                name.textContent = f.webkitRelativePath || f.name;  // Mostra o nome ou o path relativo
+                var btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = 'btn btn-xs btn-outline-danger ml-2';  // Botão de remoção
+                btn.innerHTML = '<i class="fas fa-times"></i>';
+                btn.addEventListener('click', function () {
+                    // Remover o arquivo da lista
+                    var newStore = new DataTransfer();  // Cria um novo DataTransfer
+                    for (let j = 0; j < store.files.length; j++) {
+                        if (j !== i) newStore.items.add(store.files[j]);  // Só adiciona arquivos que não foram removidos
+                    }
+                    store = newStore;  // Atualiza o DataTransfer
+                    fileInput.files = store.files;  // Atualiza o campo de arquivos
+                    renderFilesList();  // Re-renderiza a lista de arquivos
+                });
+                li.appendChild(name);  // Adiciona o nome do arquivo
+                li.appendChild(btn);  // Adiciona o botão de remoção
+                ul.appendChild(li);  // Adiciona o item da lista
+            }
+            filesList.appendChild(ul);  // Adiciona a lista à seção de arquivos
+        }
+
+        // Adiciona arquivos ao store
+        function addFiles(fileList) {
+            if (!fileList || !fileList.length) return;
+
+            for (let i = 0; i < fileList.length; i++) {
+                const f = fileList[i];
+                // Ignora diretórios em DnD (para pastas use o input webkitdirectory)
+                if (typeof f.type === 'undefined' && !f.name) continue;
+                store.items.add(f);
+            }
+            fileInput.files = store.files;
+            renderFilesList();
+        }
+
+        // Input de arquivos (múltiplos)
+        fileInput.addEventListener('change', function (e) {
+            addFiles(e.target.files);
+            // limpa seleção original para permitir selecionar os mesmos nomes de novo
+            fileInput.value = '';
+        });
+
+        // Input de pastas (webkitdirectory) -> adiciona tudo ao store
+        if (folderInput) {
+            folderInput.addEventListener('change', function (e) {
+                addFiles(e.target.files);
+                // não limpamos para manter paths; opcional:
+                // folderInput.value = '';
+            });
+        }
+
+        // Dropzone visual
+        ['dragenter', 'dragover'].forEach(function (evt) {
+            drop.addEventListener(evt, function (e) {
+                e.preventDefault(); e.stopPropagation();
+                drop.classList.add('dragover');
+            }, false);
+        });
+        ['dragleave', 'drop'].forEach(function (evt) {
+            drop.addEventListener(evt, function (e) {
+                e.preventDefault(); e.stopPropagation();
+                drop.classList.remove('dragover');
+            }, false);
+        });
+
+        drop.addEventListener('drop', function (e) {
+            var dt = e.dataTransfer;
+            if (!dt) return;
+
+            // Alguns browsers expõem items com diretórios; ignoramos diretórios e avisamos
+            if (dt.items && dt.items.length) {
+                var hadDir = false;
+                var files = [];
+                for (let i = 0; i < dt.items.length; i++) {
+                    var item = dt.items[i];
+                    if (typeof item.webkitGetAsEntry === 'function') {
+                        var entry = item.webkitGetAsEntry();
+                        if (entry && entry.isDirectory) { hadDir = true; continue; }
+                    }
+                    var f = item.getAsFile && item.getAsFile();
+                    if (f) files.push(f);
+                }
+                if (files.length) addFiles(files);
+                if (hadDir) {
+                    $(document).Toasts('create', {
+                        class: 'bg-info',
+                        title: 'Heads up',
+                        body: 'Folder drops are not supported here. Use "Upload folders" abaixo.'
+                    });
+                }
+            } else if (dt.files && dt.files.length) {
+                addFiles(dt.files);
+            }
+        });
+
+        // ======= Submit (PoC) via fetch -> JSON -> toast + redirect =======
+        var btn = document.getElementById('btnSubmit');
+        var form = document.getElementById('clab-form');
+
+        btn.addEventListener('click', function () {
+            var btnText = btn.querySelector('.btn-text');
+            var spinner = btn.querySelector('.spinner-border');
+            btn.disabled = true; btnText.classList.add('d-none'); spinner.classList.remove('d-none');
+
+            // sincroniza editor -> textarea
+            if (typeof CodeMirror !== 'undefined' && cm) { cm.save(); }
+
+            var fd = new FormData(form);
+
+            // Repassa arquivos do store (pois fileInput.files foi sobrescrito pelo store)
+            for (let i = 0; i < store.files.length; i++) {
+                fd.append('clab_files', store.files[i], store.files[i].webkitRelativePath || store.files[i].name);
+            }
+
+            // Também repassa os de pastas (se quiser distinguir no backend)
+            if (folderInput && folderInput.files && folderInput.files.length) {
+                for (let i = 0; i < folderInput.files.length; i++) {
+                    fd.append('clab_folders', folderInput.files[i], folderInput.files[i].webkitRelativePath || folderInput.files[i].name);
+                }
+            }
+
+            // Validação mínima client-side: YAML ou arquivos
+            var hasYaml = (fd.get('clab_yaml') || '').trim().length > 0;
+            var filesLen = store.files.length + (folderInput.files ? folderInput.files.length : 0);
+            if (!hasYaml && filesLen === 0) {
+                $(document).Toasts('create', { class: 'bg-danger', title: 'Failure', body: 'Provide YAML and/or files' });
+                btn.disabled = false; btnText.classList.remove('d-none'); spinner.classList.add('d-none');
+                return;
+            }
+
+            fetch('{{ url_for("clabs_blueprint.create") }}', {
+                method: 'POST',
+                body: fd
+            }).then(function (resp) {
+                if (!resp.ok) return resp.json().then(function (j) { throw (j && j.result) || 'Failed'; });
+                return resp.json();
+            }).then(function (j) {
+                sessionStorage.setItem('msgSuccess', j.result || 'CLab created (mock).');
+                window.location = '{{ url_for("clabs_blueprint.running") }}';
+            }).catch(function (err) {
+                sessionStorage.setItem('msgFail', (err && err.toString()) || 'Failed to create CLab.');
+                window.location = '{{ url_for("clabs_blueprint.running") }}';
+            });
+        });
+
+        // Render inicial
+        renderFilesList();
+    })();
+</script>
+{% endblock javascripts %}

--- a/apps/clabs/templates/clabs/open.html
+++ b/apps/clabs/templates/clabs/open.html
@@ -1,0 +1,202 @@
+{% extends "layouts/base.html" %}
+
+{% block title %} Open CLab {% endblock %}
+
+{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
+
+{% block stylesheets %}
+<!-- Google Font: Source Sans Pro -->
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
+<!-- Font Awesome -->
+<link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+<!-- DataTables -->
+<link rel="stylesheet" href="/static/assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
+<link rel="stylesheet" href="/static/assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css">
+<!-- Theme style -->
+<link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+{% endblock stylesheets %}
+
+{% block content %}
+
+<div class="content-wrapper">
+
+    <section class="content-header">
+        <div class="container-fluid">
+            <div class="row mb-2">
+                <div class="col-sm-6">
+                    <h1>Open CLab</h1>
+                    <small class="text-muted">View ContainerLab resources</small>
+                </div>
+                <div class="col-sm-6">
+                    <ol class="breadcrumb float-sm-right">
+                        <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
+                        <li class="breadcrumb-item"><a href="{{ url_for('clabs_blueprint.running') }}">ContainerLabs</a>
+                        </li>
+                        <li class="breadcrumb-item active">{{ lab.lab_instance_id }}</li>
+                    </ol>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="content">
+
+        <!-- Summary -->
+        <div class="row">
+            <div class="col-md-12">
+                <div class="card card-outline card-primary">
+                    <div class="card-header">
+                        <h3 class="card-title">{{ lab.title }}</h3>
+                    </div>
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-sm-3">
+                                <strong>Instance ID:</strong>
+                                <p class="text-muted">{{ lab.lab_instance_id }}</p>
+                            </div>
+                            <div class="col-sm-3">
+                                <strong>User:</strong>
+                                <p class="text-muted">{{ lab.user }}</p>
+                            </div>
+                            <div class="col-sm-3">
+                                <strong>Created (UTC):</strong>
+                                <p class="text-muted">{{ lab.created or '--' }}</p>
+                            </div>
+                            <div class="col-sm-3">
+                                <strong>Expires at:</strong>
+                                <p class="text-muted">{{ lab.expires_at or '--' }}</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Files Uploaded Section (Alteração para Bloco 3) -->
+        <div class="row mt-4">
+            <div class="col-md-12">
+                <div class="card card-outline card-info">
+                    <div class="card-header">
+                        <h3 class="card-title">Uploaded Files</h3>
+                    </div>
+                    <div class="card-body">
+                        {% if lab.files %}
+                        <ul>
+                            {% for file in lab.files %}
+                            <li>
+                                {{ file.filename if file.filename else file }} <!-- Exibe o nome do arquivo -->
+                            </li>
+                            {% endfor %}
+                        </ul>
+                        {% else %}
+                        <p>No files uploaded.</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Resources table -->
+        <div class="row">
+            <div class="col-md-12">
+                <div class="card card-outline card-secondary">
+                    <div class="card-header">
+                        <h3 class="card-title">Resources</h3>
+                    </div>
+                    <div class="card-body table-responsive">
+                        <table id="tableResources" class="table table-striped display">
+                            <thead>
+                                <tr>
+                                    <th>Kind</th>
+                                    <th>Name</th>
+                                    <th>Status</th>
+                                    <th>Node</th>
+                                    <th>Pod IP</th>
+                                    <th>Age</th>
+                                    <th>Services</th>
+                                    <th>Links</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for r in lab.resources %}
+                                <tr>
+                                    <td>{{ r.kind }}</td>
+                                    <td>{{ r.name }}</td>
+                                    <td>
+                                        {% if r.ready == 'Running' %}
+                                        <span class="badge badge-success">{{ r.ready }}</span>
+                                        {% else %}
+                                        <span class="badge badge-secondary">{{ r.ready }}</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>{{ r.node_name or '--' }}</td>
+                                    <td>{{ r.pod_ip or '--' }}</td>
+                                    <td>{{ r.age or '--' }}</td>
+                                    <td>
+                                        {% if r.services %}
+                                        {% for s in r.services %}
+                                        <a href="{{ s.url }}" class="btn btn-xs btn-outline-primary" target="_blank">{{
+                                            s.name }}</a>
+                                        {% endfor %}
+                                        {% else %}
+                                        <span class="text-muted">--</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if r.links %}
+                                        {% for l in r.links %}
+                                        <a href="{{ l.href }}" class="btn btn-xs btn-default">{{ l.label }}</a>
+                                        {% endfor %}
+                                        {% else %}
+                                        <span class="text-muted">--</span>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </section>
+
+</div>
+
+{% endblock content %}
+
+{% block javascripts %}
+<!-- jQuery -->
+<script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+<!-- Bootstrap 4 -->
+<script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+<!-- DataTables -->
+<script src="/static/assets/plugins/datatables/jquery.dataTables.min.js"></script>
+<script src="/static/assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
+<script src="/static/assets/plugins/datatables-responsive/js/dataTables.responsive.min.js"></script>
+<script src="/static/assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js"></script>
+<!-- AdminLTE App -->
+<script src="/static/assets/js/adminlte.min.js"></script>
+
+<script>
+    $(function () {
+        $("#tableResources").DataTable({
+            responsive: false,
+            autoWidth: false,
+            language: { emptyTable: 'No resources' },
+            columns: [
+                { name: 'kind' },
+                { name: 'name' },
+                { name: 'status' },
+                { name: 'node' },
+                { name: 'pod_ip' },
+                { name: 'age' },
+                { orderable: false, name: 'services' },
+                { orderable: false, name: 'links' },
+            ],
+            order: [[1, 'asc']]
+        });
+    });
+</script>
+{% endblock javascripts %}

--- a/apps/clabs/templates/clabs/open.html
+++ b/apps/clabs/templates/clabs/open.html
@@ -72,7 +72,7 @@
             </div>
         </div>
 
-        <!-- Files Uploaded Section (Alteração para Bloco 3) -->
+        <!-- Files Uploaded Section -->
         <div class="row mt-4">
             <div class="col-md-12">
                 <div class="card card-outline card-info">
@@ -80,16 +80,19 @@
                         <h3 class="card-title">Uploaded Files</h3>
                     </div>
                     <div class="card-body">
-                        {% if lab.files %}
-                        <ul>
-                            {% for file in lab.files %}
+                        {% if lab.files and lab.files|length > 0 %}
+                        <ul class="list-unstyled mb-0">
+                            {% for f in lab.files %}
                             <li>
-                                {{ file.filename if file.filename else file }} <!-- Exibe o nome do arquivo -->
+                                <i class="far fa-file"></i>
+                                {{ f.name or f.filename or f }}
+                                {% if f.size %}<small class="text-muted"> ({{ f.size }} bytes)</small>{% endif %}
+                                {% if f.mimetype %}<small class="text-muted"> — {{ f.mimetype }}</small>{% endif %}
                             </li>
                             {% endfor %}
                         </ul>
                         {% else %}
-                        <p>No files uploaded.</p>
+                        <p class="mb-0"><em>No files uploaded.</em></p>
                         {% endif %}
                     </div>
                 </div>

--- a/apps/clabs/templates/clabs/open.html
+++ b/apps/clabs/templates/clabs/open.html
@@ -126,11 +126,10 @@
                                     <td>{{ r.kind }}</td>
                                     <td>{{ r.name }}</td>
                                     <td>
-                                        {% if r.ready == 'Running' %}
-                                        <span class="badge badge-success">{{ r.ready }}</span>
-                                        {% else %}
-                                        <span class="badge badge-secondary">{{ r.ready }}</span>
-                                        {% endif %}
+                                        <span
+                                            class="badge badge-{{ 'success' if r.ready=='Running' else ('danger' if r.ready=='Failed' else 'secondary') }}">
+                                            {{ r.ready or '--' }}
+                                        </span>
                                     </td>
                                     <td>{{ r.node_name or '--' }}</td>
                                     <td>{{ r.pod_ip or '--' }}</td>

--- a/apps/clabs/templates/clabs/running.html
+++ b/apps/clabs/templates/clabs/running.html
@@ -165,7 +165,7 @@
         if (sessionStorage.getItem('msgSuccess')) {
             $(document).Toasts('create', {
                 class: 'bg-success',
-                title: 'Sucess',
+                title: 'Success',
                 body: sessionStorage.getItem('msgSuccess')
             });
             sessionStorage.removeItem('msgSuccess');

--- a/apps/clabs/templates/clabs/running.html
+++ b/apps/clabs/templates/clabs/running.html
@@ -146,12 +146,15 @@
 
 <script>
     $(function () {
+        // URL templates (o segundo recebe o ID por replace)
+        const listUrl = "{{ url_for('clabs_blueprint.api_list') }}";
+        const deleteUrlTpl = "{{ url_for('clabs_blueprint.api_delete', clab_id='__ID__') }}";
+
+        // DataTable
         var table = $("#tableLabs").DataTable({
             responsive: false,
             autoWidth: false,
-            language: {
-                emptyTable: 'No running clabs',
-            },
+            language: { emptyTable: 'No running clabs' },
             columns: [
                 { orderable: false, name: 'select' },
                 { name: 'user' },
@@ -162,62 +165,115 @@
             order: [[2, 'asc']]
         });
 
-        if (sessionStorage.getItem('msgSuccess')) {
-            $(document).Toasts('create', {
-                class: 'bg-success',
-                title: 'Success',
-                body: sessionStorage.getItem('msgSuccess')
+        // Renderiza linhas para DataTables
+        function buildRows(items) {
+            return (items || []).map(function (it) {
+                var id = it.lab_instance_id;
+                var checkbox = `
+          <div class="icheck-primary">
+            <input type="checkbox" id="checkbox-${id}">
+            <label for="checkbox-${id}"></label>
+          </div>`;
+                var actions = `
+          <a class="btn btn-default" href="/containerlabs/open/${id}">
+            <i class="fas fa-eye"></i> Open CLab
+          </a>`;
+                return [checkbox, it.user || '--', it.title || '--', it.created || '--', actions];
             });
+        }
+
+        // Carrega lista (AJAX) e popula tabela
+        async function loadList() {
+            try {
+                const res = await fetch(listUrl, { cache: 'no-store' });
+                const data = await res.json();
+                const rows = buildRows(data.items || []);
+                table.clear().rows.add(rows).draw(false);
+            } catch (e) {
+                console.warn('Failed to load clabs list', e);
+            }
+        }
+
+        // Toasts de sessão
+        if (sessionStorage.getItem('msgSuccess')) {
+            $(document).Toasts('create', { class: 'bg-success', title: 'Success', body: sessionStorage.getItem('msgSuccess') });
             sessionStorage.removeItem('msgSuccess');
         }
         if (sessionStorage.getItem('msgFail')) {
-            $(document).Toasts('create', {
-                class: 'bg-danger',
-                title: 'Failure',
-                body: sessionStorage.getItem('msgFail')
-            });
+            $(document).Toasts('create', { class: 'bg-danger', title: 'Failure', body: sessionStorage.getItem('msgFail') });
             sessionStorage.removeItem('msgFail');
         }
 
-        $('#delete-labs').click(function () {
-            var rows = $('#tableLabs tr').filter(':has(:checkbox:checked)');
-            $("#delete-labs").html('<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Deleting ' + table.rows(rows).data().length + ' row(s)...');
-            $("#delete-labs").prop('disabled', true);
-            setTimeout(function () {
-                sessionStorage.setItem('msgSuccess', 'Selected CLabs removed (mock).');
-                location.reload();
-            }, 600);
-        });
-
-        $('#modal-default').on('show.bs.modal', function (e) {
-            var rows = $('#tableLabs tr').filter(':has(:checkbox:checked)');
-            var data = table.rows(rows).data();
+        // Modal de confirmação — montar lista
+        $('#modal-default').on('show.bs.modal', function () {
             var items = $("#modal-default-items");
             items.empty();
-            $("#delete-labs").prop('disabled', false);
-            if (data.length === 0) {
+            var checked = $('#tableLabs tbody input[type="checkbox"]:checked');
+            if (checked.length === 0) {
                 items.append("<li>No clab selected!</li>");
                 $("#delete-labs").prop('disabled', true);
-                return;
+            } else {
+                $("#delete-labs").prop('disabled', false);
+                checked.each(function () {
+                    var id = this.id.replace('checkbox-', '');
+                    // pega a linha correspondente no DataTables para exibir título e data
+                    var row = $(this).closest('tr');
+                    var rowData = table.row(row).data() || [];
+                    var title = rowData[2] || '--';
+                    var created = rowData[3] || '--';
+                    items.append(`<li data-id="${id}">${title} - ${created}</li>`);
+                });
             }
-            data.each(function (value, index) {
-                items.append(`<li>${value[2]} - ${value[3]}</li>`);
-            });
         });
 
-        $('.checkbox-toggle').click(function () {
-            var clicks = $(this).data('clicks')
-            if (clicks) {
-                $('.lab-items input[type="checkbox"]').prop('checked', false)
-                $('.checkbox-toggle .far.fa-check-square').removeClass('fa-check-square').addClass('fa-square')
-            } else {
-                $('.lab-items input[type="checkbox"]').prop('checked', true)
-                $('.checkbox-toggle .far.fa-square').removeClass('fa-square').addClass('fa-check-square')
+        // Delete (mock)
+        $('#delete-labs').click(async function () {
+            var btn = $(this);
+            var rows = $('#tableLabs tbody input[type="checkbox"]:checked');
+            var count = rows.length;
+            btn.html('<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Deleting ' + count + ' row(s)...');
+            btn.prop('disabled', true);
+
+            let ok = 0, fail = 0;
+            for (const el of rows.toArray()) {
+                const id = el.id.replace('checkbox-', '');
+                try {
+                    const url = deleteUrlTpl.replace('__ID__', id);
+                    const resp = await fetch(url, { method: 'DELETE' });
+                    const j = await resp.json().catch(() => ({}));
+                    if (resp.ok && j.ok) ok++; else fail++;
+                } catch (e) { fail++; }
             }
-            $(this).data('clicks', !clicks)
+
+            // fecha modal, atualiza tabela e mostra toast
+            $('#modal-default').modal('hide');
+            await loadList();
+            if (fail === 0) {
+                sessionStorage.setItem('msgSuccess', 'Selected CLabs removed (mock).');
+            } else {
+                sessionStorage.setItem('msgFail', `Some items failed to delete (${fail}/${count}).`);
+            }
+            location.reload(); // mantém seu fluxo de recarregar/mostrar toast
         });
+
+        // Toggle "select all"
+        $('.checkbox-toggle').click(function () {
+            var clicks = $(this).data('clicks');
+            $('#tableLabs tbody input[type="checkbox"]').prop('checked', !clicks);
+            $(this).data('clicks', !clicks);
+            // alterna o ícone
+            var ico = $(this).find('.far');
+            if (clicks) { ico.removeClass('fa-check-square').addClass('fa-square'); }
+            else { ico.removeClass('fa-square').addClass('fa-check-square'); }
+        });
+
+        // inicial
+        loadList();
+        // refresh periódico (8s)
+        setInterval(loadList, 8000);
     });
 </script>
+
 
 <script src="/static/assets/js/demo.js"></script>
 {% endblock javascripts %}

--- a/apps/clabs/templates/clabs/running.html
+++ b/apps/clabs/templates/clabs/running.html
@@ -1,0 +1,223 @@
+{% extends "layouts/base.html" %}
+
+{% block title %} Running CLabs {% endblock %}
+
+{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
+
+{% block stylesheets %}
+<!-- Google Font: Source Sans Pro -->
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
+<!-- Font Awesome -->
+<link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+<!-- DataTables -->
+<link rel="stylesheet" href="/static/assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
+<link rel="stylesheet" href="/static/assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css">
+<!-- icheck bootstrap -->
+<link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+<!-- Theme style -->
+<link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+{% endblock stylesheets %}
+
+{% block content %}
+
+<div class="content-wrapper">
+    <section class="content-header">
+        <div class="container-fluid">
+            <div class="row mb-2">
+                <div class="col-sm-6">
+                    <h1>Running CLabs</h1>
+                </div>
+                <div class="col-sm-6">
+                    <ol class="breadcrumb float-sm-right">
+                        <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
+                        <li class="breadcrumb-item active">Running CLabs</li>
+                    </ol>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="content">
+        <div class="row">
+            <div class="col-md-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Running CLabs</h3>
+                        <div class="float-right">
+                            <button type="button" class="btn btn-default btn-sm checkbox-toggle"><i
+                                    class="far fa-square"></i></button>
+                            <button type="button" class="btn btn-default btn-sm" data-toggle="modal"
+                                data-target="#modal-default">
+                                <i class="far fa-trash-alt"></i>
+                            </button>
+                        </div>
+                    </div>
+                    <!-- /.card-header -->
+                    <div class="card-body table-responsive lab-items">
+                        <table id="tableLabs" class="table table-striped display">
+                            <thead>
+                                <tr>
+                                    <th></th>
+                                    <th>User</th>
+                                    <th>Lab title</th>
+                                    <th>Created (UTC)</th>
+                                    <th>Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for lab in labs %}
+                                <tr id="{{ lab['lab_instance_id'] }}">
+                                    <td>
+                                        <div class="icheck-primary">
+                                            <input type="checkbox" value="" id="checkbox-{{ lab['lab_instance_id'] }}">
+                                            <label for="checkbox-{{ lab['lab_instance_id'] }}"></label>
+                                        </div>
+                                    </td>
+                                    <td>{{ lab['user'] }}</td>
+                                    <td>{{ lab['title'] }}</td>
+                                    <td>{{ lab['created'] }}</td>
+                                    <td>
+                                        <a class="btn btn-default"
+                                            href="{{ url_for('clabs_blueprint.open_clab', clab_id=lab['lab_instance_id']) }}"><i
+                                                class="fas fa-eye"></i> Open CLab</a>
+                                    </td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                        <!-- /.table -->
+                    </div>
+                    <!-- /.card-body -->
+                    <div class="card-footer p-0">
+                        <div class="mailbox-controls">
+                            <button type="button" class="btn btn-default btn-sm checkbox-toggle">
+                                <i class="far fa-square"></i>
+                            </button>
+                            <button type="button" class="btn btn-default btn-sm" data-toggle="modal"
+                                data-target="#modal-default">
+                                <i class="far fa-trash-alt"></i>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+                <!-- /.card -->
+            </div>
+        </div>
+
+        <div class="modal fade" id="modal-default">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h4 class="modal-title">Confirm CLab removal</h4>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Are you sure you want to remove the selected CLabs?</p>
+                        <ul id="modal-default-items"></ul>
+                    </div>
+                    <div class="modal-footer justify-content-between">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-danger" id="delete-labs">Delete CLabs</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </section>
+</div>
+
+{% endblock content %}
+
+{% block javascripts %}
+
+<!-- jQuery -->
+<script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+<!-- Bootstrap 4 -->
+<script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+<!-- DataTables -->
+<script src="/static/assets/plugins/datatables/jquery.dataTables.min.js"></script>
+<script src="/static/assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
+<script src="/static/assets/plugins/datatables-responsive/js/dataTables.responsive.min.js"></script>
+<script src="/static/assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js"></script>
+<!-- AdminLTE App -->
+<script src="/static/assets/js/adminlte.min.js"></script>
+
+<script>
+    $(function () {
+        var table = $("#tableLabs").DataTable({
+            responsive: false,
+            autoWidth: false,
+            language: {
+                emptyTable: 'No running clabs',
+            },
+            columns: [
+                { orderable: false, name: 'select' },
+                { name: 'user' },
+                { name: 'lab' },
+                { name: 'created' },
+                { orderable: false, name: 'actions' },
+            ],
+            order: [[2, 'asc']]
+        });
+
+        if (sessionStorage.getItem('msgSuccess')) {
+            $(document).Toasts('create', {
+                class: 'bg-success',
+                title: 'Sucess',
+                body: sessionStorage.getItem('msgSuccess')
+            });
+            sessionStorage.removeItem('msgSuccess');
+        }
+        if (sessionStorage.getItem('msgFail')) {
+            $(document).Toasts('create', {
+                class: 'bg-danger',
+                title: 'Failure',
+                body: sessionStorage.getItem('msgFail')
+            });
+            sessionStorage.removeItem('msgFail');
+        }
+
+        $('#delete-labs').click(function () {
+            var rows = $('#tableLabs tr').filter(':has(:checkbox:checked)');
+            $("#delete-labs").html('<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Deleting ' + table.rows(rows).data().length + ' row(s)...');
+            $("#delete-labs").prop('disabled', true);
+            setTimeout(function () {
+                sessionStorage.setItem('msgSuccess', 'Selected CLabs removed (mock).');
+                location.reload();
+            }, 600);
+        });
+
+        $('#modal-default').on('show.bs.modal', function (e) {
+            var rows = $('#tableLabs tr').filter(':has(:checkbox:checked)');
+            var data = table.rows(rows).data();
+            var items = $("#modal-default-items");
+            items.empty();
+            $("#delete-labs").prop('disabled', false);
+            if (data.length === 0) {
+                items.append("<li>No clab selected!</li>");
+                $("#delete-labs").prop('disabled', true);
+                return;
+            }
+            data.each(function (value, index) {
+                items.append(`<li>${value[2]} - ${value[3]}</li>`);
+            });
+        });
+
+        $('.checkbox-toggle').click(function () {
+            var clicks = $(this).data('clicks')
+            if (clicks) {
+                $('.lab-items input[type="checkbox"]').prop('checked', false)
+                $('.checkbox-toggle .far.fa-check-square').removeClass('fa-check-square').addClass('fa-square')
+            } else {
+                $('.lab-items input[type="checkbox"]').prop('checked', true)
+                $('.checkbox-toggle .far.fa-square').removeClass('fa-square').addClass('fa-check-square')
+            }
+            $(this).data('clicks', !clicks)
+        });
+    });
+</script>
+
+<script src="/static/assets/js/demo.js"></script>
+{% endblock javascripts %}

--- a/apps/config.py
+++ b/apps/config.py
@@ -11,6 +11,14 @@ class Config(object):
 
     basedir = os.path.abspath(os.path.dirname(__file__))
 
+    # Persistência dos CLabs (PoC)
+    CLABS_STATE_PATH = os.getenv("CLABS_STATE_PATH", None) 
+    CLABS_EXPIRE_DAYS = int(os.getenv("CLABS_EXPIRE_DAYS", "0"))  
+
+    # Limites de upload
+    MAX_CONTENT_LENGTH = int(os.getenv("MAX_CONTENT_LENGTH", str(50 * 1024 * 1024)))  # 50 MB
+    CLABS_UPLOAD_MAX_FILES = int(os.getenv("CLABS_UPLOAD_MAX_FILES", "200"))
+
     # Limite total do corpo (teto de upload) — 50MB por padrão
     MAX_CONTENT_LENGTH = int(os.getenv("MAX_CONTENT_LENGTH", 50 * 1024 * 1024))
 

--- a/apps/config.py
+++ b/apps/config.py
@@ -11,6 +11,12 @@ class Config(object):
 
     basedir = os.path.abspath(os.path.dirname(__file__))
 
+    # Limite total do corpo (teto de upload) — 50MB por padrão
+    MAX_CONTENT_LENGTH = int(os.getenv("MAX_CONTENT_LENGTH", 50 * 1024 * 1024))
+
+    # Limite de quantidade de arquivos (PoC)
+    CLABS_UPLOAD_MAX_FILES = int(os.getenv("CLABS_UPLOAD_MAX_FILES", 200))
+
     # Directories
     DATA_DIR = os.getenv('DATA_DIR', os.path.join(basedir, 'data'))
     UPLOAD_DIR = os.path.join(DATA_DIR, 'uploads')

--- a/apps/templates/includes/sidebar.html
+++ b/apps/templates/includes/sidebar.html
@@ -96,15 +96,33 @@
               </li>
             </ul>
           </li>
-          <li class="nav-item">
-            <a href="{{url_for('home_blueprint.running_labs')}}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.running_labs' %} active {% endif %}">
-              <i class="nav-icon far fa-calendar-alt"></i>
+
+          {% if config.get('ENABLE_CLABS') %}
+          <li class="nav-item has-treeview {% if request.path.startswith('/containerlabs') %} menu-open {% endif %}">
+            <a href="#" class="nav-link {% if request.path.startswith('/containerlabs') %} active {% endif %}">
+              <i class="nav-icon fas fa-layer-group"></i>
               <p>
-                Running Labs
-                <span class="badge badge-info right">{{g.running_labs}}</span>
+                ContainerLabs
+                <i class="fas fa-angle-left right"></i>
               </p>
             </a>
+            <ul class="nav nav-treeview">
+              <li class="nav-item">
+                <a href="{{ url_for('clabs_blueprint.running') }}" class="nav-link {% if request.endpoint == 'clabs_blueprint.running' %} active {% endif %}">
+                  <i class="far fa-circle nav-icon"></i>
+                  <p>Running CLabs</p>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a href="{{ url_for('clabs_blueprint.create') }}" class="nav-link {% if request.endpoint == 'clabs_blueprint.create' %} active {% endif %}">
+                  <i class="far fa-circle nav-icon"></i>
+                  <p>Create CLabs</p>
+                </a>
+              </li>
+            </ul>
           </li>
+          {% endif %}
+
           <li class="nav-header">MANAGEMENT</li>
           {% if current_user.category == "admin" or current_user.category == "teacher" %}
           <li class="nav-item">


### PR DESCRIPTION
Adds a new ContainerLabs menu (below “Running Labs”) with two submenus:
- Running CLabs: DataTable mirroring “Running Labs”, with Open CLab action. Supports AJAX refresh and mock Delete.
- Create CLabs: CodeMirror YAML editor + file/folder uploads with drag & drop. Client-side YAML validation (js-yaml) with server fallback. No duplicate files in FormData.
