### PR TITLE
Adding script to wait for docker to be ready before start clab graph

### DIFF
--- a/apps/controllers/clabernetes.py
+++ b/apps/controllers/clabernetes.py
@@ -46,8 +46,14 @@ spec:
         args:
         - |
           service docker start
+          echo Waiting for Docker daemon to be ready...
+          until [ -S /var/run/docker.sock ]; do sleep 1; done
+          service docker status
+          docker info
+          echo Waiting for topology to be ready...
           until [ -s /topology-data.yaml ]; do sleep 1; done
           cat /topology-data.yaml
+          echo Starting clab graph...
           clab graph --offline --topo /topology-data.yaml
         volumeMounts:
         - name: clab-topology-data

--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -206,7 +206,6 @@ def run_lab(lab_id):
         clab_md = lab.lab_metadata.md
         lab_manifest += "\n---\n" + c9s.get_topology_visualizer_manifest(pod_hash, clab_md["topology"])
 
-    current_app.logger.warning(f"creating manifest: {lab_manifest}")
     status, msg = k8s.create_lab(lab_id, lab_manifest, user_uid=current_user.uid, pod_hash=pod_hash, replace_identifiers=replace_identifiers)
 
     if status:


### PR DESCRIPTION
Fix #220 

### Description of the change

Fix an issue when the topology visualizer could stay in a CrashLoopback error because docker was not ready when starting `clab graph`. We've added a wait docker ready routine to deal with that case.