### PR TITLE
feat: adding support for file upload

### DIFF
--- a/apps/config.py
+++ b/apps/config.py
@@ -156,6 +156,10 @@ class Config(object):
     # feedback modal, default to 1 day
     HIDE_FEEDBACK_SEC = 1*24*60*60
 
+    # File upload configurations for lab editor
+    LAB_UPLOAD_MAX_SIZE = int(os.getenv("LAB_UPLOAD_MAX_SIZE", str(10 * 1024 * 1024))) # Default 10MB
+    LAB_UPLOAD_ALLOWED_EXTENSIONS = set(os.getenv("LAB_UPLOAD_ALLOWED_EXTENSIONS", "png,jpg,jpeg,gif,svg,webp,pdf,txt,zip,tar.gz").split(","))
+
 class ProductionConfig(Config):
     DEBUG = False
 

--- a/apps/config.py
+++ b/apps/config.py
@@ -158,7 +158,7 @@ class Config(object):
 
     # File upload configurations for lab editor
     LAB_UPLOAD_MAX_SIZE = int(os.getenv("LAB_UPLOAD_MAX_SIZE", str(10 * 1024 * 1024))) # Default 10MB
-    LAB_UPLOAD_ALLOWED_EXTENSIONS = set(os.getenv("LAB_UPLOAD_ALLOWED_EXTENSIONS", "png,jpg,jpeg,gif,svg,webp,pdf,txt,zip,tar.gz").split(","))
+    LAB_UPLOAD_ALLOWED_EXTENSIONS = set(os.getenv("LAB_UPLOAD_ALLOWED_EXTENSIONS", "png,jpg,jpeg,gif,svg,webp,pdf,txt,yaml,yml,zip,tar.gz,tgz,tar.xz").split(","))
 
 class ProductionConfig(Config):
     DEBUG = False

