### PR TITLE
small bug fixes and handling warnings/deprecated messages

### DIFF
--- a/apps/api/routes.py
+++ b/apps/api/routes.py
@@ -37,7 +37,7 @@ def get_lab_status(lab_id):
     if current_user.category == "user":
         return {}, 404
 
-    lab = LabInstances.query.get(lab_id)
+    lab = db.session.get(LabInstances, lab_id)
     if not lab:
         return {"status": "fail", "result": "Lab instance not found"}, 404
     
@@ -64,7 +64,7 @@ def delete_lab(lab_id):
     if current_user.category == "user":
         return {}, 404
 
-    lab = LabInstances.query.get(lab_id)
+    lab = db.session.get(LabInstances, lab_id)
     if not lab:
         return {"status": "fail", "result": "Lab instance not found"}, 404
 
@@ -132,7 +132,7 @@ def bulk_approve_users():
         if not user_id.isdigit():
             errors.append(f"Invalid user provided {user_id=}")
             continue
-        user = Users.query.get(int(user_id))
+        user = db.session.get(Users, int(user_id))
         if not user or user.is_deleted or user.category != "user":
             errors.append(f"Invalid user provided {user_id=}")
             continue
@@ -158,7 +158,7 @@ def get_lab_answers(lab_inst_id):
     if current_user.category == "user":
         return {}, 404
 
-    lab_inst = LabInstances.query.get(lab_inst_id)
+    lab_inst = db.session.get(LabInstances, lab_inst_id)
     if not lab_inst:
         return {"status": "fail", "result": "Lab instance not found"}, 404
 
@@ -182,7 +182,7 @@ def save_lab_answers(lab_inst_id):
     if not content:
         return {"status": "fail", "result": "invalid content"}, 400
 
-    lab_inst = LabInstances.query.get(lab_inst_id)
+    lab_inst = db.session.get(LabInstances, lab_inst_id)
     if not lab_inst:
         return {"status": "fail", "result": "Lab instance not found"}, 404
 
@@ -205,7 +205,7 @@ def save_grades_comments(answer_id):
     if current_user.category not in ["admin", "teacher"]:
         return {"status": "fail", "result": "User not authorized"}, 401
 
-    lab_answers = LabAnswers.query.get(answer_id)
+    lab_answers = db.session.get(LabAnswers, answer_id)
     if not lab_answers:
         return {"status": "fail", "result": "Lab answers not found"}, 404
 
@@ -245,7 +245,7 @@ def delete_user(user_id):
     if current_user.category != "admin":
         return {"status": "fail", "result": "Unauthorized access"}, 401
 
-    user = Users.query.get(user_id)
+    user = db.session.get(Users, user_id)
     if not user or user.is_deleted:
         return {"status": "fail", "result": "User not found"}, 404
 
@@ -280,7 +280,7 @@ def delete_group(group_id):
     if current_user.category not in ["admin", "teacher"]:
         return {"status": "fail", "result": "Unauthorized access"}, 401
 
-    group = Groups.query.get(group_id)
+    group = db.session.get(Groups, group_id)
     if not group or group.is_deleted:
         return {"status": "fail", "result": "Group not found"}, 404
 
@@ -294,9 +294,9 @@ def delete_group(group_id):
     deleted = DeletedGroupUsers()
     deleted.object_id = group.id
     deleted.object_type = "group"
-    deleted.members = json.dumps(group.members_dict.keys())
-    deleted.assistants = json.dumps(group.assistants_dict.keys())
-    deleted.owners = json.dumps(group.owners_dict.keys())
+    deleted.members = json.dumps(list(group.members_dict.keys()))
+    deleted.assistants = json.dumps(list(group.assistants_dict.keys()))
+    deleted.owners = json.dumps(list(group.owners_dict.keys()))
     db.session.add(deleted)
     group.members.clear()
     group.assistants.clear()
@@ -341,7 +341,7 @@ def join_group(group_id):
     if not content or not content.get("accessToken"):
         return {"status": "fail", "result": "invalid content"}, 400
 
