### PR TITLE
Require e-mail confirmation after login when missing

### DIFF
--- a/apps/api/routes.py
+++ b/apps/api/routes.py
@@ -317,7 +317,7 @@ def delete_lab_category(category_id):
     if current_user.category != "admin":
         return {"status": "fail", "result": "Unauthorized access"}, 401
 
-    category = LabCategories.query.get(category_id)
+    category = db.session.get(LabCategories, category_id)
     if not category or category.is_deleted:
         return {"status": "fail", "result": "Lab Category not found"}, 404
 

--- a/apps/authentication/forms.py
+++ b/apps/authentication/forms.py
@@ -59,6 +59,12 @@ class GroupForm(FlaskForm):
     accesstoken = StringField('Accesstoken', id='accesstoken', validators=[DataRequired()])
 
 
+class RequireEmailForm(FlaskForm):
+    email = StringField('Email',
+                      id='email_require',
+                      validators=[DataRequired(), Email()])
+
+
 class ConfirmAccountForm(FlaskForm):
     confirmation_token = StringField('Confirmation Token',
                                     id='confirmation_token',

--- a/apps/authentication/routes.py
+++ b/apps/authentication/routes.py
@@ -139,8 +139,8 @@ def register():
                 msg += f" Errors: {create_account_form.errors}"
             return render_template('pages/register.html', form=create_account_form, msg=msg)
 
-        username = create_account_form.username.data
-        email = create_account_form.email.data
+        username = create_account_form.username.data.lower()
+        email = create_account_form.email.data.lower()
         password = create_account_form.password.data
 
         # Check username exists

--- a/apps/authentication/routes.py
+++ b/apps/authentication/routes.py
@@ -288,7 +288,7 @@ def require_email():
                 msg += f" Errors: {form.errors}"
             return render_template('pages/email_required.html', form=form, msg=msg)
 
-        email = form.email.data
+        email = form.email.data.lower()
 
         # Check email exists for another user
         user = Users.query.filter(Users.email == email, Users.id != current_user.id).first()
@@ -457,7 +457,7 @@ def reset_password():
     except Exception:
         error = traceback.format_exc().replace("\n", ", ")
         app.logger.error(f"Fail to send e-mail to {user.email} user={user.username}: {error}")
-        msg="Failed to send confirmation e-mail. Please try again later"
+        msg = "Failed to send confirmation e-mail. Please try again later"
 
     return render_template('pages/reset_password.html', form=form, msg=msg)
 

--- a/apps/authentication/routes.py
+++ b/apps/authentication/routes.py
@@ -453,7 +453,7 @@ def reset_password():
         mail.send(msg)
     except:
         error = traceback.format_exc().replace("\n", ", ")
-        app.logger.info(f"Fail to send e-mail to {email}: {error}")
+        app.logger.info(f"Fail to send e-mail to {user.email} user={user.username}: {error}")
         msg="Failed to send confirmation e-mail. Please try again later"
 
     return render_template('pages/reset_password.html', form=form, msg=msg)

--- a/apps/authentication/routes.py
+++ b/apps/authentication/routes.py
@@ -450,7 +450,7 @@ def reset_password():
         html=render_template('mail/reset_password.html', confirmation_url=confirmation_url),
     )
     try:
-        mail.send(msg)
+        mail.send(mail_msg)
     except:
         error = traceback.format_exc().replace("\n", ", ")
         app.logger.info(f"Fail to send e-mail to {user.email} user={user.username}: {error}")

--- a/apps/authentication/routes.py
+++ b/apps/authentication/routes.py
@@ -216,7 +216,7 @@ def confirm_page():
         created_at = session.get('datetime')
      
         now = utcnow()
-        if not user or not created_at or now - created_at > timedelta(minutes=15):
+        if not user or not created_at or now - created_at > timedelta(minutes=app.config["EMAIL_TOKEN_EXPIRY_MINUTES"]):
             return render_template('pages/confirm.html', msg='Token expired, please <a href=/register>click here</a> to register again', success=False, form=form)
 
         if request.form['confirmation_token'] != confirmation_token:
@@ -358,7 +358,7 @@ def confirm_email():
         created_at = session.get('email_datetime')
 
         now = utcnow()
-        if not created_at or now - created_at > timedelta(minutes=15) or not pending_email:
+        if not created_at or now - created_at > timedelta(minutes=app.config["EMAIL_TOKEN_EXPIRY_MINUTES"]) or not pending_email:
             return render_template('pages/confirm_email.html', msg='Token expired, please <a href=/email/required>click here</a> to request a new code', success=False, form=form)
 
         if request.form['confirmation_token'] != confirmation_token:

--- a/apps/authentication/routes.py
+++ b/apps/authentication/routes.py
@@ -332,7 +332,7 @@ def require_email():
             mail.send(msg)
         except Exception:
             error = traceback.format_exc().replace("\n", ", ")
-            app.logger.info(f"Fail to send e-mail to {email}: {error}")
+            app.logger.error(f"Fail to send e-mail to {email}: {error}")
             session.pop('email_confirmation_token', None)
             session.pop('pending_email', None)
             session.pop('email_datetime', None)
@@ -414,7 +414,7 @@ def resend_email_code():
         mail.send(msg)
     except Exception:
         error = traceback.format_exc().replace("\n", ", ")
-        app.logger.info(f"Fail to send e-mail to {email}: {error}")
+        app.logger.error(f"Fail to send e-mail to {email}: {error}")
         session['error_msg'] = "Failed to send confirmation e-mail. Please try again later"
 
     return redirect(url_for('authentication_blueprint.confirm_email'))
@@ -456,7 +456,7 @@ def reset_password():
         mail.send(mail_msg)
     except Exception:
         error = traceback.format_exc().replace("\n", ", ")
