### PR TITLE
fix form input for secret-name

### DIFF
--- a/apps/clabs/routes.py
+++ b/apps/clabs/routes.py
@@ -45,7 +45,6 @@ def upsert(clab_id="new"):
     if request.method == "GET":
         return render_template("pages/clabs_upsert.html", clab=clab, lab_categories=lab_categories, groups=groups, current_files=current_files)
 
-    current_app.logger.info(f"clab_id={clab.id} short_uuid={clab_uuid} clab_guide={request.form['clab_guide']}")
     clab.title = request.form.get("clab_title", "").strip()
     clab.description = request.form.get("clab_desc", "").strip()
     clab.set_extended_desc(request.form["clab_extended_desc"])
@@ -136,9 +135,8 @@ def upsert(clab_id="new"):
         if not topo_status:
             msg = f"Failed to parse ContainerLab topology from {clab_dir}: {topo_data}"
             current_app.logger.error(msg)
-            if clab_id == "new":
-                current_app.logger.info(f"Remove files from {clab_dir}")
-                shutil.rmtree(clab_dir)
+            current_app.logger.info(f"Remove files from {clab_dir}")
+            shutil.rmtree(clab_dir)
             return jsonify({"ok": False, "result": msg}), 400
 
         md = clab_md.md

--- a/apps/templates/pages/clabs_upsert.html
+++ b/apps/templates/pages/clabs_upsert.html
@@ -265,7 +265,7 @@
                       <tbody id="table-body-secrets">
                       {% for secret in clab.secret_names %}
 		      <tr id="row-secret-{{secret}}">
-                        <td><input class="form-control" type="text" name="secret-name" value="{{secret}}" disabled></td>
+                        <td><input class="form-control" type="text" name="secret-name" value="{{secret}}" readonly></td>
                         <td><input class="form-control d-none" type="text" name="secret-server" value="" disabled></td>
                         <td><input class="form-control d-none" type="text" name="secret-user" value="" disabled></td>
 			<td>


### PR DESCRIPTION
Fix #222 


Fixes:

- Change form input field for secret-name from disabled to readonly
- removing debug log message with clab_guide
- removing files from lab when conversion fails