-    group = Groups.query.get(group_id)
+    group = db.session.get(Groups, group_id)
     if not group or group.is_deleted:
         return {"status": "fail", "result": "Group not found"}, 404
 
@@ -373,7 +373,7 @@ def check_lab_answer(lab_id, answer_id):
     if current_user.category not in ["admin", "teacher"]:
         return {"status": "fail", "result": "Unauthorized access"}, 401
 
-    lab = Labs.query.get(lab_id)
+    lab = db.session.get(Labs, lab_id)
     if not lab:
         return {"status": "fail", "result": "Invalid or Unauthorized access to lab"}, 401
 
@@ -384,7 +384,7 @@ def check_lab_answer(lab_id, answer_id):
     else:
         return {"status": "fail", "result": "Invalid or Unauthorized access to lab"}, 401
 
-    lab_answer = LabAnswers.query.get(answer_id)
+    lab_answer = db.session.get(LabAnswers, answer_id)
     if not lab_answer:
         return {"status": "fail", "result": "Invalid or Unauthorized access to lab answer"}, 401
 
@@ -477,7 +477,7 @@ def feedback():
 @login_required
 def add_user_like():
     counter = cache.get("user_likes") or UserLikes.query.count()
-    user_like = UserLikes.query.get(current_user.id)
+    user_like = db.session.get(UserLikes, current_user.id)
     if user_like:
         return {"status": "ok", "result": counter}, 200
     user_like = UserLikes(user_id=current_user.id)
@@ -509,7 +509,7 @@ def del_user_like():
 @login_required
 def extend_lab(lab_id):
 
-    lab_instance = LabInstances.query.get(lab_id)
+    lab_instance = db.session.get(LabInstances, lab_id)
     if not lab_instance:
         return {"status": "fail", "result": "Lab instance not found"}, 404
 

--- a/apps/authentication/routes.py
+++ b/apps/authentication/routes.py
@@ -67,7 +67,7 @@ def login():
                 return redirect(next_url)
             return redirect(url_for('authentication_blueprint.route_default'))
 
-        app.logger.warn(f"Failed login ipaddr={get_remote_addr()} login={identifier} auth_provider=local")
+        app.logger.warning(f"Failed login ipaddr={get_remote_addr()} login={identifier} auth_provider=local")
         login_log = LoginLogging(ipaddr=get_remote_addr(), login=identifier, auth_provider="local", success=False)
         db.session.add(login_log)
         db.session.commit()
@@ -102,7 +102,7 @@ def callback():
     email = token.get("email", None)
 
     if not subject:
-        app.logger.warn("Invalid auth token from OAUTH callback:", token)
+        app.logger.warning(f"Invalid auth token from OAUTH callback: {token}")
         return render_template('pages/page-403.html'), 403
 
     user = Users.query.filter_by(subject=subject).first()

--- a/apps/clabs/routes.py
+++ b/apps/clabs/routes.py
@@ -21,7 +21,7 @@ def upsert(clab_id="new"):
     """Update or Insert a ContainerLab."""
 
     if clab_id != "new":
-        clab = Labs.query.get(clab_id)
+        clab = db.session.get(Labs, clab_id)
         if not clab:
             return render_template("pages/clabs_upsert.html", clab=None, msg_fail="ContainerLab not found")
         if not clab.is_clab:
@@ -51,6 +51,8 @@ def upsert(clab_id="new"):
     if request.method == "GET":
         return render_template("pages/clabs_upsert.html", clab=clab, lab_categories=lab_categories, groups=groups, current_files=current_files)
 
+    db.session.add(clab)
+    db.session.add(clab_md)
     clab.title = request.form.get("clab_title", "").strip()
     clab.description = request.form.get("clab_desc", "").strip()
     clab.set_extended_desc(request.form["clab_extended_desc"])
@@ -134,7 +136,7 @@ def upsert(clab_id="new"):
     if len(files) > max_files:
         return jsonify({
             "ok": False,
-            "result": f"Too many files: {files_count} (max {max_files})"
+            "result": f"Too many files: {len(files)} (max {max_files})"
         }), 400
 
     changed_files = False
@@ -183,8 +185,6 @@ def upsert(clab_id="new"):
                 return jsonify({"ok": False, "result": msg}), 400
 
     try:
-        db.session.add(clab)
-        db.session.add(clab_md)
         db.session.commit()
         status = True
         msg = "ContainerLab saved with success"

--- a/apps/cli/lab_schedule.py
+++ b/apps/cli/lab_schedule.py
@@ -19,9 +19,9 @@ def alert_expiring_labs(app, send_email=False):
     ).all()
     app.logger.info(f"Checking for expiring labs. Found {len(lab_instances)} lab instances expiring..")
     for lab_instance in lab_instances:
-        lab = Labs.query.get(lab_instance.lab_id)
+        lab = db.session.get(Labs, lab_instance.lab_id)
         end_time = datetime_from_ts(lab_instance.expiration_ts)
-        user = Users.query.get(lab_instance.user_id)
+        user = db.session.get(Users, lab_instance.user_id)
         if not user or not send_email:
             app.logger.info(f"ALERT Expiring Lab {user=} {lab_instance.id=} {end_time=}. No e-mail to send..")
             continue

--- a/apps/home/models.py
+++ b/apps/home/models.py
@@ -121,11 +121,11 @@ class LabInstances(db.Model, AuditMixin):
         self._k8s_resources = json.dumps(k8s_resources)
 
     def get_user(self):
-        user = Users.query.get(self.user_id)
+        user = db.session.get(Users, self.user_id)
         return user.realname
 
     def get_lab(self):
-        lab = Labs.query.get(self.lab_id)
+        lab = db.session.get(Labs, self.lab_id)
         return lab.title
 
     def get_id(self):

--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -56,7 +56,7 @@ def index():
         "lab_categories": stats_data.get("lab_categories", {}),
         "lab_usage": stats_data.get("lab_usage", {}),
         "likes": user_likes,
-        "has_liked": UserLikes.query.get(current_user.id),
+        "has_liked": db.session.get(UserLikes, current_user.id),
         "users": stats_data.get("users", 0),
         "lab_inst_period_report": "1 Jul, 2014 - 23 Nov, 2014",
         "cpu_capacity": stats_data.get("total_cpu_capacity", 0),
@@ -103,7 +103,7 @@ def running_labs():
     filter_members = {}
     if filter_group.isdigit():
         filter_group = int(filter_group)
-        group = Groups.query.get(filter_group)
+        group = db.session.get(Groups, filter_group)
         if not group or group.is_deleted:
             return render_template("pages/error.html", title="Error getting running labs", msg="Group not found")
         filter_members = group.members_dict
@@ -181,7 +181,7 @@ def running_labs():
 def run_lab(lab_id):
 
     msg_error = ""
-    lab = Labs.query.get(lab_id)
+    lab = db.session.get(Labs, lab_id)
     if not lab:
         return render_template("pages/error.html", title="Error Running Labs", msg="Lab not found")
 
@@ -255,7 +255,7 @@ def run_lab(lab_id):
 def check_lab_status(lab_id):
 
     msg_error = ""
-    lab = LabInstances.query.get(lab_id)
+    lab = db.session.get(LabInstances, lab_id)
     if not lab:
         return render_template("pages/error.html", title="Error checking lab status", msg="Lab not found")
 
@@ -268,7 +268,7 @@ def check_lab_status(lab_id):
 @login_required
 @check_user_category(["admin", "teacher", "labcreator", "student"])
 def xterm(lab_id, kind, pod, container):
-    lab = LabInstances.query.get(lab_id)
+    lab = db.session.get(LabInstances, lab_id)
     if not lab:
         return render_template("pages/error.html", title="Error checking lab status", msg="Lab not found")
     if (current_user.category in ["student", "labcreator"] and (lab.user_id != current_user.id)):
@@ -294,7 +294,7 @@ def edit_user(user_id=None):
     if current_user.id != user_id and current_user.category not in ["admin"]:
         return render_template("pages/error.html", title="Unauthorized access", msg="You dont have access for this page")
 
-    user = Users.query.get(user_id)
+    user = db.session.get(Users, user_id)
     if not user or user.is_deleted:
         return render_template("pages/error.html", title="Invalid user", msg="User not found or deactivated on the database")
 