-        app.logger.info(f"Fail to send e-mail to {user.email} user={user.username}: {error}")
+        app.logger.error(f"Fail to send e-mail to {user.email} user={user.username}: {error}")
         msg="Failed to send confirmation e-mail. Please try again later"
 
     return render_template('pages/reset_password.html', form=form, msg=msg)

--- a/apps/authentication/routes.py
+++ b/apps/authentication/routes.py
@@ -1,7 +1,10 @@
 # -*- encoding: utf-8 -*-
 """
-Copyright (c) 2019 - present AppSeed.us
+Copyright (c) 2019 - 2024 AppSeed.us
+Copyright (c) 2024 - present HackInSDN
 """
+
+import traceback
 
 from flask import render_template, redirect, request, url_for, session
 from flask import current_app as app
@@ -183,7 +186,17 @@ def register():
             ),
             html=render_template('mail/confirmation_token.html', confirmation_token=confirmation_token),
         )
-        mail.send(msg)
+        try:
+            mail.send(msg)
+        except:
+            error = traceback.format_exc().replace("\n", ", ")
+            app.logger.error(f"Fail to send e-mail to email={email} user={username}: {error}")
+            return render_template(
+                "pages/confirm.html",
+                form=create_account_form,
+                msg="Failed to send confirmation e-mail. Please try again later",
+                success=False,
+            )
 
         return redirect(url_for('authentication_blueprint.confirm_page'))
 
@@ -203,7 +216,7 @@ def confirm_page():
         created_at = session.get('datetime')
      
         now = utcnow()
-        if now - created_at > timedelta(minutes=5):
+        if not user or not created_at or now - created_at > timedelta(minutes=15):
             return render_template('pages/confirm.html', msg='Token expired, please <a href=/register>click here</a> to register again', success=False, form=form)
 
         if request.form['confirmation_token'] != confirmation_token:
@@ -217,6 +230,12 @@ def confirm_page():
         db.session.commit()
 
         return redirect(url_for('authentication_blueprint.login'))
+
+    error_msg = session.pop("error_msg", None)
+    if error_msg:
+        return render_template(
+            'pages/confirm.html', form=form, success=False, msg=error_msg
+        )
     
     return render_template('pages/confirm.html', form=form)
 
@@ -239,7 +258,12 @@ def resend_code():
         ),
         html=render_template('mail/confirmation_token.html', confirmation_token=confirmation_token),
     )
-    mail.send(msg)
+    try:
+        mail.send(msg)
+    except:
+        error = traceback.format_exc().replace("\n", ", ")
+        app.logger.error(f"Fail to send e-mail to email={email} user={username}: {error}")
+        session['error_msg'] = "Failed to send confirmation e-mail. Please try again later"
 
     return redirect(url_for('authentication_blueprint.confirm_page'))
 
@@ -301,7 +325,20 @@ def require_email():
             ),
             html=render_template('mail/confirmation_token.html', confirmation_token=confirmation_token),
         )
-        mail.send(msg)
+        try:
+            mail.send(msg)
+        except:
+            error = traceback.format_exc().replace("\n", ", ")
+            app.logger.info(f"Fail to send e-mail to {email}: {error}")
+            session.pop('email_confirmation_token', None)
+            session.pop('pending_email', None)
+            session.pop('email_datetime', None)
+            return render_template(
+                'pages/email_required.html',
+                msg='Failed to send confirmation e-mail. Please try again later',
+                success=False,
+                form=form,
+            )
 
         return redirect(url_for('authentication_blueprint.confirm_email'))
 
@@ -321,7 +358,7 @@ def confirm_email():
         created_at = session.get('email_datetime')
 
         now = utcnow()
-        if now - created_at > timedelta(minutes=5):
+        if not created_at or now - created_at > timedelta(minutes=15) or not pending_email:
             return render_template('pages/confirm_email.html', msg='Token expired, please <a href=/email/required>click here</a> to request a new code', success=False, form=form)
 
         if request.form['confirmation_token'] != confirmation_token:
@@ -339,6 +376,12 @@ def confirm_email():
             next_url = session.pop("next_url")
             return redirect(next_url)
         return redirect(url_for('authentication_blueprint.route_default'))
+
+    error_msg = session.pop("error_msg", None)
+    if error_msg:
+        return render_template(
+            'pages/confirm_email.html', form=form, success=False, msg=error_msg
+        )
 
     return render_template('pages/confirm_email.html', form=form)
 
@@ -364,7 +407,12 @@ def resend_email_code():
         ),
         html=render_template('mail/confirmation_token.html', confirmation_token=confirmation_token),
     )
-    mail.send(msg)
+    try:
+        mail.send(msg)
+    except:
+        error = traceback.format_exc().replace("\n", ", ")
+        app.logger.info(f"Fail to send e-mail to {email}: {error}")
+        session['error_msg'] = "Failed to send confirmation e-mail. Please try again later"
 
     return redirect(url_for('authentication_blueprint.confirm_email'))
 
@@ -401,7 +449,12 @@ def reset_password():
         ),
         html=render_template('mail/reset_password.html', confirmation_url=confirmation_url),
     )
-    mail.send(mail_msg)
+    try:
+        mail.send(msg)
+    except:
+        error = traceback.format_exc().replace("\n", ", ")
+        app.logger.info(f"Fail to send e-mail to {email}: {error}")
+        msg="Failed to send confirmation e-mail. Please try again later"
 
     return render_template('pages/reset_password.html', form=form, msg=msg)
 

--- a/apps/authentication/routes.py
+++ b/apps/authentication/routes.py
@@ -241,8 +241,11 @@ def confirm_page():
 
 @blueprint.route('/resend-code', methods=['GET'])
 def resend_code():