--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -4,6 +4,7 @@ Copyright (c) 2019 - present AppSeed.us
 """
 import traceback
 import uuid
+import os
 import re
 from collections import OrderedDict
 
@@ -12,7 +13,7 @@ from apps.home import blueprint
 from apps.controllers import k8s, c9s
 from apps.home.models import Labs, LabInstances, LabCategories, LabAnswers, LabAnswerSheet, HomeLogging, UserLikes, UserFeedbacks
 from apps.authentication.models import Users, Groups
-from flask import render_template, request, current_app, redirect, url_for, session
+from flask import render_template, request, current_app, redirect, url_for, session, send_from_directory, jsonify
 from flask_login import login_required, current_user
 from jinja2 import TemplateNotFound
 from apps.audit_mixin import get_remote_addr, check_user_category
@@ -254,7 +255,7 @@ def check_lab_status(lab_id):
     lab = LabInstances.query.get(lab_id)
     if not lab:
         return render_template("pages/error.html", title="Error checking lab status", msg="Lab not found")
-    
+
     if lab.user_id != current_user.id:
         return render_template("pages/error.html", title="Error checking lab status", msg="You are not authorized to run this lab")
 
@@ -483,7 +484,7 @@ def edit_lab(lab_id):
 
     lab.title = request.form["lab_title"]
     lab.description = request.form["lab_description"]
-    
+
     selected_category_ids = request.form.getlist('lab_categories')
     invalid_lab_category = ""
     if selected_category_ids:
@@ -494,7 +495,7 @@ def edit_lab(lab_id):
                 invalid_lab_category = f"Invalid Lab Category ({c_id}). "
                 break
             lab.categories.append(category)
-    
+
     lab.set_extended_desc(request.form["lab_extended_desc"])
     lab.set_lab_guide_md(request.form["lab_guide"])
     lab.manifest = request.form["lab_manifest"]
@@ -504,7 +505,7 @@ def edit_lab(lab_id):
 
     if not lab.categories or invalid_lab_category:
         return render_template("pages/labs_edit.html", lab=lab, lab_categories=lab_categories, msg_fail=invalid_lab_category+"Please select at least one category", segment="/labs/edit", groups=groups, allowed_groups=lab.allowed_groups)
-    
+
     try:
         db.session.add(lab)
         db.session.commit()
@@ -528,7 +529,6 @@ def edit_lab(lab_id):
 @login_required
 @check_user_category(["admin", "teacher"])
 def view_users():
-   
     users = Users.query.filter_by(is_deleted=False)
     if current_user.category in ["teacher"]:
         users = users.filter(Users.category == "user")
@@ -557,7 +557,7 @@ def view_labs(lab_id=None):
 
     if lab_id:
         labs = labs.filter(Labs.id == lab_id)
-    
+
     labs = labs.all()
     user_labs_status = {}
     for lab in LabInstances.query.filter_by(user_id=current_user.id).all():
@@ -1038,3 +1038,64 @@ def view_contact():
 @login_required
 def view_finished_lab_infos(lab_id):
     return render_template("pages/finished_lab_infos.html", lab_id=lab_id)
+
+
+@blueprint.route('/uploads/<path:filename>')
+@login_required
+def serve_upload(filename):
+    return send_from_directory(current_app.config['UPLOAD_DIR'], filename)
+
+
+@blueprint.route('/labs/upload-file', methods=['POST'])
+@login_required
+@check_user_category(["admin", "teacher", "labcreator"])
+def upload_lab_file():
+    if 'file' not in request.files:
+        return jsonify({"status": "fail", "result": "No file part in the request"}), 400
+
+    file = request.files['file']
+    if file.filename == '':
+        return jsonify({"status": "fail", "result": "No file selected"}), 400
+
+    # Validate extension
+    allowed_exts = current_app.config['LAB_UPLOAD_ALLOWED_EXTENSIONS']
+    _, ext = os.path.splitext(file.filename)
+    if not ext or ext[1:].lower() not in allowed_exts:
+        # Also check for double extensions like .tar.gz if they exist in allowed_exts
+        is_allowed = False
+        lower_filename = file.filename.lower()
+        for allowed_ext in allowed_exts:
+            if lower_filename.endswith('.' + allowed_ext.lower()):
+                is_allowed = True
+                ext = '.' + allowed_ext
+                break
+        if not is_allowed:
+            return jsonify({"status": "fail", "result": f"File extension not allowed. Allowed: {', '.join(allowed_exts)}"}), 400
+
+    # Validate size
+    file.seek(0, os.SEEK_END)
+    size = file.tell()
+    file.seek(0) # reset pointer
+
+    max_size = current_app.config['LAB_UPLOAD_MAX_SIZE']
+    if size > max_size:
+        return jsonify({"status": "fail", "result": f"File exceeds maximum allowed size ({max_size // (1024*1024)}MB)"}), 400
+
+    # Save directory
+    upload_dir = current_app.config['UPLOAD_DIR']
+    os.makedirs(upload_dir, exist_ok=True)
+
+    # Generate unique filename using uuid
+    new_filename = f"{uuid.uuid4().hex}{ext.lower()}"
+
+    try:
+        file.save(os.path.join(upload_dir, new_filename))
+        url = url_for('home_blueprint.serve_upload', filename=new_filename)
+        return jsonify({
+            "status": "ok",
+            "url": url,
+            "filename": file.filename
+        }), 200
+    except Exception as exc:
+        current_app.logger.error(f"Failed to save uploaded file: {exc}")
+        return jsonify({"status": "fail", "result": "Failed to save file on server"}), 500

--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -6,12 +6,13 @@ import traceback
 import uuid
 import os
 import re
+import json
 from collections import OrderedDict
 
 from apps import db, cache
 from apps.home import blueprint
 from apps.controllers import k8s, c9s
-from apps.home.models import Labs, LabInstances, LabCategories, LabAnswers, LabAnswerSheet, HomeLogging, UserLikes, UserFeedbacks
+from apps.home.models import Labs, LabInstances, LabCategories, LabAnswers, LabAnswerSheet, HomeLogging, UserLikes, UserFeedbacks, LabMetadata
 from apps.authentication.models import Users, Groups
 from flask import render_template, request, current_app, redirect, url_for, session, send_from_directory, jsonify
 from flask_login import login_required, current_user
@@ -474,8 +475,12 @@ def edit_lab(lab_id):
 
     groups = Groups.query.filter_by(is_deleted=False).all()
 
+    lab_uploads = []
+    if lab.lab_metadata:
+        lab_uploads = lab.lab_metadata.md.get("uploads", [])
+
     if request.method == "GET":
-        return render_template("pages/labs_edit.html", lab=lab, lab_categories=lab_categories, groups=groups, allowed_groups=lab.allowed_groups, segment="/labs/edit")
+        return render_template("pages/labs_edit.html", lab=lab, lab_categories=lab_categories, groups=groups, allowed_groups=lab.allowed_groups, segment="/labs/edit", lab_uploads=lab_uploads)
 
     # TODO: data validation/sanitization
     # validate manifest using k8s dry-run?
@@ -504,7 +509,7 @@ def edit_lab(lab_id):
     lab.allowed_groups = Groups.query.filter(Groups.id.in_(selected_group_ids), Groups.is_deleted==False).all()
 
     if not lab.categories or invalid_lab_category:
-        return render_template("pages/labs_edit.html", lab=lab, lab_categories=lab_categories, msg_fail=invalid_lab_category+"Please select at least one category", segment="/labs/edit", groups=groups, allowed_groups=lab.allowed_groups)
+        return render_template("pages/labs_edit.html", lab=lab, lab_categories=lab_categories, msg_fail=invalid_lab_category+"Please select at least one category", segment="/labs/edit", groups=groups, allowed_groups=lab.allowed_groups, lab_uploads=lab_uploads)
 
     try:
         db.session.add(lab)
@@ -516,14 +521,51 @@ def edit_lab(lab_id):
         msg = "Failed to save Lab information"
         current_app.logger.error(f"{msg} - {exc}")
 
-    edit_lab_log = HomeLogging(ipaddr=get_remote_addr(), action="edit_lab", success= status, lab_id=lab.id, user_id=current_user.id)
+    # Associate any pending uploads (from new-lab mode where lab.id was not yet available)
+    if status:
+        pending_filenames_raw = request.form.get("pending_upload_filenames", "[]")
+        pending_orignames_raw = request.form.get("pending_upload_orignames", "[]")
+        try:
+            pending_filenames = json.loads(pending_filenames_raw)
+            pending_orignames = json.loads(pending_orignames_raw)
+        except Exception:
+            pending_filenames = []
+            pending_orignames = []
+
+        if pending_filenames:
+            upload_dir = current_app.config['UPLOAD_DIR']
+            lab_md = lab.lab_metadata
+            if not lab_md:
+                lab_md = LabMetadata(lab=lab, is_clab=False)
+                db.session.add(lab_md)
+            md = lab_md.md
+            existing_uploads = md.get("uploads", [])
+            existing_filenames = {u["filename"] for u in existing_uploads}
+            for fname, orig in zip(pending_filenames, pending_orignames):
+                if fname in existing_filenames:
+                    continue
+                fpath = os.path.join(upload_dir, fname)
+                if not os.path.exists(fpath):
+                    current_app.logger.warning(f"Pending upload file not found on disk: {fname}")
+                    continue
+                file_url = url_for('home_blueprint.serve_upload', filename=fname)
+                existing_uploads.append({"filename": fname, "original_name": orig, "url": file_url})
+                existing_filenames.add(fname)
+            md["uploads"] = existing_uploads
+            lab_md.md = md
+            try:
+                db.session.commit()
+            except Exception as exc:
+                current_app.logger.error(f"Failed to save pending uploads metadata for lab {lab.id}: {exc}")
+
+    edit_lab_log = HomeLogging(ipaddr=get_remote_addr(), action="edit_lab", success=status, lab_id=lab.id, user_id=current_user.id)
     db.session.add(edit_lab_log)
     db.session.commit()
 
     if status:
         return redirect(url_for('home_blueprint.view_labs', lab_id=lab.id))
     else:
-        return render_template("pages/labs_edit.html", lab=lab, lab_categories=lab_categories, msg_fail=msg, segment="/labs/edit", groups=groups, allowed_groups=lab.allowed_groups)
+        return render_template("pages/labs_edit.html", lab=lab, lab_categories=lab_categories, msg_fail=msg, segment="/labs/edit", groups=groups, allowed_groups=lab.allowed_groups, lab_uploads=lab_uploads)
 
 @blueprint.route('/users')
 @login_required
@@ -1090,12 +1132,95 @@ def upload_lab_file():
 
     try:
         file.save(os.path.join(upload_dir, new_filename))
-        url = url_for('home_blueprint.serve_upload', filename=new_filename)
-        return jsonify({
-            "status": "ok",
-            "url": url,
-            "filename": file.filename
-        }), 200
+        file_url = url_for('home_blueprint.serve_upload', filename=new_filename)
     except Exception as exc:
         current_app.logger.error(f"Failed to save uploaded file: {exc}")
         return jsonify({"status": "fail", "result": "Failed to save file on server"}), 500
+
+    # If a lab_id was provided, persist the file reference to LabMetadata
+    uploads = []
+    lab_id = request.form.get("lab_id", "").strip()
+    if lab_id and lab_id != "new":
+        lab = Labs.query.get(lab_id)
+        if lab:
+            lab_md = lab.lab_metadata
+            if not lab_md:
+                lab_md = LabMetadata(lab=lab, is_clab=False)
+                db.session.add(lab_md)
+            md = lab_md.md
+            existing_uploads = md.get("uploads", [])
+            existing_uploads.append({
+                "filename": new_filename,
+                "original_name": file.filename,
+                "url": file_url,
+            })
+            md["uploads"] = existing_uploads
+            lab_md.md = md
+            try:
+                db.session.commit()
+            except Exception as exc:
+                current_app.logger.error(f"Failed to save upload metadata for lab {lab_id}: {exc}")
+            uploads = existing_uploads
+
+    return jsonify({
+        "status": "ok",
+        "url": file_url,
+        "filename": file.filename,
+        "saved_filename": new_filename,
+        "uploads": uploads,
+    }), 200
+
+
+@blueprint.route("/labs/<lab_id>/uploads", methods=["GET"])
+@login_required
+@check_user_category(["admin", "teacher", "labcreator"])
+def get_lab_uploads(lab_id):
+    lab = Labs.query.get(lab_id)
+    if not lab:
+        return jsonify({"status": "fail", "result": "Lab not found"}), 404
+    if current_user.category == "labcreator" and lab.updated_by != current_user.id:
+        return jsonify({"status": "fail", "result": "Unauthorized"}), 403
+    uploads = lab.lab_metadata.md.get("uploads", []) if lab.lab_metadata else []
+    return jsonify({"status": "ok", "uploads": uploads}), 200
+
+
+@blueprint.route("/labs/<lab_id>/uploads/<filename>", methods=["DELETE"])
+@login_required
+@check_user_category(["admin", "teacher", "labcreator"])
+def delete_lab_upload(lab_id, filename):
+    lab = Labs.query.get(lab_id)
+    if not lab:
+        return jsonify({"status": "fail", "result": "Lab not found"}), 404
+    if current_user.category == "labcreator" and lab.updated_by != current_user.id:
+        return jsonify({"status": "fail", "result": "Unauthorized"}), 403
+
+    lab_md = lab.lab_metadata
+    if not lab_md:
+        return jsonify({"status": "fail", "result": "No uploads found"}), 404
+
+    md = lab_md.md
+    uploads = md.get("uploads", [])
+    original_count = len(uploads)
+    uploads = [u for u in uploads if u.get("filename") != filename]
+    if len(uploads) == original_count:
+        return jsonify({"status": "fail", "result": "File not found in uploads list"}), 404
+
+    md["uploads"] = uploads
+    lab_md.md = md
+
+    upload_dir = current_app.config["UPLOAD_DIR"]
+    fpath = os.path.join(upload_dir, filename)
+    try:
+        os.remove(fpath)
+    except FileNotFoundError:
+        current_app.logger.warning(f"Upload file not found on disk during delete: {filename}")
+    except Exception as exc:
+        current_app.logger.error(f"Failed to delete upload file {filename}: {exc}")
+
+    try:
+        db.session.commit()
+    except Exception as exc:
+        current_app.logger.error(f"Failed to update uploads metadata after delete: {exc}")
+        return jsonify({"status": "fail", "result": "Failed to update metadata"}), 500
+
+    return jsonify({"status": "ok"}), 200

--- a/apps/templates/pages/index.html
+++ b/apps/templates/pages/index.html
@@ -727,8 +727,7 @@
   <script>
     document.addEventListener("DOMContentLoaded", function () {
         {% if show_feedback_modal %}
-        const modalFeedback = new bootstrap.Modal(document.getElementById('modal-feedback'));
-        modalFeedback.show();
+        $('#modal-feedback').modal('show');
         {% endif %}
 
         const stars = document.querySelectorAll("#stars i");

--- a/apps/templates/pages/labs_edit.html
+++ b/apps/templates/pages/labs_edit.html
@@ -81,6 +81,8 @@
     <!-- Main content -->
     <section class="content">
       <form method="POST" enctype="multipart/form-data" action="{{url_for('home_blueprint.edit_lab', lab_id=lab.id|default('new', true))}}">
+      <input type="hidden" name="pending_upload_filenames" id="pending-upload-filenames" value="[]">
+      <input type="hidden" name="pending_upload_orignames" id="pending-upload-orignames" value="[]">
       <div class="container-fluid">
         <div class="row">
           <!-- left column -->
@@ -232,7 +234,7 @@
         <!-- /.row -->
         <div class="row">
           <div class="col-md-12">
-            <div class="card card-dark">
+            <div id="lab-guide" class="card card-dark">
               <div class="card-header">
                 <h3 class="card-title">
                   Lab Guide
@@ -264,10 +266,24 @@
                         <div class="mb-3">
                           <textarea name="lab_guide" id="lab-edit-guide" class="textarea" placeholder="Place some text here" rows="16">{{lab.lab_guide_md_str|default('', true)}}</textarea>
                         </div>
+                        <div id="lab-uploads-panel" class="mt-3">
+                          <h6><i class="fas fa-paperclip"></i> Attached files</h6>
+                          <ul id="lab-uploads-list" class="list-group list-group-flush">
+                            {% for upload in lab_uploads|default([], true) %}
+                            <li class="list-group-item d-flex justify-content-between align-items-center" data-filename="{{ upload.filename }}" data-url="{{ upload.url }}">
+                              <a href="{{ upload.url }}" target="_blank">{{ upload.original_name }}</a>
+                              <button type="button" class="btn btn-sm btn-outline-danger remove-upload-btn" data-filename="{{ upload.filename }}" data-original-name="{{ upload.original_name }}">
+                                <i class="fas fa-trash"></i> Remove
+                              </button>
+                            </li>
+                            {% endfor %}
+                          </ul>
+                        </div>
                       </div>
                       <div class="tab-pane fade" id="custom-tabs-labguide-preview" role="tabpanel" aria-labelledby="custom-tabs-labguide-preview-tab">
                       </div>
                     </div>
+                    <a href="#lab-guide">back to the top</a>
                   </div>
 		</div>
               </div>
@@ -519,6 +535,61 @@
       var questionCounter = 0;
       editorLabGuide.setSize("100%", 600);
 
+      var labId = "{{ lab.id|default('', true) }}";
+      var pendingFilenames = [];
+      var pendingOrignames = [];
+
+      function renderUploads(uploads) {
+        var list = $('#lab-uploads-list');
+        list.empty();
+        uploads.forEach(function(upload) {
+          list.append(
+            '<li class="list-group-item d-flex justify-content-between align-items-center"' +
+            ' data-filename="' + upload.filename + '" data-url="' + upload.url + '">' +
+            '<a href="' + upload.url + '" target="_blank">' + upload.original_name + '</a>' +
+            '<button type="button" class="btn btn-sm btn-outline-danger remove-upload-btn"' +
+            ' data-filename="' + upload.filename + '" data-original-name="' + upload.original_name + '">' +
+            '<i class="fas fa-trash"></i> Remove</button></li>'
+          );
+        });
+      }
+
+      $(document).on('click', '.remove-upload-btn', function() {
+        var btn = $(this);
+        var filename = btn.data('filename');
+        var origName = btn.data('original-name');
+        var content = editorLabGuide.getValue();
+        if (content.indexOf(filename) !== -1 || content.indexOf(origName) !== -1) {
+          alert('Warning: this file is still referenced in the Lab Guide. Remove the reference before deleting.');
+          return;
+        }
+        if (labId) {
+          $.ajax({
+            url: '/labs/' + labId + '/uploads/' + encodeURIComponent(filename),
+            type: 'DELETE',
+            success: function(response) {
+              if (response.status === 'ok') {
+                btn.closest('li').remove();
+              } else {
+                alert('Failed to remove file: ' + response.result);
+              }
+            },
+            error: function(jqXHR) {
+              var msg = jqXHR.responseJSON && jqXHR.responseJSON.result ? jqXHR.responseJSON.result : 'Unknown error';
+              alert('Failed to remove file: ' + msg);
+            }
+          });
+        } else {
+          // New lab mode: remove from pending arrays and DOM
+          var idx = pendingFilenames.indexOf(filename);
+          if (idx !== -1) {
+            pendingFilenames.splice(idx, 1);
+            pendingOrignames.splice(idx, 1);
+          }
+          btn.closest('li').remove();
+        }
+      });
+
       // Drag, Drop, Paste and Click handlers for Lab Guide file upload
       $('#upload-file-labguide-btn').click(function() {
         $('#labguide-file-input').click();
@@ -569,6 +640,9 @@
 
         var data = new FormData();
         data.append("file", file);
+        if (labId) {
+          data.append("lab_id", labId);
+        }
 
         $.ajax({
           url: "/labs/upload-file",
@@ -589,6 +663,21 @@
                 replacement = "[" + response.filename + "](" + response.url + ")";
               }
               replacePlaceholder(placeholder, replacement);
+
+              if (labId) {
+                renderUploads(response.uploads);
+              } else {
+                pendingFilenames.push(response.saved_filename);
+                pendingOrignames.push(response.filename);
+                $('#lab-uploads-list').append(
+                  '<li class="list-group-item d-flex justify-content-between align-items-center"' +
+                  ' data-filename="' + response.saved_filename + '" data-url="' + response.url + '">' +
+                  '<a href="' + response.url + '" target="_blank">' + response.filename + '</a>' +
+                  '<button type="button" class="btn btn-sm btn-outline-danger remove-upload-btn"' +
+                  ' data-filename="' + response.saved_filename + '" data-original-name="' + response.filename + '">' +
+                  '<i class="fas fa-trash"></i> Remove</button></li>'
+                );
+              }
             } else {
               replacePlaceholder(placeholder, "<!-- Upload failed: " + response.result + " -->");
               alert("Upload failed: " + response.result);
@@ -684,6 +773,8 @@
           alert('Please select at least one lab category.');
           return false;
         }
+        $('#pending-upload-filenames').val(JSON.stringify(pendingFilenames));
+        $('#pending-upload-orignames').val(JSON.stringify(pendingOrignames));
         parseLabGuide(e, true);
       });
       $('#custom-tabs-labguide-preview-tab').on('click', function (e) {

--- a/apps/templates/pages/labs_edit.html
+++ b/apps/templates/pages/labs_edit.html
@@ -259,6 +259,8 @@
                         <button class="btn btn-outline-secondary" type="button" id="add-textarea-input-labguide">Add text area question</button>
                         <button class="btn btn-outline-secondary" type="button" id="add-select-input-labguide">Add select question</button>
                         <button class="btn btn-outline-secondary" type="button" id="add-check-input-labguide">Add checkbox question</button>
+                        <button class="btn btn-outline-secondary" type="button" id="upload-file-labguide-btn"><i class="fas fa-paperclip"></i> Paste, drop, or click to add files</button>
+                        <input type="file" id="labguide-file-input" style="display: none;">
                         <div class="mb-3">
                           <textarea name="lab_guide" id="lab-edit-guide" class="textarea" placeholder="Place some text here" rows="16">{{lab.lab_guide_md_str|default('', true)}}</textarea>
                         </div>
@@ -466,13 +468,43 @@
     $(function () {
       $('#lab-editor').summernote({
         height: 500,
-        maximumImageFileSize: 358400,
+        maximumImageFileSize: 10 * 1024 * 1024,
         callbacks: {
+          onImageUpload: function(files) {
+            for (var i = 0; i < files.length; i++) {
+              uploadSummernoteImage(files[i]);
+            }
+          },
           onImageUploadError: function(msg) {
-            alert('Image upload failed: ' + msg + ' (Maximum size: 350KB)');
+            alert('Image upload failed: ' + msg);
           }
         }
       });
+
+      function uploadSummernoteImage(file) {
+        var data = new FormData();
+        data.append("file", file);
+        $.ajax({
+          url: "/labs/upload-file",
+          cache: false,
+          contentType: false,
+          processData: false,
+          data: data,
+          type: "POST",
+          success: function(response) {
+            if (response.status === "ok") {
+              $('#lab-editor').summernote("insertImage", response.url, response.filename);
+            } else {
+              alert("Failed to upload image: " + response.result);
+            }
+          },
+          error: function(jqXHR, textStatus, errorThrown) {
+            var errorMsg = jqXHR.responseJSON && jqXHR.responseJSON.result ? jqXHR.responseJSON.result : errorThrown;
+            alert("Failed to upload image: " + errorMsg);
+          }
+        });
+      }
+
       bsCustomFileInput.init();
       //Bootstrap Duallistbox
       $('.duallistbox').bootstrapDualListbox({
@@ -486,9 +518,105 @@
       });
       var questionCounter = 0;
       editorLabGuide.setSize("100%", 600);
+
+      // Drag, Drop, Paste and Click handlers for Lab Guide file upload
+      $('#upload-file-labguide-btn').click(function() {
+        $('#labguide-file-input').click();
+      });
+
+      $('#labguide-file-input').change(function() {
+        if (this.files.length > 0) {
+          uploadLabGuideFile(this.files[0]);
+          this.value = ''; // Reset input so same file can be uploaded again if needed
+        }
+      });
+
+      var codeMirrorWrapper = editorLabGuide.getWrapperElement();
+
+      codeMirrorWrapper.addEventListener('paste', function(e) {
+        var items = (e.clipboardData || e.originalEvent.clipboardData).items;
+        for (var i = 0; i < items.length; i++) {
+          if (items[i].kind === 'file') {
+            var file = items[i].getAsFile();
+            uploadLabGuideFile(file);
+            e.preventDefault();
+            break;
+          }
+        }
+      });
+
+      codeMirrorWrapper.addEventListener('dragover', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+      });
+
+      codeMirrorWrapper.addEventListener('drop', function(e) {
+        var files = (e.dataTransfer || e.originalEvent.dataTransfer).files;
+        if (files.length > 0) {
+          uploadLabGuideFile(files[0]);
+          e.preventDefault();
+          e.stopPropagation();
+        }
+      });
+
+      function uploadLabGuideFile(file) {
+        var uploadId = Math.random().toString(36).substring(2, 9);
+        var placeholder = "<!-- Uploading file (" + uploadId + ")... -->";
+
+        var doc = editorLabGuide.getDoc();
+        var cursor = doc.getCursor();
+        doc.replaceRange(placeholder, cursor);
+
+        var data = new FormData();
+        data.append("file", file);
+
+        $.ajax({
+          url: "/labs/upload-file",
+          type: "POST",
+          data: data,
+          contentType: false,
+          processData: false,
+          success: function(response) {
+            if (response.status === "ok") {
+              var ext = response.url.split('.').pop().toLowerCase();
+              var isImage = ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp'].indexOf(ext) !== -1;
+
+              var replacement = "";
+              var cleanName = response.filename.replace(/\.[^/.]+$/, "");
+              if (isImage) {
+                replacement = "![" + cleanName + "](" + response.url + ")";
+              } else {
+                replacement = "[" + response.filename + "](" + response.url + ")";
+              }
+              replacePlaceholder(placeholder, replacement);
+            } else {
+              replacePlaceholder(placeholder, "<!-- Upload failed: " + response.result + " -->");
+              alert("Upload failed: " + response.result);
+            }
+          },
+          error: function(jqXHR, textStatus, errorThrown) {
+            var errorMsg = jqXHR.responseJSON && jqXHR.responseJSON.result ? jqXHR.responseJSON.result : errorThrown;
+            replacePlaceholder(placeholder, "<!-- Upload failed: " + errorMsg + " -->");
+            alert("Upload failed: " + errorMsg);
+          }
+        });
+      }
+
+      function replacePlaceholder(placeholder, replacement) {
+        var doc = editorLabGuide.getDoc();
+        var totalLines = doc.lineCount();
+        for (var i = 0; i < totalLines; i++) {
+          var lineText = doc.getLine(i);
+          var idx = lineText.indexOf(placeholder);
+          if (idx !== -1) {
+            doc.replaceRange(replacement, {line: i, ch: idx}, {line: i, ch: idx + placeholder.length});
+            return;
+          }
+        }
+      }
       //Initialize Select2 Elements
       $('.select2').select2();
-      
+
       $('select[name="lab_categories"]').select2({
         placeholder: 'Select one or more categories',
         allowClear: false,
@@ -497,10 +625,10 @@
           if (!option.id) {
             return option.text;
           }
-          
+
           var $option = $(option.element);
           var colorClass = $option.data('color') || 'secondary';
-          
+
           return $(
             '<span class="badge badge-' + colorClass + ' mr-2" style="font-size: 0.9em;">' + 
             option.text + 
@@ -511,10 +639,10 @@
           if (!option.id) {
             return option.text;
           }
-          
+
           var $option = $(option.element);
           var colorClass = $option.data('color') || 'secondary';
-          
+
           return $(
             '<span class="badge badge-' + colorClass + '" style="font-size: 0.8em; margin: 1px;">' + 
             option.text + 
@@ -561,7 +689,6 @@
       $('#custom-tabs-labguide-preview-tab').on('click', function (e) {
         parseLabGuide(e, false);
       });
-      
       $('#add-text-input-labguide').click(function () {
         parseLabGuide(null, false);
         questionCounter++;
@@ -625,7 +752,7 @@
         });
 
         return templates; 
-        
+
       } catch (error) {
         console.error(error);
         templateSelect.innerHTML = '<option value="">Failed to load</option>';
@@ -657,7 +784,6 @@
           const response = await fetch(`/api/templates/${templateName}`);
           if (response.ok) {
             const templateContent = await response.json();
-            
             cmEditor.setValue(templateContent.result);
             cmEditor.setSize("100%",600)
           } else {


### PR DESCRIPTION
Fix #233 

## Description of the changes

We have successfully implemented the image and file upload feature for the lab editor. Below is a summary of the changes and how to manually verify them.

### 1. Configuration
- Added lab upload settings in [config.py](apps/config.py):
  - `LAB_UPLOAD_MAX_SIZE`: Configured default size to `10MB` (`10 * 1024 * 1024`).
  - `LAB_UPLOAD_ALLOWED_EXTENSIONS`: Allowed file extensions set to `{'png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'pdf', 'txt', 'zip', 'tar.gz'}`.

### 2. Backend Routing
- Implemented routes in [routes.py](apps/home/routes.py):
  - `POST /labs/upload-file`: Accepts a multipart form file upload, validates its extension and file size against the configurations, renames the file using a unique UUID, saves it to `UPLOAD_DIR`, and returns a JSON payload containing the file URL and original filename.
  - `GET /uploads/<path:filename>`: Serves the uploaded files from `UPLOAD_DIR` using Flask's `send_from_directory`. Restricts access using the `@login_required` decorator to keep files secure for authenticated users.
  - Added GET /labs/<lab_id>/uploads — returns the upload list from LabMetadata for a given lab, with access control.
  - Added DELETE /labs/<lab_id>/uploads/<filename> — removes the file from LabMetadata.md["uploads"] and deletes it from disk (soft failure if file is already gone).





**Frontend (`labs_edit.html`):**



### 3. Frontend UI & Editors
- Modified [labs_edit.html](apps/templates/pages/labs_edit.html):
  - **Button**: Added a new `"Paste, drop, or click to add files"` button next to standard question inputs in the Lab Guide section.
  - **Upload Handlers**: 
    - Wired CodeMirror to handle **Drag & Drop** and **Paste (Ctrl+V/Cmd+V)** events directly on its wrapper.
    - Wired the hidden file input to trigger when the button is clicked.
    - Initiates an asynchronous upload using AJAX.
    - Automatically inserts a unique placeholder comment like `<!-- Uploading file (abc1234)... -->` at the cursor position.
    - Upon a successful upload, parses the file type (image vs. normal document) and replaces the unique placeholder with the appropriate Markdown syntax:
      - Images: exclamation mark followed by `[original_filename](url)`
      - Other files: `[original_filename](url)`
    - On failure, cleans up by changing the placeholder to `<!-- Upload failed: error -->` and displaying an alert.
  - Added hidden fields `pending_upload_filenames` and `pending_upload_orignames` for new-lab mode.
  - Added the "Attached files" panel (`#lab-uploads-panel`) below the CodeMirror editor, pre-populated server-side via `lab_uploads`.
  - Added `labId`, `pendingFilenames`, `pendingOrignames` JS variables.
  - Added `renderUploads()` to rebuild the list from a server response.
  - Updated `uploadLabGuideFile()` to send `lab_id` in the form data, and on success either call `renderUploads()` (edit mode) or push to pending arrays and append an `<li>` (new-lab mode).
  - Added `.remove-upload-btn` click handler that checks for references in the editor content, then calls the DELETE endpoint (edit mode) or removes from pending arrays (new-lab mode).
  - Updated form submit to sync the hidden pending fields before submission.


## Local tests

I've manually verified the changes by following the steps below:

### 1. File Dialog / Click Upload
1. Log in to the application and navigate to the Labs Edit/Create page.
2. Scroll to the **Lab Guide** section and click the button `"Paste, drop, or click to add files"`.
3. Select any small image file (e.g. `test.png`).
4. Verify the editor inserts `<!-- Uploading file (xxxxxxx)... -->` instantly, and replaces it with the image syntax for `/uploads/<uuid>.png` once the upload is completed successfully.

### 2. Drag & Drop Upload
1. Drag a PDF file (e.g., `manual.pdf`) and drop it onto the Lab Guide CodeMirror text area.
2. Verify the placeholder is inserted and replaced by `[manual](/uploads/<uuid>.pdf)`.

### 3. Paste Upload
1. Copy an image to your clipboard (e.g., take a screenshot or copy an image file).
2. Click inside the CodeMirror text editor.
3. Paste the image using `Ctrl+V` (or `Cmd+V`).
4. Verify that the image is automatically uploaded, showing the placeholder, and then substituting it with the image syntax for `/uploads/<uuid>.<ext>`.

### 4. Access Control
1. Copy the URL of one of your uploaded files (e.g., `https://localhost:5000/uploads/<uuid>.png`).
2. Log out of the application (or open an Incognito window).
3. Try to access the file URL directly.
4. Verify that the server redirects you to the login page.
5. Log back in and verify that the file loads successfully.