@@ -346,13 +346,13 @@ def edit_user(user_id=None):
 @check_user_category(["admin", "teacher", "labcreator", "student"])
 def view_lab_instance(lab_id):
 
-    lab_instance = LabInstances.query.get(lab_id)
+    lab_instance = db.session.get(LabInstances, lab_id)
     if not lab_instance:
         return render_template("pages/error.html", title="Error accessing Lab Instance", msg="Lab not found")
     if lab_instance.is_deleted:
         return render_template("pages/error.html", title="Error accessing Lab Instance", msg="Lab finished")
 
-    lab = Labs.query.get(lab_instance.lab_id)
+    lab = db.session.get(Labs, lab_instance.lab_id)
     if not lab:
         return render_template("pages/error.html", title="Error accessing Lab Instance", msg="Lab instance belongs to an unknown Lab.")
 
@@ -366,7 +366,7 @@ def view_lab_instance(lab_id):
 
     owner = current_user
     if lab_instance.user_id != current_user.id:
-        owner = Users.query.get(lab_instance.user_id)
+        owner = db.session.get(Users, lab_instance.user_id)
 
     ports = {}
     if lab.lab_metadata:
@@ -431,7 +431,7 @@ def view_lab_instance(lab_id):
 @login_required
 @check_user_category(["admin", "teacher", "student"])
 def cancel_restart_lab_instance(lab_id):
-    lab_instance = LabInstances.query.get(lab_id)
+    lab_instance = db.session.get(LabInstances, lab_id)
     if not lab_instance or lab_instance.is_deleted:
         return render_template("pages/error.html", title="Error accessing Lab Instance", msg="Lab not found")
 
@@ -459,7 +459,7 @@ def cancel_restart_lab_instance(lab_id):
 def edit_lab(lab_id):
 
     if lab_id != "new":
-        lab = Labs.query.get(lab_id)
+        lab = db.session.get(Labs, lab_id)
         if not lab:
             return render_template("pages/labs_edit.html", lab=None, segment="/labs/edit", msg_fail="Lab not found")
         if current_user.category == "labcreator" and lab.updated_by != current_user.id:
@@ -488,7 +488,7 @@ def edit_lab(lab_id):
     # validate manifest using k8s dry-run?
     # validate mandatory fields
     # ...
-
+    db.session.add(lab)
     lab.title = request.form["lab_title"]
     lab.description = request.form["lab_description"]
 
@@ -514,7 +514,6 @@ def edit_lab(lab_id):
         return render_template("pages/labs_edit.html", lab=lab, lab_categories=lab_categories, msg_fail=invalid_lab_category+"Please select at least one category", segment="/labs/edit", groups=groups, allowed_groups=lab.allowed_groups, lab_uploads=lab_uploads)
 
     try:
-        db.session.add(lab)
         db.session.commit()
         status = True
         msg = "Lab saved with success"
@@ -718,7 +717,7 @@ def edit_group(group_id):
             )
     else:
         action_name = "Update"
-        group = Groups.query.get(int(group_id))
+        group = db.session.get(Groups, int(group_id))
         if not group or group.is_deleted:
             return render_template("pages/groups_edit.html", segment="/groups/edit", msg_fail="Group not found")
         if (current_user.category == "teacher" and current_user not in group.owners) or (current_user.category == "student" and current_user not in group.assistants):
@@ -780,7 +779,7 @@ def edit_group(group_id):
         try:
             user = users[int(user_id)]
         except Exception as exc:
-            current_app.logger.warn(f"Failed to process group_members {user_id=}: user not found")
+            current_app.logger.warning(f"Failed to process group_members {user_id=}: user not found")
             continue
         if user.id not in current_members:
             current_app.logger.info(
@@ -805,7 +804,7 @@ def edit_group(group_id):
         try:
             user = users[int(user_id)]
         except Exception as exc:
-            current_app.logger.warn(f"Failed to process group_assistants {user_id=}: user not found")
+            current_app.logger.warning(f"Failed to process group_assistants {user_id=}: user not found")
             continue
         if user.id not in current_assistants:
             group.assistants.append(user)
@@ -830,7 +829,7 @@ def edit_group(group_id):
         try:
             user = users[int(user_id)]
         except Exception as exc:
-            current_app.logger.warn(f"Failed to process group_owners {user_id=}: user not found")
+            current_app.logger.warning(f"Failed to process group_owners {user_id=}: user not found")
             continue
         if user.id not in current_owners:
             group.owners.append(user)
@@ -1034,7 +1033,7 @@ def hide_feedback():
     if not feedback_id or action not in ["hide", "unhide"]:
         return redirect(url_for('home_blueprint.feedback_view'))
 
-    feedback = UserFeedbacks.query.get(feedback_id)
+    feedback = db.session.get(UserFeedbacks, feedback_id)
     if not feedback:
         return redirect(url_for('home_blueprint.feedback_view'))
 
@@ -1055,7 +1054,7 @@ def view_finished_labs():
     filter_members = {}
     if filter_group.isdigit():
         filter_group = int(filter_group)
-        group = Groups.query.get(filter_group)
+        group = db.session.get(Groups, filter_group)
         if not group or group.is_deleted:
             return render_template("pages/error.html", title="Error getting finished labs", msg="Group not found")
         filter_members = group.members_dict
@@ -1218,7 +1217,7 @@ def upload_lab_file():
     uploads = []
     lab_id = request.form.get("lab_id", "").strip()
     if lab_id and lab_id != "new":
-        lab = Labs.query.get(lab_id)
+        lab = db.session.get(Labs, lab_id)
         if lab:
             lab_md = lab.lab_metadata
             if not lab_md:
@@ -1252,7 +1251,7 @@ def upload_lab_file():
 @login_required
 @check_user_category(["admin", "teacher", "labcreator"])
 def get_lab_uploads(lab_id):
-    lab = Labs.query.get(lab_id)
+    lab = db.session.get(Labs, lab_id)
     if not lab:
         return jsonify({"status": "fail", "result": "Lab not found"}), 404
     if current_user.category == "labcreator" and lab.updated_by != current_user.id:
@@ -1265,7 +1264,7 @@ def get_lab_uploads(lab_id):
 @login_required
 @check_user_category(["admin", "teacher", "labcreator"])
 def delete_lab_upload(lab_id, filename):
-    lab = Labs.query.get(lab_id)
+    lab = db.session.get(Labs, lab_id)
     if not lab:
         return jsonify({"status": "fail", "result": "Lab not found"}), 404
     if current_user.category == "labcreator" and lab.updated_by != current_user.id:

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -256,7 +256,7 @@ def list_files(folder, ignore_prefix=""):
 
 def remove_empty_folders(folder):
     """Remove empty folders inside a particular folder."""
-    folders = list(os.walk(mydir))[1:]
+    folders = list(os.walk(folder))[1:]
     for folder in folders:
         if not folder[2]:
             os.rmdir(folder[0])


### PR DESCRIPTION
### Description of the changes

Production fixes:
- `apps/utils.py:259` remove_empty_folders — mydir → folder (dead code with a NameError), now fixed and tested.
- `apps/api/routes.py:297` - delete_group was calling json.dumps(group.members_dict.keys()) (and .assistants_dict/.owners_dict). json.dumps can't serialize a dict_keys, and this ran before the try/except, so an admin deleting any group hit an uncaught 500. Wrapped each in list(...) to match how delete_user already does it. The new test_admin_can_delete_group_with_member covers this.
-  `apps/clabs/routes.py:137`: the too-many-files error used an undefined files_count, which would raise NameError (500) instead of returning 400. Changed to len(files). Covered by TestTooManyFiles.

Warnings/Deprecated message
- Several routes were using the deprecated Query.get() approach and were changed to `db.session.get(Model, pk)  `
- logging module were being used with `logger.warn` and was replaced with `logger.warning`
- we also address a few warnings related to objects not yet on DB being modified (or their relationship), usually the warning message was like this: `SAWarning: Object of type <Labs> not in session, add operation along 'Groups.labs' won't proceed`. In the end we identified this was happening because a new object was being added and relationships with that object were being updated without that object be added to DB session