-    email = session.get('user').get('email')
+    email = session.get('user', {}).get('email')
     confirmation_token = session.get('confirmation_token')
+    if not email or not confirmation_token:
+        session['error_msg'] = "Failed to send confirmation e-mail. No user found"
+        return redirect(url_for('authentication_blueprint.confirm_page'))
 
     msg = Message(
         subject="HackInSDN - Verify your identity",
@@ -262,7 +265,7 @@ def resend_code():
         mail.send(msg)
     except Exception:
         error = traceback.format_exc().replace("\n", ", ")
-        app.logger.error(f"Fail to send e-mail to email={email} user={username}: {error}")
+        app.logger.error(f"Fail to send e-mail to email={email}: {error}")
         session['error_msg'] = "Failed to send confirmation e-mail. Please try again later"
 
     return redirect(url_for('authentication_blueprint.confirm_page'))

--- a/apps/authentication/routes.py
+++ b/apps/authentication/routes.py
@@ -16,7 +16,7 @@ from apps import db, login_manager, oauth, mail
 from apps.config import app_config
 from apps.audit_mixin import get_remote_addr, utcnow
 from apps.authentication import blueprint
-from apps.authentication.forms import LoginForm, CreateAccountForm, ConfirmAccountForm, ResetPasswordForm, ResetPasswordConfirmForm
+from apps.authentication.forms import LoginForm, CreateAccountForm, ConfirmAccountForm, ResetPasswordForm, ResetPasswordConfirmForm, RequireEmailForm
 from apps.authentication.models import Users, LoginLogging
 from apps.utils import check_pre_approved
 from flask_mail import Message
@@ -57,6 +57,8 @@ def login():
             login_log = LoginLogging(ipaddr=get_remote_addr(), login=identifier, auth_provider="local", success=True)
             db.session.add(login_log)
             db.session.commit()
+            if not user.email:
+                return redirect(url_for('authentication_blueprint.require_email'))
             if "next_url" in session:
                 next_url = session.pop("next_url")
                 return redirect(next_url)
@@ -113,6 +115,9 @@ def callback():
     db.session.commit()
 
     login_user(user)
+
+    if not user.email:
+        return redirect(url_for('authentication_blueprint.require_email'))
 
     if "next_url" in session:
         next_url = session.pop("next_url")
@@ -237,6 +242,131 @@ def resend_code():
     mail.send(msg)
 
     return redirect(url_for('authentication_blueprint.confirm_page'))
+
+@blueprint.route('/email/required', methods=['GET', 'POST'])
+@login_required
+def require_email():
+    if current_user.email:
+        if "next_url" in session:
+            next_url = session.pop("next_url")
+            return redirect(next_url)
+        return redirect(url_for('authentication_blueprint.route_default'))
+
+    form = RequireEmailForm(request.form)
+
+    if 'submit_email' in request.form:
+        if not form.validate_on_submit():
+            msg = "Failed to validate form."
+            if form.errors:
+                msg += f" Errors: {form.errors}"
+            return render_template('pages/email_required.html', form=form, msg=msg)
+
+        email = form.email.data
+
+        # Check email exists for another user
+        user = Users.query.filter(Users.email == email, Users.id != current_user.id).first()
+        if user:
+            return render_template('pages/email_required.html',
+                                   msg='Email already registered',
+                                   success=False,
+                                   form=form)
+
+        # else: send confirmation e-mail if configured, otherwise set the email directly
+        if not app.config['MAIL_SERVER']:
+            current_user.email = email
+            check_pre_approved(current_user)
+            db.session.commit()
+            if "next_url" in session:
+                next_url = session.pop("next_url")
+                return redirect(next_url)
+            return redirect(url_for('authentication_blueprint.route_default'))
+
+        confirmation_token = str(uuid.uuid4().int)[:6]
+        session['email_confirmation_token'] = confirmation_token
+        session['pending_email'] = email
+        session['email_datetime'] = utcnow()
+
+        # Send email
+        msg = Message(
+            subject="HackInSDN - Verify your identity",
+            sender=app.config['MAIL_USERNAME'],
+            recipients=[email],
+            body=(
+                "Help us protect your account\n\n"
+                "Before we confirm your e-mail, we need to verify your identity. Enter the following code on the confirmation page.\n\n"
+                f"{confirmation_token}\n\n"
+                "If you have not recently tried to update your e-mail on HackInSDN, you can ignore this e-mail.\n\n"
+                "--\n\n"
+                f"You're receiving this email because of your account on Dashboard HackInSDN."
+            ),
+            html=render_template('mail/confirmation_token.html', confirmation_token=confirmation_token),
+        )
+        mail.send(msg)
+
+        return redirect(url_for('authentication_blueprint.confirm_email'))
+
+    return render_template('pages/email_required.html', form=form)
+
+@blueprint.route('/email/required/confirm', methods=['GET', 'POST'])
+@login_required
+def confirm_email():
+    form = ConfirmAccountForm(request.form)
+
+    confirmation_token = session.get('email_confirmation_token')
+    if not confirmation_token:
+        return redirect(url_for('authentication_blueprint.require_email'))
+
+    if 'confirm' in request.form:
+        pending_email = session.get('pending_email')
+        created_at = session.get('email_datetime')
+
+        now = utcnow()
+        if now - created_at > timedelta(minutes=5):
+            return render_template('pages/confirm_email.html', msg='Token expired, please <a href=/email/required>click here</a> to request a new code', success=False, form=form)
+
+        if request.form['confirmation_token'] != confirmation_token:
+            return render_template('pages/confirm_email.html', msg='Invalid token', success=False, form=form)
+
+        session.pop('email_confirmation_token')
+        session.pop('pending_email')
+        session.pop('email_datetime')
+
+        current_user.email = pending_email
+        check_pre_approved(current_user)
+        db.session.commit()
+
+        if "next_url" in session:
+            next_url = session.pop("next_url")
+            return redirect(next_url)
+        return redirect(url_for('authentication_blueprint.route_default'))
+
+    return render_template('pages/confirm_email.html', form=form)
+
+@blueprint.route('/email/required/resend-code', methods=['GET'])
+@login_required
+def resend_email_code():
+    email = session.get('pending_email')
+    confirmation_token = session.get('email_confirmation_token')
+    if not email or not confirmation_token:
+        return redirect(url_for('authentication_blueprint.require_email'))
+
+    msg = Message(
+        subject="HackInSDN - Verify your identity",
+        sender=app.config['MAIL_USERNAME'],
+        recipients=[email],
+        body=(
+            "Help us protect your account\n\n"
+            "Before we confirm your e-mail, we need to verify your identity. Enter the following code on the confirmation page.\n\n"
+            f"{confirmation_token}\n\n"
+            "If you have not recently tried to update your e-mail on HackInSDN, you can ignore this e-mail.\n\n"
+            "--\n\n"
+            f"You're receiving this email because of your account on Dashboard HackInSDN."
+        ),
+        html=render_template('mail/confirmation_token.html', confirmation_token=confirmation_token),
+    )
+    mail.send(msg)
+
+    return redirect(url_for('authentication_blueprint.confirm_email'))
 
 @blueprint.route('/reset-password', methods=['GET', 'POST'])
 def reset_password():

--- a/apps/authentication/routes.py
+++ b/apps/authentication/routes.py
@@ -188,7 +188,7 @@ def register():
         )
         try:
             mail.send(msg)
