### PR TITLE
Fix: using request full_path to avoid dropping the query string

### DIFF
--- a/apps/authentication/routes.py
+++ b/apps/authentication/routes.py
@@ -323,7 +323,7 @@ def reload_profile():
 @login_manager.unauthorized_handler
 def unauthorized_handler():
     if 'login' not in request.path:
-        session['next_url'] = request.path
+        session['next_url'] = request.full_path.rstrip('?')
     return redirect(url_for('authentication_blueprint.login'))
 
 


### PR DESCRIPTION
Fix #242 

## Description of the change

- Fixed: unauthorized_handler in `apps/authentication/routes.py` was storing `request.path` (no query string) into `session['next_url']`. Changed to `request.full_path.rstrip('?')`, which preserves query args and strips the trailing `?` Flask appends when there's no query string.