-        except:
+        except Exception:
             error = traceback.format_exc().replace("\n", ", ")
             app.logger.error(f"Fail to send e-mail to email={email} user={username}: {error}")
             return render_template(
@@ -260,7 +260,7 @@ def resend_code():
     )
     try:
         mail.send(msg)
-    except:
+    except Exception:
         error = traceback.format_exc().replace("\n", ", ")
         app.logger.error(f"Fail to send e-mail to email={email} user={username}: {error}")
         session['error_msg'] = "Failed to send confirmation e-mail. Please try again later"
@@ -327,7 +327,7 @@ def require_email():
         )
         try:
             mail.send(msg)
-        except:
+        except Exception:
             error = traceback.format_exc().replace("\n", ", ")
             app.logger.info(f"Fail to send e-mail to {email}: {error}")
             session.pop('email_confirmation_token', None)
@@ -409,7 +409,7 @@ def resend_email_code():
     )
     try:
         mail.send(msg)
-    except:
+    except Exception:
         error = traceback.format_exc().replace("\n", ", ")
         app.logger.info(f"Fail to send e-mail to {email}: {error}")
         session['error_msg'] = "Failed to send confirmation e-mail. Please try again later"
@@ -451,7 +451,7 @@ def reset_password():
     )
     try:
         mail.send(mail_msg)
-    except:
+    except Exception:
         error = traceback.format_exc().replace("\n", ", ")
         app.logger.info(f"Fail to send e-mail to {user.email} user={user.username}: {error}")
         msg="Failed to send confirmation e-mail. Please try again later"

--- a/apps/authentication/routes.py
+++ b/apps/authentication/routes.py
@@ -478,7 +478,7 @@ def confirm_reset_password(token):
 
     cache.delete(f"resetpw-{token}")
 
-    user = Users.query.get(resetpw_user)
+    user = db.session.get(Users, resetpw_user)
     if not user or user.is_deleted:
         app.logger.info(f"Invalid password reset request ipaddr={get_remote_addr()} user={resetpw_user}")
         msg = "Invalid password reset request! You need to request a new <a href='{url_for('authentication_blueprint.reset_password')}'>Password Reset</a>"

--- a/apps/config.py
+++ b/apps/config.py
@@ -166,6 +166,9 @@ class Config(object):
         "primary,secondary,success,danger,warning,info,light,dark,white,black"
     ).split(",") if c.strip()]
 
+    # E-mail validation token expiration time
+    EMAIL_TOKEN_EXPIRY_MINUTES = int(os.getenv("EMAIL_TOKEN_EXPIRY_MINUTES", 15)
+
 class ProductionConfig(Config):
     DEBUG = False
 

--- a/apps/config.py
+++ b/apps/config.py
@@ -167,7 +167,7 @@ class Config(object):
     ).split(",") if c.strip()]
 
     # E-mail validation token expiration time
-    EMAIL_TOKEN_EXPIRY_MINUTES = int(os.getenv("EMAIL_TOKEN_EXPIRY_MINUTES", 15)
+    EMAIL_TOKEN_EXPIRY_MINUTES = int(os.getenv("EMAIL_TOKEN_EXPIRY_MINUTES", 15))
 
 class ProductionConfig(Config):
     DEBUG = False

--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -83,7 +83,9 @@ def index():
     show_feedback_modal = False
 
     if not user_feedback:
-        last_shown = cache.get(f"feedback_prompt_last_shown_{current_user.id}") or 0
+        last_shown = cache.get(f"feedback_prompt_last_shown_{current_user.id}")
+        if not last_shown:
+            last_shown = int(current_user.created_at.timestamp())
         now_ts = int(utcnow().timestamp())
         if now_ts - last_shown > current_app.config["HIDE_FEEDBACK_SEC"]:
             show_feedback_modal = True

--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -601,7 +601,7 @@ def edit_lab_category(category_id):
         category = LabCategories()
     else:
         action_name = "Update"
-        category = LabCategories.query.get(int(category_id))
+        category = db.session.get(LabCategories, int(category_id))
         if not category or category.is_deleted:
             return render_template("pages/error.html", title="Not found", msg="Lab Category not found")
         if current_user.category == "teacher" and category.updated_by != current_user.id:

--- a/apps/templates/pages/confirm.html
+++ b/apps/templates/pages/confirm.html
@@ -37,7 +37,7 @@
             {% if msg %}
               <span class="text-danger">{{ msg | safe }}</span>
             {% else %}
-                Insert the token sent to your email (check your spam/junk folder!)
+                Insert the token sent to your email (check your spam/junk folder!). The token will expire in 15 minutes.
             {% endif %}
         </p>
 

--- a/apps/templates/pages/confirm.html
+++ b/apps/templates/pages/confirm.html
@@ -37,7 +37,7 @@
             {% if msg %}
               <span class="text-danger">{{ msg | safe }}</span>
             {% else %}
-                Insert the token sent to your email (check your spam/junk folder!). The token will expire in 15 minutes.
+                Insert the token sent to your email (check your spam/junk folder!). The token will expire in {{ config.EMAIL_TOKEN_EXPIRY_MINUTES }} minutes.
             {% endif %}
         </p>
 

--- a/apps/templates/pages/confirm_email.html
+++ b/apps/templates/pages/confirm_email.html
@@ -37,7 +37,7 @@
             {% if msg %}
               <span class="text-danger">{{ msg | safe }}</span>
             {% else %}
-                Insert the token sent to your email (check your spam/junk folder!)
+                Insert the token sent to your email (check your spam/junk folder!). The token will expire in 15 minutes
             {% endif %}
         </p>
 

--- a/apps/templates/pages/confirm_email.html
+++ b/apps/templates/pages/confirm_email.html
@@ -37,7 +37,7 @@
             {% if msg %}
               <span class="text-danger">{{ msg | safe }}</span>
             {% else %}
-                Insert the token sent to your email (check your spam/junk folder!). The token will expire in 15 minutes
+                Insert the token sent to your email (check your spam/junk folder!). The token will expire in {{ config.EMAIL_TOKEN_EXPIRY_MINUTES }} minutes
             {% endif %}
         </p>
 

--- a/apps/templates/pages/confirm_email.html
+++ b/apps/templates/pages/confirm_email.html
@@ -1,0 +1,86 @@
+{% extends "layouts/base-fullscreen.html" %}
+
+{% block title %} Confirm your e-mail {% endblock %}
+
+<!-- Element injected in the BODY element -->
+{% block body_class %} login-page {% endblock body_class %}
+
+<!-- Specific Page CSS goes HERE  -->
+{% block stylesheets %}
+
+  <!-- Google Font: Source Sans Pro -->
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
+  <!-- Font Awesome -->
+  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <!-- icheck bootstrap -->
+  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <!-- Theme style -->
+  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+
+{% endblock stylesheets %}
+
+{% block content %}
+
+  <div class="login-box">
+
+    <div class="login-logo">
+        <a target="_blank" rel="noopener noreferrer" href="https://hackinsdn.github.io/">
+            <img src="{{ url_for('static', filename='assets/img/hackinsdn.png') }}" alt="HackInSDN">
+        </a>
+    </div>
+
+    <!-- /.login-logo -->
+    <div class="card">
+      <div class="card-body login-card-body">
+
+        <p class="login-box-msg">
+            {% if msg %}
+              <span class="text-danger">{{ msg | safe }}</span>
+            {% else %}
+                Insert the token sent to your email (check your spam/junk folder!)
+            {% endif %}
+        </p>
+
+        <form method="post" action="">
+
+          {{ form.hidden_tag() }}
+
+          <div class="input-group mb-3">
+            {{ form.confirmation_token(placeholder="Token", class="form-control") }}
+            <div class="input-group-append">
+              <div class="input-group-text">
+                <span class="fas fa-key"></span>
+              </div>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-6">
+                <button type="submit" name="confirm" class="btn btn-primary btn-block">Verify code</button>
+            </div>
+            <div class="col-6">
+                <a href="{{ url_for('authentication_blueprint.resend_email_code')}}" class="btn btn-secondary btn-block">Resend code</a>
+          </div>
+        </form>
+
+        <br />
+        <div class="text-center">
+          <a href="{{ url_for('authentication_blueprint.logout') }}" class="text-center">Logout</a>
+        </div>
+
+      </div>
+      <!-- /.login-card-body -->
+    </div>
+
+  </div>
+
+{% endblock content %}
+
+<!-- Specific Page JS goes HERE  -->
+{% block javascripts %}
+
+  <!-- jQuery -->
+  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <!-- Bootstrap 4 -->
+  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+
+{% endblock javascripts %}

--- a/apps/templates/pages/email_required.html
+++ b/apps/templates/pages/email_required.html
@@ -1,0 +1,79 @@
+{% extends "layouts/base-fullscreen.html" %}
+
+{% block title %} Confirm your e-mail {% endblock %}
+
+<!-- Element injected in the BODY element -->
+{% block body_class %} register-page {% endblock body_class %}
+
+<!-- Specific Page CSS goes HERE  -->
+{% block stylesheets %}
+
+<!-- Google Font: Source Sans Pro -->
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
+<!-- Font Awesome -->
+<link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+<!-- icheck bootstrap -->
+<link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+<!-- Theme style -->
+<link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+
+{% endblock stylesheets %}
+
+{% block content %}
+
+<div class="register-box">
+
+  <div class="login-logo">
+    <a target="_blank" rel="noopener noreferrer" href="https://hackinsdn.github.io/">
+      <img src="{{ url_for('static', filename='assets/img/hackinsdn.png') }}" alt="HackInSDN" />
+    </a>
+  </div>
+
+  <div class="card">
+    <div class="card-body register-card-body">
+      <p class="login-box-msg">
+        {% if msg %}
+        <span class="text-danger">{{ msg | safe }}</span>
+        {% else %}
+        <span>
+          We need a valid e-mail address for your account before you can continue.
+        </span>
+        {% endif %}
+      </p>
+
+      <form id="emailForm" role="form" method="post" action="">
+
+        {{ form.hidden_tag() }}
+
+        <div class="input-group mb-3">
+          {{ form.email(placeholder="Email", class="form-control") }}
+          <div class="input-group-append">
+            <div class="input-group-text">
+              <span class="fas fa-envelope"></span>
+            </div>
+          </div>
+        </div>
+
+        <button type="submit" name="submit_email" class="btn btn-primary btn-block">Continue</button>
+      </form>
+
+      <br />
+      <div class="text-center">
+        <a href="{{ url_for('authentication_blueprint.logout') }}" class="text-center">Logout</a>
+      </div>
+
+    </div><!-- /.card-body -->
+  </div><!-- /.card -->
+</div><!-- /.register-box -->
+
+{% endblock content %}
+
+<!-- Specific Page JS goes HERE  -->
+{% block javascripts %}
+
+<!-- jQuery -->
+<script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+<!-- Bootstrap 4 -->
+<script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+
+{% endblock javascripts %}

--- a/doc/DEV.md
+++ b/doc/DEV.md
@@ -2,6 +2,17 @@
 
 This page contains some documentation for developers.
 
+## Tests + Linter + Format
+
+```
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install -r requirements-dev.txt
+pytest -v tests/
+djlint --profile=jinja2 --ignore=H023,D004,J004 apps/templates/
+black --check apps/
+```
+
 ## Entity Relationship Diagram
 
 The picture below shows the Entity Relationship Diagram for Dashboard HackInSDN:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
 -r requirements.txt
 pytest==8.3.4
+djlint==1.40.1
+black==24.3.0

--- a/tests/test_email_required.py
+++ b/tests/test_email_required.py
@@ -305,7 +305,7 @@ class TestTokenConfirmationPath:
             data={"email": "expireduser@example.com", "submit_email": "1"},
         )
         token = get_session_value(client, "email_confirmation_token")
-        set_session_value(client, "email_datetime", utcnow() - timedelta(minutes=10))
+        set_session_value(client, "email_datetime", utcnow() - timedelta(minutes=20))
 
         resp = client.post(
             "/email/required/confirm",

--- a/tests/test_email_required.py
+++ b/tests/test_email_required.py
@@ -2,11 +2,13 @@
 
 Exercises the same scenarios that were checked manually while building the
 feature: login redirects to /email/required when Users.email is empty,
-next_url is preserved through the detour, the no-MAIL_SERVER fast path sets
-the email directly, duplicate emails are rejected, a user who already has an
-email is bounced straight through (not looped back into the flow), the full
-token-confirmation path (including resend and expiry), and the Logout
-escape hatch is present on both new pages.
+the same guard on the OAuth callback() path (which creates the Users row
+itself, unlike local login), next_url is preserved through the detour, the
+no-MAIL_SERVER fast path sets the email directly, duplicate emails are
+rejected, a user who already has an email is bounced straight through (not
+looped back into the flow), the full token-confirmation path (including
+resend and expiry), and the Logout escape hatch is present on both new
+pages.
 
 Runs entirely against a throwaway temporary SQLite database created in a temp
 directory - it never touches the real dev/production database
@@ -155,6 +157,53 @@ class TestLoginRedirectsWhenEmailMissing:
         assert resp.status_code == 200
         assert b"email_require" in resp.data
         assert b'href="/logout"' in resp.data
+        logout(client)
+
+
+# --- OAuth callback with a missing e-mail claim ----------------------------
+class TestOAuthCallbackWhenEmailMissing:
+    """OAuth providers sometimes don't return an email claim at all
+    (token.get("email") is None) - callback() creates the Users row itself
+    rather than going through register(), so this exercises that path
+    independently of the local-login tests above."""
+
+    def test_oauth_callback_redirects_then_completes_email_required_flow(
+        self, client, monkeypatch, no_mail_server
+    ):
+        logout(client)
+        monkeypatch.setattr(
+            auth_routes.oauth.provider,
+            "authorize_access_token",
+            lambda *a, **kw: {
+                "userinfo": {
+                    "sub": "oauth-noemail-sub",
+                    "iss": "https://idp.example.com",
+                    "given_name": "OAuth",
+                    "family_name": "NoEmail",
+                    "email": None,
+                }
+            },
+        )
+
+        resp = client.get("/login/callback")
+        assert resp.status_code == 302
+        assert "/email/required" in resp.headers["Location"]
+
+        user = Users.query.filter_by(subject="oauth-noemail-sub").first()
+        assert user is not None
+        assert not user.email
+
+        # same email_required.html/confirm flow local-login users go
+        # through - no special-casing for OAuth-created accounts
+        resp = client.post(
+            "/email/required",
+            data={"email": "oauthnoemail@example.com", "submit_email": "1"},
+        )
+        assert resp.status_code == 302
+        assert "/email/required" not in resp.headers["Location"]
+
+        db.session.refresh(user)
+        assert user.email == "oauthnoemail@example.com"
         logout(client)
 
 

--- a/tests/test_email_required.py
+++ b/tests/test_email_required.py
@@ -1,0 +1,319 @@
+"""Pytest suite for the "require e-mail after login" feature.
+
+Exercises the same scenarios that were checked manually while building the
+feature: login redirects to /email/required when Users.email is empty,
+next_url is preserved through the detour, the no-MAIL_SERVER fast path sets
+the email directly, duplicate emails are rejected, a user who already has an
+email is bounced straight through (not looped back into the flow), the full
+token-confirmation path (including resend and expiry), and the Logout
+escape hatch is present on both new pages.
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3). No real email is ever sent: MAIL_SERVER is either
+left falsy (default fast path) or monkeypatched together with
+apps.authentication.routes.mail.send for the confirmation-path tests.
+
+Usage:
+    pip install -r requirements-test.txt
+    pytest tests/test_email_required.py -v
+"""
+import os
+import sys
+import tempfile
+import types
+from datetime import timedelta
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+# Must happen before `apps`/`run` are imported below, since apps/config.py
+# reads DATA_DIR at import time.
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# apps/controllers/clabernetes.py hard-requires a 'clabverter' binary to be
+# installed on disk at *import* time. That requirement is unrelated to this
+# feature, so stub the module out in sys.modules before anything imports
+# apps.controllers - this avoids needing that binary just to run these tests.
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db  # noqa: E402
+from apps.authentication import routes as auth_routes  # noqa: E402
+from apps.authentication.models import Users  # noqa: E402
+from apps.audit_mixin import utcnow  # noqa: E402
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def ids(app):
+    """Seed one dedicated user per scenario, so tests don't interfere."""
+    users = {
+        "taken_email": Users(username="takenemail", password="pass123", email="taken@example.com"),
+        "login_redirect": Users(username="loginredirect", password="pass123", email=""),
+        "nexturl": Users(username="nexturluser", password="pass123", email=""),
+        "fastpath": Users(username="fastpathuser", password="pass123", email=""),
+        "duplicate": Users(username="dupuser", password="pass123", email=""),
+        "stale_next": Users(username="stalenextuser", password="pass123", email="stale1@example.com"),
+        "stale_default": Users(username="staledefaultuser", password="pass123", email="stale2@example.com"),
+        "token_flow": Users(username="tokenflowuser", password="pass123", email=""),
+        "expired": Users(username="expireduser", password="pass123", email=""),
+    }
+    db.session.add_all(users.values())
+    db.session.commit()
+    return {name: user.id for name, user in users.items()}
+
+
+@pytest.fixture
+def no_mail_server(monkeypatch):
+    """Force the no-MAIL_SERVER fast path regardless of ambient env vars."""
+    monkeypatch.setitem(flask_app.config, "MAIL_SERVER", "")
+
+
+@pytest.fixture
+def mail_outbox(monkeypatch):
+    """Force the token-confirmation path and capture sent messages instead
+    of hitting the network."""
+    outbox = []
+    monkeypatch.setitem(flask_app.config, "MAIL_SERVER", "smtp.test.local")
+    monkeypatch.setitem(flask_app.config, "MAIL_USERNAME", "noreply@test.local")
+    monkeypatch.setattr(auth_routes.mail, "send", lambda msg: outbox.append(msg))
+    return outbox
+
+
+# --- helpers -----------------------------------------------------------
+def login(client, username, password):
+    return client.post(
+        "/login/",
+        data={"identifier": username, "password": password, "login": "1"},
+    )
+
+
+def logout(client):
+    client.get("/logout")
+
+
+def get_session_value(client, key):
+    with client.session_transaction() as sess:
+        return sess.get(key)
+
+
+def set_session_value(client, key, value):
+    with client.session_transaction() as sess:
+        sess[key] = value
+
+
+# --- login redirect -------------------------------------------------------
+class TestLoginRedirectsWhenEmailMissing:
+    def test_login_redirects_to_email_required(self, client, ids):
+        logout(client)
+        resp = login(client, "loginredirect", "pass123")
+        assert resp.status_code == 302
+        assert "/email/required" in resp.headers["Location"]
+
+    def test_email_required_form_is_shown_with_logout_link(self, client, ids):
+        resp = client.get("/email/required")
+        assert resp.status_code == 200
+        assert b"email_require" in resp.data
+        assert b'href="/logout"' in resp.data
+        logout(client)
+
+
+# --- next_url preserved through the detour --------------------------------
+class TestNextUrlPreservedThroughEmailFlow:
+    def test_next_url_survives_login_and_is_used_after_email_is_set(self, client, ids, no_mail_server):
+        logout(client)
+        set_session_value(client, "next_url", "/index")
+
+        resp = login(client, "nexturluser", "pass123")
+        assert resp.status_code == 302
+        assert "/email/required" in resp.headers["Location"]
+        # next_url must still be sitting in the session for later
+        assert get_session_value(client, "next_url") == "/index"
+
+        resp = client.post(
+            "/email/required",
+            data={"email": "nexturluser@example.com", "submit_email": "1"},
+        )
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/index")
+        assert get_session_value(client, "next_url") is None
+
+        user = db.session.get(Users, ids["nexturl"])
+        assert user.email == "nexturluser@example.com"
+        logout(client)
+
+
+# --- no-MAIL_SERVER fast path ---------------------------------------------
+class TestNoMailServerFastPath:
+    def test_submitting_email_sets_it_directly_without_confirmation(self, client, ids, no_mail_server):
+        logout(client)
+        login(client, "fastpathuser", "pass123")
+
+        resp = client.post(
+            "/email/required",
+            data={"email": "fastpathuser@example.com", "submit_email": "1"},
+        )
+        assert resp.status_code == 302
+        # no next_url was stashed -> falls back to the default route
+        assert "/email/required" not in resp.headers["Location"]
+
+        user = db.session.get(Users, ids["fastpath"])
+        assert user.email == "fastpathuser@example.com"
+        logout(client)
+
+    def test_duplicate_email_is_rejected(self, client, ids, no_mail_server):
+        logout(client)
+        login(client, "dupuser", "pass123")
+
+        resp = client.post(
+            "/email/required",
+            data={"email": "taken@example.com", "submit_email": "1"},
+        )
+        assert resp.status_code == 200
+        assert b"already registered" in resp.data
+
+        user = db.session.get(Users, ids["duplicate"])
+        assert user.email == ""
+        logout(client)
+
+
+# --- stale visits once the email is already set --------------------------
+class TestStaleVisitAfterEmailAlreadySet:
+    def test_redirects_to_next_url_if_present(self, client, ids):
+        logout(client)
+        # email is already set, so login() itself would consume/redirect on
+        # any next_url already in session - stash it *after* login instead,
+        # simulating a next_url captured later (e.g. by the
+        # @login_required guard on some other page), to isolate
+        # require_email()'s own redirect branch.
+        login(client, "stalenextuser", "pass123")
+        set_session_value(client, "next_url", "/index")
+
+        resp = client.get("/email/required")
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/index")
+        assert get_session_value(client, "next_url") is None
+        logout(client)
+
+    def test_redirects_to_default_route_otherwise(self, client, ids):
+        logout(client)
+        login(client, "staledefaultuser", "pass123")
+
+        resp = client.get("/email/required")
+        assert resp.status_code == 302
+        assert "/email/required" not in resp.headers["Location"]
+        logout(client)
+
+
+# --- full token-confirmation path -----------------------------------------
+class TestTokenConfirmationPath:
+    def test_full_flow_with_wrong_token_resend_and_success(self, client, ids, mail_outbox):
+        logout(client)
+        login(client, "tokenflowuser", "pass123")
+
+        resp = client.post(
+            "/email/required",
+            data={"email": "tokenflowuser@example.com", "submit_email": "1"},
+        )
+        assert resp.status_code == 302
+        assert "/email/required/confirm" in resp.headers["Location"]
+        assert len(mail_outbox) == 1
+
+        user = db.session.get(Users, ids["token_flow"])
+        assert user.email == ""
+
+        resp = client.get("/email/required/confirm")
+        assert resp.status_code == 200
+        assert b'href="/logout"' in resp.data
+
+        # wrong token
+        resp = client.post(
+            "/email/required/confirm",
+            data={"confirmation_token": "000000", "confirm": "1"},
+        )
+        assert resp.status_code == 200
+        assert b"Invalid token" in resp.data
+        db.session.refresh(user)
+        assert user.email == ""
+
+        # resend re-sends the same token
+        token_before = get_session_value(client, "email_confirmation_token")
+        resp = client.get("/email/required/resend-code")
+        assert resp.status_code == 302
+        assert len(mail_outbox) == 2
+        assert get_session_value(client, "email_confirmation_token") == token_before
+
+        # correct token
+        resp = client.post(
+            "/email/required/confirm",
+            data={"confirmation_token": token_before, "confirm": "1"},
+        )
+        assert resp.status_code == 302
+        assert "/email/required" not in resp.headers["Location"]
+        assert get_session_value(client, "email_confirmation_token") is None
+
+        db.session.refresh(user)
+        assert user.email == "tokenflowuser@example.com"
+        logout(client)
+
+    def test_expired_token_is_rejected(self, client, ids, mail_outbox):
+        logout(client)
+        login(client, "expireduser", "pass123")
+
+        client.post(
+            "/email/required",
+            data={"email": "expireduser@example.com", "submit_email": "1"},
+        )
+        token = get_session_value(client, "email_confirmation_token")
+        set_session_value(client, "email_datetime", utcnow() - timedelta(minutes=10))
+
+        resp = client.post(
+            "/email/required/confirm",
+            data={"confirmation_token": token, "confirm": "1"},
+        )
+        assert resp.status_code == 200
+        assert b"Token expired" in resp.data
+
+        user = db.session.get(Users, ids["expired"])
+        assert user.email == ""
+        logout(client)


### PR DESCRIPTION
## Summary
- After a successful local login or OAuth callback, if the authenticated user's `email` is empty, redirect to a new `/email/required` flow instead of continuing to `next_url`/the default route.
- The new flow asks for an email and confirms it via a 6-digit token e-mail, mirroring the existing `register()`/`confirm_page()`/`resend_code()` pattern (same mail template, same session-based token/expiry logic). If `MAIL_SERVER` isn't configured, the email is set directly without a confirmation step, mirroring `register()`'s existing fallback.
- `next_url` is preserved through the whole detour (not popped until the email is actually confirmed/set), so the user still lands wherever they were originally headed.
- Both new pages (`email_required.html`, `confirm_email.html`) include a Logout link so the user isn't trapped there.
- Users who already have an email are never routed through this flow.

## Why
Some accounts end up with an empty `email` (e.g. OAuth providers that don't return an email claim, or accounts created without one). `email` is used elsewhere in the app for auto-approval matching (`check_pre_approved`) and password-reset, so an account stuck with no email silently loses those features. This closes that gap right at login time.

## Changes
- `apps/authentication/forms.py`: new `RequireEmailForm`.
- `apps/authentication/routes.py`: email-missing check in `login()`/`callback()`; new `require_email`, `confirm_email`, `resend_email_code` routes.
- `apps/templates/pages/email_required.html`, `apps/templates/pages/confirm_email.html`: new pages.
- `tests/test_email_required.py`: new pytest suite (modeled on `tests/test_lab_categories.py`) covering the login redirect, `next_url` preservation, the no-`MAIL_SERVER` fast path, duplicate-email rejection, the "already has an email" guard (both redirect branches), and the full token-confirmation path (wrong token, resend, success, expiry).

## Test plan
- [x] `pytest tests/test_email_required.py -v` — 9/9 passed
- [x] `pytest tests/` (full suite) — 28/28 passed, no regressions
- [x] `python3 -m py_compile apps/authentication/routes.py apps/authentication/forms.py`