### PR TITLE
test: add unit test suite and CI coverage workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,69 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: ['**']  # run for PRs targeting any branch
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref (e.g. new pushes to a PR branch)
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Unit tests & coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"  # matches the Dockerfile (python:3.12-bookworm)
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run tests with coverage
+        # Produces coverage.xml + the .coverage data file and prints the
+        # per-file report. Does not enforce the threshold here so that a
+        # coverage regression is reported separately from a test failure.
+        run: |
+          python -m pytest tests/ \
+            --cov=apps \
+            --cov-report=term-missing \
+            --cov-report=xml
+
+      - name: Coverage summary
+        if: ${{ always() }}
+        run: |
+          if [ -f .coverage ]; then
+            echo "## Coverage" >> "$GITHUB_STEP_SUMMARY"
+            python -m coverage report --format=markdown >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload coverage.xml
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: ignore
+
+      - name: Enforce coverage threshold
+        # Fails the job if overall coverage drops below the floor. Bump this up
+        # over time as coverage improves.
+        run: python -m coverage report --fail-under=75

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ __pycache__/
 # tests and coverage
 *.pytest_cache
 .coverage
+coverage.xml
+htmlcov/
 
 # database & logs
 *.db

--- a/doc/test-coverage-auth-api-plan.md
+++ b/doc/test-coverage-auth-api-plan.md
@@ -1,0 +1,248 @@
+# Implementation plan: raise unit-test coverage of `apps/authentication/routes.py` and `apps/api/routes.py`
+
+## Context
+
+`tests/test_email_required.py` already covers the post-login e-mail flow
+(`require_email`, `confirm_email`, `resend_email_code`, the OAuth `callback`
+missing-email path, and the login->`/email/required` redirect). The three
+delete endpoints (`delete_user`, `delete_group`, `delete_lab_category`) are
+covered by `test_users.py` / `test_groups.py` / `test_lab_categories.py`. The
+rest of both blueprints is untested.
+
+This plan adds five new pytest files that follow the established approach
+(session-scoped temp SQLite DB, `clabernetes` import stub, ordered/stateful
+classes, unique username prefixes, `login`/`logout` helpers). Reuse verbatim
+the harness boilerplate + the `no_mail_server` / `mail_outbox` monkeypatch
+fixtures from `tests/test_email_required.py` (lines 34-145) for the mail-driven
+auth tests.
+
+### Shared-DB isolation & cache
+
+All modules share ONE singleton app/DB **and one SimpleCache** (module-level
+`apps.cache`). So:
+- unique username prefixes per file (`ar`, `as`, `aa`, `ae`, `ak` below);
+- any test that asserts on a cache-backed value (`user_likes`,
+  `user_feedbacks`) must `cache.delete(<key>)` at the start to neutralise
+  cross-module leakage.
+
+### Untested routes
+
+**auth** (`apps/authentication/routes.py`): `route_default`, `login`
+(GET form / bad-password / already-authenticated branches), `login_oauth`,
+`register`, `confirm_page`, `resend_code`, `reset_password`,
+`confirm_reset_password`, `reload_profile`, and the error handlers.
+
+**api** (`apps/api/routes.py`): `get_pods`, `get_lab_status`, `delete_lab`,
+`get_nodes`, `bulk_approve_users`, `get_lab_answers`, `save_lab_answers`,
+`save_grades_comments`, `join_group`, `check_lab_answer`, `feedback`,
+`add_user_like`, `del_user_like`, `extend_lab`, `list_kubernetes_templates`,
+`get_kubernetes_template`.
+
+### Mocking
+
+- Mail: reuse `no_mail_server` (fast path) and `mail_outbox` (captures
+  `auth_routes.mail.send`) fixtures.
+- k8s: `monkeypatch.setattr("apps.api.routes.k8s.<fn>", ...)` for the happy
+  paths only (`validate_token`, `get_pods_by_lab_id`, `get_resources_by_name`,
+  `delete_resources_by_name`, `get_nodes`). Permission/validation branches
+  return before any k8s call.
+- git templates: `monkeypatch.setattr("apps.api.routes.git.<fn>", ...)`
+  (`update_repo`, `list_files`, `get_file`).
+- OAuth: `monkeypatch.setattr(auth_routes.oauth.provider, "authorize_redirect", ...)`
+  (as `test_email_required.py` already does for `authorize_access_token`).
+
+Forms (no recaptcha; CSRF disabled via `WTF_CSRF_ENABLED=False`):
+`CreateAccountForm` needs `username,email,password,terms` (send `terms="y"`);
+`ConfirmAccountForm` needs `confirmation_token`; `ResetPasswordForm` needs
+`identifier`; `ResetPasswordConfirmForm` needs `password`+`password_confirm`
+(min 8, must match).
+
+---
+
+## File 1: `tests/test_auth_register.py`  (prefix `ar`)
+
+Covers `register`, `confirm_page`, `resend_code`.
+
+`register`:
+- GET -> 200 registration form.
+- POST invalid form (missing `terms`) -> 200 "Failed to validate form".
+- POST existing username -> "Username already registered".
+- POST existing email -> "Email already registered".
+- POST valid with `no_mail_server` -> 302 to login; a `Users` row exists
+  (username/email lower-cased, `issuer="LOCAL"`).
+- POST valid with `mail_outbox` -> 302 to `/confirm`; `len(outbox)==1`; user is
+  NOT yet created (`session['user']`/`confirmation_token` stashed instead).
+
+`confirm_page` (drive it right after the register token path, same client):
+- GET with no `confirmation_token` in session -> 302 to `/register`.
+- POST wrong token -> "Invalid token"; user still not created.
+- POST expired (`session['datetime']` set to >EXPIRY ago) -> "Token expired".
+- POST correct token -> 302 to login; `Users` row now created and session keys
+  popped.
+
+`resend_code`:
+- with no `user`/`token` in session -> 302 to `/confirm` (stashes error_msg).
+- with a live registration session + `mail_outbox` -> 302 to `/confirm`;
+  outbox grew by one.
+
+---
+
+## File 2: `tests/test_auth_session.py`  (prefix `as`)
+
+Covers `route_default`, `login` (uncovered branches), `login_oauth`,
+`reload_profile`, and the logout redirect. Seed one active user.
+
+- `route_default`: GET `/` -> 302 to `/login/`.
+- `login` GET unauthenticated -> 200 login form.
+- `login` POST bad password -> 200 "Wrong user or password"; a
+  `LoginLogging(success=False)` row is written.
+- `login` GET while already authenticated -> 302 to the home index.
+- `login_oauth`: GET `/login/oauth` with `oauth.provider.authorize_redirect`
+  monkeypatched to return a redirect -> 302.
+- `reload_profile`: logged-in GET `/profile/reload` -> 302 to `route_default`.
+- `logout`: logged-in GET `/logout` -> 302 to `/login/`; afterwards a
+  protected page redirects back to login (session cleared).
+- (optional) `unauthorized_handler`: GET a protected page while logged out ->
+  302 to login and `session['next_url']` is set.
+
+---
+
+## File 3: `tests/test_auth_password_reset.py`  (prefix `ap`)
+
+Covers `reset_password` and `confirm_reset_password`. Seed an active user and a
+soft-deleted user.
+
+`reset_password`:
+- POST invalid form (no `identifier`) -> 200 with validation error.
+- POST unknown identifier -> 200 generic "If the user provided is valid..."
+  message (no user enumeration), no mail sent.
+- POST valid identifier with `mail_outbox` -> 200 generic message; `len(outbox)==1`.
+
+`confirm_reset_password` (seed the cache token directly:
+`cache.set(f"resetpw-{token}", user_id, timeout=3600)`):
+- GET/POST with a token not in cache -> "Invalid or expired token".
+- POST valid token, mismatched passwords -> form error (passwords must match).
+- POST valid token, matching >=8-char passwords -> "Password changed
+  successfully"; the user can now log in with the new password and the old one
+  fails; the cache token is consumed.
+- POST valid token whose user is soft-deleted -> "Invalid password reset request".
+
+---
+
+## File 4: `tests/test_api_lab_answers.py`  (prefix `ae`)
+
+Covers `get_lab_answers`, `save_lab_answers`, `save_grades_comments`,
+`check_lab_answer`. Seed: admin, teacher (owner of a group), student (member),
+a Lab allowed to that group, a `LabInstance` owned by the student, a
+`LabAnswerSheet`, and `LabAnswers`.
+
+`get_lab_answers` (GET `/api/lab_answers/<lab_inst_id>`):
+- category `user` -> 404; missing instance -> 404; non-owner -> 401;
+  owner -> 200 with the answers dict.
+
+`save_lab_answers` (POST JSON `/api/lab_answers/<lab_inst_id>`):
+- `user` -> 404; empty body -> 400; missing instance -> 404; non-owner -> 401;
+  owner POST answers -> 200 and a `LabAnswers` row created/updated (verify
+  `answers_dict`); re-POST updates the same row.
+
+`save_grades_comments` (POST JSON `/api/lab_answers/grades_comments/<answer_id>`):
+- non-admin/teacher -> 401; missing answer -> 404; teacher who doesn't own the
+  group -> 401; admin empty body -> 400; admin grade out of range (e.g. 150)
+  -> 400 "Invalid grade"; admin valid -> 200 and `grades`/`comments` persisted.
+
+`check_lab_answer` (GET `/api/lab_answers/check/<lab_id>/<answer_id>`):
+- non-admin/teacher -> 401; unknown lab -> 401; lab not in a privileged group
+  -> 401; unknown answer -> 401; lab without a sheet -> 400; valid -> 200 with a
+  computed score string (reuse the scoring seeds from `test_lab_answers.py`).
+
+---
+
+## File 5: `tests/test_api_engagement.py`  (prefix `an`)
+
+Covers `feedback`, `add_user_like`, `del_user_like`, `join_group`,
+`extend_lab`, and `bulk_approve_users`. Seed: admin, teacher, an unapproved
+`user`-category account, a student, a group with an `accesstoken`, a
+`LabInstance` owned by the student.
+
+`feedback` (`/api/feedback`), `cache.delete("user_feedbacks")` first:
+- category `user` -> 401; GET -> 200 `recent_feedbacks`; POST without `stars`
+  -> 400; POST with stars -> 200 and a `UserFeedbacks` row (created then
+  updated on a second POST, no duplicate).
+
+`add_user_like` / `del_user_like` (`/api/user_like`), `cache.delete("user_likes")` first:
+- POST creates a `UserLikes` row and returns an incremented counter; POST again
+  (already liked) returns the counter unchanged; DELETE removes it and floors
+  the counter at 0.
+
+`join_group` (POST JSON `/api/groups/join/<group_id>`):
+- empty body -> 400; unknown group -> 404; SYSTEM group as non-admin -> 404;
+  wrong `accessToken` -> 400; correct token -> 200 and membership added;
+  re-join -> 200 "Already member of group".
+
+`extend_lab` (POST JSON `/api/lab/<lab_id>/extend`):
+- missing instance -> 404; non-owner non-admin -> 401; empty/`extend_hours`-less
+  body -> 400; out-of-range hours (0 or >720 or non-int) -> 400; valid ->
+  200 and `expiration_ts` updated.
+
+`bulk_approve_users` (POST JSON `/api/users/bulk-approve`):
+- non-admin/teacher -> 401; empty body -> 400; a non-`user` / invalid id in the
+  list -> 400 with the error list; a valid list of `user`-category ids -> 200
+  and those users flipped to `student`.
+
+---
+
+## File 6: `tests/test_api_k8s.py`  (prefix `ak`)
+
+Covers the k8s/git-backed endpoints, stubbing only the happy paths. Seed:
+admin, an unapproved `user`, a student, a `LabInstance` owned by the student.
+
+`get_pods` (GET `/api/pods/<lab_id>`):
+- `user` -> 404; no/blank Authorization header -> 400; token rejected
+  (`validate_token` -> False) -> 404; valid (`validate_token` -> True,
+  `get_pods_by_lab_id` -> [...]) -> 200.
+
+`get_lab_status` (GET `/api/lab/status/<lab_id>`):
+- `user` -> 404; missing instance -> 404; non-owner -> 401; owner with
+  `get_resources_by_name` -> [...] -> 200.
+
+`delete_lab` (DELETE `/api/lab/<lab_id>`):
+- `user` -> 404; missing instance -> 404; non-owner non-admin -> 401; owner with
+  `delete_resources_by_name` -> [] (empty resources) -> 200 and instance
+  `is_deleted`/`finish_reason` set.
+
+`get_nodes` (GET `/api/nodes`):
+- `user` -> 404; `get_nodes` -> [ {name,latitude,longitude,status} ] -> 200.
+
+`list_kubernetes_templates` (GET `/api/templates/list`, no auth required):
+- with `LAB_TEMPLATES_GIT_URL` unset (default) -> 200 `{"status":"not-defined"}`;
+  with it set + `git.update_repo`/`git.list_files` monkeypatched -> 200 list;
+  `git.list_files` raising -> 400.
+
+`get_kubernetes_template` (GET `/api/templates/<name>`):
+- non-admin/teacher -> "Unauthorized request"; admin with `git.get_file` ->
+  `(True, "yaml")` -> 200; `(False, "err")` -> 400.
+
+---
+
+## Files to create
+- `tests/test_auth_register.py`
+- `tests/test_auth_session.py`
+- `tests/test_auth_password_reset.py`
+- `tests/test_api_lab_answers.py`
+- `tests/test_api_engagement.py`
+- `tests/test_api_k8s.py`
+
+No production changes are expected. If any handler surfaces a real bug (as the
+`delete_group` `dict_keys` issue did earlier), stop and confirm the fix before
+asserting a happy path.
+
+## Verification
+```
+pip install -r requirements-dev.txt
+pytest tests/test_auth_register.py tests/test_auth_session.py \
+       tests/test_auth_password_reset.py tests/test_api_lab_answers.py \
+       tests/test_api_engagement.py tests/test_api_k8s.py -v
+pytest tests/ -v      # whole suite stays green
+pytest tests/ --cov=apps.authentication.routes --cov=apps.api.routes \
+       --cov-report=term-missing
+```

--- a/doc/test-coverage-clabernetes-plan.md
+++ b/doc/test-coverage-clabernetes-plan.md
@@ -1,0 +1,118 @@
+# Implementation plan: unit tests for `apps/controllers/clabernetes.py`
+
+## Context
+
+`apps/controllers/clabernetes.py` defines `C9sController`, the pure-logic helper
+that processes ContainerLab topologies and drives the external `clabverter`
+binary. It has **no coverage** - and unlike everything tested so far, every
+existing suite *stubs it out* because the module raises at **import time** if the
+`clabverter` binary is missing:
+
+```python
+CLABVERTER_BIN = "/usr/local/bin/clabverter"
+if not os.path.exists(CLABVERTER_BIN) or not os.access(CLABVERTER_BIN, os.X_OK):
+    raise ValueError("Missing executable 'clabverter'. ...")
+```
+
+The good news: the module imports only stdlib + `yaml` (no `apps.*`), and only
+`convert_clab` actually shells out to the binary (via `subprocess.run`, trivially
+mockable). Every other method is pure logic. So this is a **plain unit-test
+file** - no Flask app, no DB, no login/client harness - which makes it simpler
+than the route suites, just structured the same way (one ordered pytest file).
+
+### The one trick: import past the binary guard
+
+Load the module **directly from its file** with `importlib`, temporarily
+patching `os.path.exists`/`os.access` so the guard passes. Loading by path (not
+`from apps.controllers import ...`) sidesteps `apps/controllers/__init__.py`,
+which eagerly imports the real `K8sController`/`GitController` (kube config, etc.)
+and would defeat the isolation the other suites rely on:
+
+```python
+import importlib.util, os
+_PATH = os.path.join(REPO_ROOT, "apps", "controllers", "clabernetes.py")
+_real_exists, _real_access = os.path.exists, os.access
+os.path.exists = lambda p, *a: True if p == "/usr/local/bin/clabverter" else _real_exists(p, *a)
+os.access = lambda p, m, *a, **k: True if p == "/usr/local/bin/clabverter" else _real_access(p, m, *a, **k)
+try:
+    spec = importlib.util.spec_from_file_location("clabernetes_under_test", _PATH)
+    c9s_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(c9s_mod)
+finally:
+    os.path.exists, os.access = _real_exists, _real_access
+C9sController = c9s_mod.C9sController
+```
+
+This creates a standalone module (`clabernetes_under_test`) that never touches
+`sys.modules["apps.controllers.clabernetes"]`, so it can't interfere with the
+other files' stub, and needs nothing from the app. `subprocess` is mocked via
+`monkeypatch.setattr(c9s_mod.subprocess, "run", ...)`.
+
+## New file: `tests/test_clabernetes.py`
+
+A `c9s` fixture returns `C9sController()`. Uses pytest's built-in `tmp_path` for
+the filesystem-touching topology tests. No temp DB / client.
+
+### TestFilenameFromUploads (`filename_from_uploads`)
+- a path ending in `/<uploaded>` resolves to the bare uploaded name
+  (`"configs/r1.cfg"`, `["r1.cfg"]` -> `"r1.cfg"`).
+- no match -> the original string is returned unchanged.
+
+### TestCleanUpForClabGraph (`clean_up_for_clab_graph`)
+- a topology with `binds` under `defaults`, a `kind`, a `group` and a `node`
+  comes back with every `binds` key removed.
+- a minimal topology (only `nodes`, no defaults/kinds/groups) is handled without
+  KeyError.
+
+### TestCheckTopologySecrets (`check_topology_secrets`)
+- a known `imagePullSecrets` name on a node is rewritten to its mapped k8s name
+  and no failure is reported.
+- an unknown secret is left and produces a descriptive failure entry.
+- the same rewrite/failure logic is covered for `defaults` and `kinds` blocks.
+
+### TestProcessClabTopology (`process_clab_topology`, uses `tmp_path`)
+- **no `*.clab.y*ml` file** in the dir -> `(False, "No ContainerLab topology file...")`.
+- **two** clab files -> `(False, "Too many ContainerLab topology files...")`.
+- a file that is invalid YAML / missing `topology` / has zero nodes ->
+  `(False, "Failed to load ContainerLab topology...")`.
+- **happy path**: write a valid `test.clab.yaml` (a node with `ports`
+  `["8080:80", "53/udp"]`, a `startup-config`, a `binds` entry, and
+  `imagePullSecrets: ["myreg"]`) plus an uploaded `r1.cfg`; call with
+  `clab_uuid="abc"`, `secrets={"myreg": "clab-secret-x"}`. Assert:
+  - returns `(True, topology)`;
+  - `topology["name"] == "clab-abc"`;
+  - `topology["ports"] == {"<node>": {"80": "8080:80", "53": "53/udp"}}`;
+  - the node's `imagePullSecrets` became `["clab-secret-x"]`;
+  - `binds` was stripped from the returned topology (clean-up step);
+  - the original file was unlinked and `clab-abc.clab.yaml` now exists on disk.
+- **failed secrets**: same topology but `secrets={}` ->
+  `(False, "Failed to find imagePullSecrets...")`.
+
+### TestConvertClab (`convert_clab`, `subprocess.run` mocked)
+- success: mock `run` to return an object whose `stdout` is a multi-doc YAML
+  string containing a `kind: Namespace` doc among others -> `(True, manifest)`
+  where the Namespace doc has been removed and the rest re-joined with `---\n`.
+- no Namespace doc in the output -> `(False, "could not find Namespace component")`.
+- `subprocess.CalledProcessError` (with `.stderr`) -> `(False, "Convert ContainerLab failed: ...")`.
+- any other exception from `run` -> `(False, "Convert ContainerLab failed: ...")`.
+
+### TestVisualizerManifest (`get_topology_visualizer_manifest`)
+- `%CLAB_UUID%` is substituted throughout; the result contains the Deployment,
+  Service and a ConfigMap whose `topology-data.yaml` embeds the dumped topology;
+  the three docs are joined with `---\n`.
+
+## Files to create
+- `tests/test_clabernetes.py`
+
+No production changes expected. If a method turns out to misbehave on a valid
+input (e.g. the `PORT_RE` edge cases in the docstring), stop and confirm before
+asserting around it.
+
+## Verification
+```
+pip install -r requirements-dev.txt
+pytest tests/test_clabernetes.py -v
+pytest tests/ -v          # whole suite stays green (this file is self-contained
+                          # and does not disturb the shared clabernetes stub)
+pytest tests/ --cov=apps.controllers.clabernetes --cov-report=term-missing
+```

--- a/doc/test-coverage-clabs-plan.md
+++ b/doc/test-coverage-clabs-plan.md
@@ -1,0 +1,137 @@
+# Implementation plan: raise unit-test coverage of `apps/clabs/routes.py`
+
+## Context
+
+`apps/clabs/routes.py` is a single blueprint with one substantial route:
+`upsert` (GET/POST `/clabs/upsert/` and `/clabs/upsert/<clab_id>`) - the
+create/edit form for **ContainerLabs** (`Labs` rows with `is_clab=True`, backed
+by a `LabMetadata` record). It has no test coverage. This plan adds one pytest
+file, `tests/test_clabs.py`, following the established approach (session-scoped
+temp SQLite DB, `clabernetes` import stub, ordered/stateful classes, unique
+username prefix `cl`, `login`/`logout` helpers).
+
+### How `upsert` breaks down (for test design)
+
+Most branches never touch Kubernetes/clabernetes and are trivially testable:
+load/permission gating, category handling, and the **manifest-only** save. The
+`c9s` (clabernetes) and `k8s` controllers are only reached when files are
+uploaded or registry secrets are edited - and both are lazy proxies
+(`c9s = _LazyProxy(lambda: C9sController())`), currently pointed at the
+`_StubC9sController` that raises on any attribute. So:
+
+- **No-c9s/no-k8s paths** (gating, validation, manifest-only create/edit): no
+  mocking needed - the stub is never called.
+- **Secret editing**: replace the module-level name
+  `apps.clabs.routes.k8s` with a small fake exposing `create_registry_secret`
+  / `delete_secret_by_name` (setattr on the string path). For a brand-new clab
+  `md` has no `topology`, so the `check_topology_secrets` branch is skipped and
+  this path saves without `c9s`.
+- **File upload / topology conversion**: replace `apps.clabs.routes.c9s` with a
+  fake exposing `process_clab_topology` / `convert_clab` /
+  `check_topology_secrets`. Files are written under the temp `CLABS_DIR`.
+
+Confirmed helpers/config: `apps.utils.list_files` returns an empty set for a
+non-existent dir (safe on new clabs); `CLABS_DIR` is under the temp `DATA_DIR`;
+`CLABS_UPLOAD_MAX_FILES` defaults to 200; the template renders `clab.extended_desc_str|default('',true)`
+(Jinja swallows the property's `AttributeError` on an empty clab, so GET-new
+renders).
+
+## Production fix (required for the "too many files" test)
+
+`apps/clabs/routes.py:137` builds the error string with an **undefined
+variable** `files_count`:
+```python
+"result": f"Too many files: {files_count} (max {max_files})"
+```
+`files_count` is never assigned, so the moment more than `CLABS_UPLOAD_MAX_FILES`
+files are posted this raises `NameError` (HTTP 500) instead of the intended
+400. Fix: use `len(files)` (the variable already in scope):
+```python
+"result": f"Too many files: {len(files)} (max {max_files})"
+```
+The too-many-files test depends on this fix; the rest of the suite does not.
+
+## New file: `tests/test_clabs.py`  (prefix `cl`)
+
+Seed: `cladmin` (admin), `clcreator`/`clcreator2` (labcreator), `clstudent`
+(student); one generic `LabCategories` `clcat` (NOT named "ContainerLab", so the
+category-required branch is reachable); one plain non-clab `Labs` (no metadata);
+one existing clab (`Labs` + `LabMetadata(is_clab=True)`, `updated_by=cladmin`).
+A `clab_form(**overrides)` helper builds the full POST body
+(`clab_title, clab_desc, clab_extended_desc, clab_guide, clab_yaml, clab_goals`,
+plus `clab_categories`/`clab_allowed_groups` lists).
+
+### TestRoleGating
+- student GET `/clabs/upsert/new` -> "Unauthorized request".
+
+### TestLoadAndPermissions
+- unknown `clab_id` -> "ContainerLab not found".
+- a non-clab lab id -> 302 redirect to `home_blueprint.edit_lab` (`/labs/edit/<id>`).
+- labcreator opening another user's clab (`updated_by != self`) -> "Unauthorized access".
+- **no categories exist**: temporarily flip every active `LabCategories` to
+  `is_deleted=True` (other modules share this DB), GET new -> "No Lab Categories
+  found", then restore in a `finally` (same technique as
+  `tests/test_labs.py::TestNoCategoriesGuard`).
+
+### TestGetForm
+- admin GET `/clabs/upsert/new` -> 200 (form renders with `clcat`).
+
+### TestCreate (manifest-only; no c9s/k8s)
+- POST with a category but no manifest/giturl/files -> 400 "Provide GIT URL or files".
+- POST with a manifest but no category selected (and no "ContainerLab" category
+  present) -> "Please select at least one category".
+- POST valid (manifest + `clab_categories=[clcat]`) -> 201 "ContainerLab saved
+  with success"; the created `Labs` row has `is_clab` True, `manifest` set, and a
+  `HomeLogging(action="upsert_clab", success=True)` row exists. Capture the id.
+
+### TestEditExisting (reuses the id created above)
+- GET the created clab -> 200.
+- POST editing the title -> 201; verify the DB change.
+
+### TestSecrets (k8s replaced with a fake)
+- `monkeypatch.setattr("apps.clabs.routes.k8s", fake_k8s)` where
+  `create_registry_secret -> (True, "")` and `delete_secret_by_name -> None`.
+- POST create with `secret-name/secret-server/secret-user/secret-pass` + a
+  category + manifest -> 201; the clab's `lab_metadata.md["secrets"]["name"]`
+  contains the new secret name.
+
+### TestFileUpload (c9s replaced with a fake)
+- `monkeypatch.setattr("apps.clabs.routes.c9s", fake_c9s)` where
+  `process_clab_topology -> (True, {"ports": {}, "nodes": {}})` and
+  `convert_clab -> (True, "converted-manifest")`.
+- POST create with `clab_files=(BytesIO(b"..."), "topo.yaml")` +
+  `relative_paths="topo.yaml"` + a category -> 201; `clab.manifest` becomes
+  "converted-manifest".
+- `process_clab_topology -> (False, "bad topo")` -> 400 (and the temp dir is
+  cleaned up).
+- `process -> (True, {...})`, `convert_clab -> (False, "convert err")` -> 400.
+
+### TestTooManyFiles (depends on the production fix above)
+- `monkeypatch.setitem(flask_app.config, "CLABS_UPLOAD_MAX_FILES", 1)`, POST two
+  files -> 400 "Too many files".
+
+### TestAutoAppendContainerLabCategory (last - it seeds a "ContainerLab" category)
+- seed a `LabCategories(category="ContainerLab")`; POST new with a manifest and
+  **no** `clab_categories` selected -> 201; the saved clab has the "ContainerLab"
+  category auto-attached. (Runs last so it doesn't disturb the category-required
+  test.)
+
+## Notes
+- Unique `cl` username prefix + unique category/lab names to avoid collisions in
+  the shared singleton DB; `app` fixture does `create_all()` only (no `drop_all`).
+- Fakes for `c9s`/`k8s` are plain objects/`types.SimpleNamespace` assigned over
+  the whole module-level name (they're lazy proxies, so patching individual
+  attributes is less reliable than replacing the reference).
+- Files/dirs land under the temp `CLABS_DIR`; nothing touches real infra.
+
+## Files to create / modify
+- **Fix**: `apps/clabs/routes.py:137` (`files_count` -> `len(files)`).
+- **New**: `tests/test_clabs.py`.
+
+## Verification
+```
+pip install -r requirements-dev.txt
+pytest tests/test_clabs.py -v
+pytest tests/ -v          # whole suite stays green
+pytest tests/ --cov=apps.clabs.routes --cov-report=term-missing
+```

--- a/doc/test-coverage-events-plan.md
+++ b/doc/test-coverage-events-plan.md
@@ -1,0 +1,94 @@
+# Implementation plan: unit tests for `apps/events.py`
+
+## Context
+
+`apps/events.py` implements the xterm/PTY terminal streaming over Socket.IO: a
+few standalone helpers plus four `@socketio.on(..., namespace="/pty")` event
+handlers (`pty_connect`, `pty_input`, `resize`, `pty_disconnect`) and two
+forwarding loops. It has no coverage.
+
+The app runs Socket.IO with `async_mode='gevent'` and the handlers do PTY/stream
+I/O and spawn background tasks - so driving them through a real
+`socketio.test_client` would be slow and flaky (greenlets, blocking read loops).
+The stable approach is to **call the functions directly** with their
+dependencies mocked, using plain Flask app/request contexts. This needs no DB.
+
+### Key techniques
+
+- Import the module as `import apps.events as events` (it is already loaded by
+  `create_app`, so this returns the cached module with handlers registered).
+- **Bypass `@login_required`** on the handlers by setting
+  `flask_app.config["LOGIN_DISABLED"] = True`, and give the handlers a user by
+  monkeypatching the module global `events.current_user` to a
+  `SimpleNamespace(username="tester")`.
+- **`request.sid`**: handlers read `request.sid` (set by Flask-SocketIO at
+  runtime). In tests, enter `flask_app.test_request_context(<path>)` and assign
+  `request.sid = "sid1"` (and use the query string for `pty_connect`'s `host`).
+- **Mock the boundaries** by monkeypatching module globals:
+  `events.k8s.get_pod_exec_stream`, `events.socketio.emit`,
+  `events.socketio.sleep` (-> no-op, so the loops don't actually sleep),
+  `events.socketio.start_background_task` (-> capture, so no greenlet spawns),
+  and `events.os` / `events.select` for the PTY loop.
+- The module-level `events.xterm_clients` dict is cleared before each test (an
+  autouse fixture) so sessions don't leak between tests.
+
+## New file: `tests/test_events.py`
+
+Harness = clabernetes stub + `from run import app` (for the socketio/k8s wiring
+and `current_app`). No database. Most handler tests run inside a
+`test_request_context` with `request.sid` set and `LOGIN_DISABLED` on.
+
+### TestHelpers (direct, no socket context)
+- `check_authorization(...)` -> always True.
+- `resize_terminal`: a fake stream -> asserts
+  `stream.write_channel(4, '{"Width":80,"Height":24}')`.
+- `set_winsize`: open a real pty with `os.openpty()`, call
+  `set_winsize(slave_fd, 24, 80)` -> no error (optionally read back the winsize
+  via `termios`); close the fds.
+- `read_and_forward_k8s_stream_output`: a fake `client_stream` whose `is_open()`
+  yields `[True, True, False]` and `read_stdout` returns `"hello"`; with
+  `socketio.emit` captured and `socketio.sleep` no-op -> emits one
+  `pty-output {"output": "hello"}` then a final `server-disconnected`.
+- `read_and_forward_pty_output`: monkeypatch `events.select.select`
+  (`[([fd],[],[]), ([],[],[fd])]` -> one read then an exception-break),
+  `events.os.read` (-> `b"hello"`), `events.os.waitpid` (-> `(pid, 0)`),
+  `events.os.waitstatus_to_exitcode` (-> 0), `socketio.emit`/`sleep` -> emits the
+  output chunk and then `server-disconnected` with `returncode 0`.
+
+### TestPtyConnect (`test_request_context` + query string)
+- invalid `host` (missing / not `a/b/c`) -> returns `False`, nothing added to
+  `xterm_clients`.
+- happy path `host="pod/mypod/mycont"`: `k8s.get_pod_exec_stream` mocked to a
+  fake stream, `start_background_task` captured -> `xterm_clients[sid]` is the
+  stream and the background task was scheduled with it.
+- `kind="clab"`: `host="clab/mypod/mycont"` -> `get_pod_exec_stream` is called
+  with `start_script == "ssh mycont"` (and kind coerced to pod).
+- already-connected sid -> returns `False` (no overwrite).
+
+### TestPtyInput / TestResize / TestPtyDisconnect
+- **not connected** (sid absent from `xterm_clients`) -> each returns `False`.
+- `pty_input` connected: fake stream `is_open() == True` -> `write_stdin` called
+  with the encoded input.
+- `resize` connected: -> `resize_terminal` reaches the stream's `write_channel`.
+- `pty_disconnect` connected: -> `stream.close()` called and the sid removed
+  from `xterm_clients`; and a variant where `close()` raises -> the error is
+  swallowed/logged and the sid is still removed.
+
+## Note (not a required fix)
+
+`check_authorization` is a stub that always returns `True` (auth is effectively
+open on the PTY namespace). That is existing behaviour; flagging it for
+awareness, not changing it here.
+
+## Files to create
+- `tests/test_events.py`
+
+No production changes expected.
+
+## Verification
+```
+pip install -r requirements-dev.txt
+pytest tests/test_events.py -v
+pytest tests/ -v          # whole suite stays green
+pytest tests/ --cov=apps.events --cov-report=term-missing
+```

--- a/doc/test-coverage-git-k8s-utils-plan.md
+++ b/doc/test-coverage-git-k8s-utils-plan.md
@@ -1,0 +1,161 @@
+# Implementation plan: unit tests for git.py, kubernetes.py, k8s/routes.py, utils.py
+
+## Context
+
+Four low-coverage modules, tackled with four new test files following the
+established conventions (harness boilerplate, ordered classes, `login`/`logout`
+where a client is needed, monkeypatch for external systems):
+
+| Module | New file | Harness needed? |
+|---|---|---|
+| `apps/controllers/git.py` | `tests/test_git_controller.py` | app (for `current_app`) |
+| `apps/controllers/kubernetes.py` | `tests/test_k8s_controller.py` | app (for `current_app`/`app_config`) |
+| `apps/k8s/routes.py` | `tests/test_k8s_routes.py` | full (app + DB + login) |
+| `apps/utils.py` | `tests/test_utils.py` | full (app + DB) |
+
+All four import cleanly under the standard harness (install the `clabernetes`
+sys.modules stub, then `from run import app`); none needs the direct-file-load
+trick used for `clabernetes` itself. External systems are mocked: GitPython for
+`git.py`, the kubernetes client for `kubernetes.py`, and the controller methods
+behind `apps.k8s.routes.k8s` for the routes.
+
+## Production fixes (recommended)
+
+`apps/utils.py:259` `remove_empty_folders` is **dead code with a `NameError`**:
+```python
+folders = list(os.walk(mydir))[1:]   # 'mydir' is undefined; the param is 'folder'
+```
+It is called nowhere in the codebase. Recommendation: fix `mydir` -> `folder`
+(one line) so it can be covered, or delete the function outright. Default in this
+plan: **fix + test** (consistent with the earlier `files_count`/`delete_group`
+fixes). Flagging for a decision.
+
+(Note: `format_duration` annotates a local as `output: List[str]` without
+importing `List`, but local annotations are not evaluated at runtime, so it is
+harmless - no fix needed.)
+
+## File 1: `tests/test_git_controller.py`
+
+Import `GitController` from `apps.controllers.git` (after the stub + app import).
+Mock the `git` module the controller uses via `monkeypatch.setattr` on
+`apps.controllers.git.git.*`. Runs inside `flask_app.app_context()` so
+`current_app.logger` works in the error branches; `tmp_path` for the filesystem.
+
+`update_repo`:
+- refresh-interval short-circuit: two quick calls with a large `refresh_interval`
+  -> the second returns True without invoking git (assert the mocked clone/pull
+  was called at most once).
+- clone path (target dir absent): `git.Repo.clone_from` mocked -> True, and it
+  was called.
+- pull path (target dir present): `git.Repo` mocked so `repo.remotes.origin.pull`
+  is a mock -> True, pull called.
+- `git.GitCommandError` raised -> False.
+- generic `Exception` raised -> False.
+
+`list_files`: create files under `tmp_path`, assert the glob pattern returns them.
+
+`get_file`:
+- missing file -> `(False, "Template not found")`.
+- existing file -> `(True, <contents>)`.
+- read error (e.g. monkeypatch `Path.read_text` to raise) -> `(False, "Failed to read template file...")`.
+
+## File 2: `tests/test_k8s_controller.py`
+
+A `k8s_ctrl` fixture builds a fully-initialised controller without a real
+cluster: set `app_config.K8S_NAMESPACE` to a dummy, and monkeypatch
+`apps.controllers.kubernetes.config.load_kube_config` plus `client.CoreV1Api` /
+`AppsV1Api` / `ApiClient` to return `MagicMock`s, then instantiate
+`K8sController()` (so `self.identifiers`, `self.nodes`, `self.v1_api`, etc. are
+all wired). Individual tests set return values / side effects on
+`ctrl.v1_api` / `ctrl.apps_v1_api`.
+
+Pure logic (no client):
+- `try_get_app`: `""` -> `"http://"`; `"https-web"` -> `"https://"`; unknown -> `"http://"`.
+- `humanbytes`: bytes/KB/MB/GB boundaries render the expected suffixes.
+- `validate_token` -> always True; `get_pods_by_lab_id` -> `[]`.
+- `get_pod_hash`: honours an explicit `pod_hash`, else returns a 14-char hex.
+- `get_allowed_nodes` / `choose_one_node`: `dry_run` and explicit `allowed_nodes`
+  branches (deterministic, no cluster).
+- `get_allowed_nodes_str`: comma-joins the above.
+- `get_identifier_func`: known key, regex-matched key, and unknown -> None.
+- `substitute_identifiers`: a manifest with `${pod_hash}` (dry-run) substitutes;
+  an unknown `${bogus}` placeholder -> `(False, "Invalid placeholder bogus")`.
+
+Client-backed (v1_api / apps_v1_api mocked):
+- `create_registry_secret`: success -> `(True, ...)`; `create_namespaced_secret`
+  raising -> `(False, "Failed to create secret...")`.
+- `get_pod_by_name` / `get_service_by_name` / `get_deployment_by_name` /
+  `get_config_map_by_name`: mock the read call to return an object with a
+  `to_dict()` and status; assert the `is_ok` flag logic (e.g. pod phase
+  "Running" -> True).
+- `delete_pod_by_name` (+ service/deployment/config_map/secret): success -> True;
+  the delete call raising -> False. `delete_secret_by_name` accepts both a dict
+  and a bare string.
+- `get_resources_by_name` / `delete_resources_by_name`: dispatch by `kind`
+  (Pod/Service/Deployment/ConfigMap/Secret/other) hits the right helper.
+- `update_nodes` + `get_nodes` + `get_node_ip`: mock `v1_api.list_node()` to
+  return fake nodes (with `status.conditions`/`addresses`); assert ready-node
+  filtering (respecting `k8s_avoid_nodes`), the `get_nodes` dict shape, and
+  `get_node_ip` returning the InternalIP (or None for an unknown node). Reset
+  `ctrl.nodes_last_updated = 0` so the 60s cache doesn't skip the refresh.
+
+(The heavy `create_lab` / `get_lab_resources` / `get_statistics` / `list_pods`
+paths are out of scope - they orchestrate many client calls and are better left
+for a later pass; this file targets the pure + thinly-wrapped methods.)
+
+## File 3: `tests/test_k8s_routes.py`
+
+Full harness + `login` helper. The k8s blueprint is a core (non-optional)
+blueprint at prefix `/k8s`. Seed an admin and a non-admin. Monkeypatch
+`apps.k8s.routes.k8s.list_pods` / `list_deployments` / `list_services`.
+
+For each of `/k8s/pods`, `/k8s/deployments`, `/k8s/services`:
+- non-admin (e.g. teacher) -> "Unauthorized request".
+- admin, controller returns a small list -> 200 and the page renders.
+- admin, controller raises -> still 200 (the handler swallows the error and
+  renders with an empty list).
+
+## File 4: `tests/test_utils.py`
+
+Full harness (DB) inside `flask_app.app_context()`.
+
+Pure functions (no DB):
+- `utcnow`: timezone-aware, ~now.
+- `parse_lab_expiration`: `"0"` -> None; `"4"` -> an int ~4h in the future.
+- `datetime_from_ts`: a valid ts -> ISO string; a bad input -> None.
+- `secure_filename`: the docstring cases (`"My cool movie.mov"` ->
+  `"My_cool_movie.mov"`, `"../../../etc/passwd"` -> `"etc/passwd"`, umlauts, etc.).
+- `format_duration`: `timedelta(0)` -> `"0s"`; negative -> `"--"`; a
+  minutes+seconds delta; a multi-day delta (>6 days truncates).
+- `list_files`: files under `tmp_path`, with and without `ignore_prefix`.
+- `remove_empty_folders` (after the fix): removes an empty subdir, leaves a
+  non-empty one.
+
+DB-backed functions (seed rows, prefix `ut`):
+- `check_pre_approved`: a non-`user` account -> returns None, unchanged; a
+  `user` in a non-SYSTEM group -> promoted to `student` (returns True); a `user`
+  whose email is in a group's `approved_users` -> promoted and added to the
+  group; a `user` only in a SYSTEM group -> not promoted by that group.
+- `update_running_labs_stats`: with seeded non-deleted `LabInstances`, sets
+  `g.running_labs` and populates the `running_labs-<id>` cache key
+  (`cache.delete` first to avoid cross-module leakage).
+- `update_category_stats`: seed categories + a lab attached to one -> the
+  returned dict's `category_names`/`usage_counts` reflect the seeded data.
+- `update_stats_lab_instances_answers`: seed a couple of finished
+  `LabInstances` and `LabAnswers` -> `months`/`labs`/`answers` totals are shaped
+  correctly (6 months, totals add up).
+
+## Files to create / modify
+- **Fix**: `apps/utils.py:259` (`mydir` -> `folder`) — or drop the dead function.
+- **New**: `tests/test_git_controller.py`, `tests/test_k8s_controller.py`,
+  `tests/test_k8s_routes.py`, `tests/test_utils.py`.
+
+## Verification
+```
+pip install -r requirements-dev.txt
+pytest tests/test_git_controller.py tests/test_k8s_controller.py \
+       tests/test_k8s_routes.py tests/test_utils.py -v
+pytest tests/ -v      # whole suite stays green
+pytest tests/ --cov=apps.controllers.git --cov=apps.controllers.kubernetes \
+       --cov=apps.k8s.routes --cov=apps.utils --cov-report=term-missing
+```

--- a/doc/test-coverage-home-routes-plan.md
+++ b/doc/test-coverage-home-routes-plan.md
@@ -1,0 +1,205 @@
+# Implementation plan: raise unit-test coverage of `apps/home/routes.py`
+
+## Context
+
+`apps/home/routes.py` has ~28 routes. The existing suites cover only the CRUD
+routes for users, groups, labs, and lab-categories. Eighteen routes and seven
+models (`LabInstances`, `LabAnswers`, `LabAnswerSheet`, `LabMetadata`,
+`UserFeedbacks`, `UserLikes`, `HomeLogging`) have no direct coverage. This plan
+adds four new pytest files that follow the exact same approach as
+`tests/test_lab_categories.py` / `tests/test_labs.py`: session-scoped temp
+SQLite DB, the `clabernetes` import stub, ordered/stateful test classes, and
+`login`/`logout` helpers.
+
+Reuse verbatim (per file) the harness boilerplate from
+`tests/test_labs.py` lines 29-128: temp `DATA_DIR`, the `apps.controllers.clabernetes`
+sys.modules stub, `flask_app` import + `TESTING`/`WTF_CSRF_ENABLED`, the
+`_cleanup_temp_data_dir`/`app`/`client` fixtures (app fixture does
+`create_all()` only, no `drop_all`), and `login`/`logout`.
+
+### Cross-file isolation (critical)
+
+All test modules share ONE singleton app/DB (`apps/config.py` reads `DATA_DIR`
+once at first import). So every new file must use a **unique username prefix**
+and unique group/lab/category names, exactly like the existing files
+(`us`/`gr`/`lb`). Proposed prefixes: `li` (instances), `la` (answers),
+`up` (uploads), `mp` (misc pages).
+
+### k8s handling
+
+Routes reference the imported module object as `k8s` (`from apps.controllers
+import k8s, c9s`). Stub only the happy paths by monkeypatching that object,
+e.g. `monkeypatch.setattr("apps.home.routes.k8s.create_lab", lambda *a, **k: (True, []))`.
+Permission/not-found/validation branches return *before* any k8s call and need
+no stub. Use the function-scoped `monkeypatch` fixture inside the specific test
+method (works fine inside an ordered class).
+
+Model seeding notes (from `apps/home/models.py`):
+- `LabInstances(user_id=, lab_id=, is_deleted=, expiration_ts=)`; set
+  `inst.k8s_resources = []` (setter JSON-encodes) so status templates render.
+- `LabAnswers(user_id=, lab_id=)` then `.answers = json.dumps({...})`,
+  `.grades = json.dumps({...})`.
+- `LabAnswerSheet()` then `.lab_id = ...; .set_answers({q: a})`.
+- `LabMetadata(lab=lab, is_clab=False)` then `lab_md.md = {"uploads": [...]}`.
+- `UserFeedbacks(user_id=, stars=, comment=, is_hidden=)`.
+- `UserLikes(user_id=)`.
+- Labs seeded directly are fine here (these routes don't render
+  `extended_desc_str`), but for `view_labs`-style rendering create via route.
+
+---
+
+## File 1: `tests/test_lab_instances.py`  (prefix `li`)
+
+Seed: admin, teacher, student, labcreator; a Lab; a group the student owns/
+assists (for the privileged-group visibility branch); LabInstances rows.
+
+`running_labs` (`/running/`):
+- student login, GET `/running/` -> 200; only their own non-deleted instances.
+- `filter_group=<gid>` with a group the user can't see / bad id -> "Group not found"
+  when group missing/deleted; admin sees SYSTEM-excluded groups list.
+- privileged (owner/assistant) user sees instances of labs allowed to their group.
+
+`run_lab` (`/run_lab/<id>`):
+- GET missing lab -> "Lab not found".
+- GET valid lab -> 200 renders run form; admin sees the extra "Never expires" option.
+- GET when an instance already runs -> 302 redirect to `view_lab_instance`.
+- POST invalid `lab_expiration` -> "Invalid lab duration/expiration".
+- POST valid, `k8s.create_lab` monkeypatched to `(True, [])` -> renders
+  run_lab_status; a `LabInstances` row + `HomeLogging` create_lab row exist.
+- POST valid, `k8s.create_lab` -> `(False, "boom")` -> "Error Running Labs" +
+  a `HomeLogging` success=False row.
+
+`check_lab_status` (`/lab_status/<id>`):
+- missing -> "Lab not found"; other user's instance -> "not authorized";
+  owner -> 200 (seed instance with `k8s_resources = []`).
+
+`xterm` (`/xterm/<id>/<kind>/<pod>/<container>`):
+- missing -> "Lab not found"; student/labcreator on another's instance ->
+  "not authorized"; owner -> 200 with host string in body.
+
+`view_lab_instance` (`/lab_instance/view/<id>`):
+- missing / deleted instance -> error; instance of unknown lab -> error;
+  non-owner non-admin without privileged group -> "Not authorized".
+- owner happy path: monkeypatch `k8s.get_lab_resources` -> `[]` -> 200 renders view.
+
+`cancel_restart_lab_instance` (`/lab_instance/cancel/<id>`):
+- missing/deleted -> error; non-owner non-admin -> "Not authorized".
+- owner: monkeypatch `k8s.delete_resources_by_name` -> `[1]* len` -> 302 redirect
+  to run_lab; instance `is_deleted` True.
+
+`view_finished_labs` (`/finished_labs`):
+- student sees only their own `is_deleted=True` instances; bad `filter_group`
+  -> "Group not found"; admin/group-filter visibility branch.
+
+---
+
+## File 2: `tests/test_lab_answers.py`  (prefix `la`)
+
+Covers the `LabAnswers` / `LabAnswerSheet` models via `list_lab_answers` and
+`add_answer_sheet`. Seed: admin, teacher (owner of a group), student (member);
+a Lab allowed to that group; `LabAnswers` rows for the student; a
+`LabAnswerSheet`.
+
+`list_lab_answers` (`/lab_answers/list`):
+- student rejected (decorator admin/teacher) -> "Unauthorized request".
+- admin GET -> 200; lists the seeded answer with a computed `score`.
+- `filter_lab=<unknown>` -> "Invalid Lab provided for filtering."
+- `filter_group=<not-visible>` -> "Invalid Group provided for filtering."
+- `check_answer_sheet=1` without `filter_lab` -> "must provide a Lab".
+- `check_answer_sheet=1` + `filter_lab` with no sheet -> "No Lab Answer Sheet".
+- scoring: seed a sheet answer + a matching student answer, assert score "100.00";
+  a grade value (numeric) is honored over regex match.
+- teacher sees only answers for labs in their privileged groups (non-admin branch).
+
+`add_answer_sheet` (`/lab_answers/answer_sheet/`):
+- GET no `lab_id` -> 200 lab picker.
+- GET `lab_id` not in labs -> "Invalid Lab provided."
+- GET valid `lab_id` -> 200, pre-fills existing answers.
+- POST `question`/`answer` lists -> creates a new `LabAnswerSheet`, "saved!";
+  verify `sheet.answers_dict`.
+- POST again editing -> updates the same sheet (no duplicate row).
+
+---
+
+## File 3: `tests/test_lab_uploads.py`  (prefix `up`)
+
+Covers `LabMetadata` + the upload endpoints. Seed: admin, teacher, labcreator
+(as `updated_by` on an owned Lab), a second labcreator (non-owner); two Labs
+(one owned by the labcreator). Uses the real temp `UPLOAD_DIR` (under the temp
+`DATA_DIR`).
+
+`upload_lab_file` (POST `/labs/upload-file`, multipart):
+- student rejected by decorator.
+- no `file` part -> 400 "No file part".
+- empty filename -> 400 "No file selected".
+- disallowed extension (e.g. `.exe`) -> 400 "File extension not allowed".
+- oversize (monkeypatch `LAB_UPLOAD_MAX_SIZE` low, or post >limit bytes) -> 400.
+- valid `.txt` upload, no `lab_id` -> 200 JSON with `saved_filename`; file exists
+  on disk in `UPLOAD_DIR`.
+- valid upload with `lab_id=<owned lab>` -> metadata persisted:
+  `lab.lab_metadata.md["uploads"]` contains the entry.
+
+`serve_upload` (GET `/uploads/<filename>`):
+- after an upload, GET the returned URL -> 200 and body matches file contents;
+  unknown filename -> 404.
+
+`get_lab_uploads` (GET `/labs/<id>/uploads`):
+- missing lab -> 404; labcreator on another's lab -> 403 "Unauthorized";
+  owner/admin -> 200 with the uploads list.
+
+`delete_lab_upload` (DELETE `/labs/<id>/uploads/<filename>`):
+- missing lab -> 404; labcreator non-owner -> 403; lab without metadata -> 404
+  "No uploads found"; filename not in list -> 404; valid -> 200 `{"status":"ok"}`,
+  entry removed from `lab.lab_metadata.md["uploads"]`. The handler also
+  `os.remove`s the file but tolerates a missing one (FileNotFoundError is
+  logged, not fatal), so the happy-path test needn't put a real file on disk.
+
+---
+
+## File 4: `tests/test_misc_pages.py`  (prefix `mp`)
+
+Covers the remaining simple/feedback routes and `UserFeedbacks`/`UserLikes`.
+Seed: admin, teacher, student; a couple of `UserFeedbacks` (one hidden).
+
+Static GETs (login-required only):
+- `/gallery`, `/documentation`, `/contact`, `/finished-lab-infos/<id>` -> 200
+  for any logged-in user; anonymous -> redirect to `/login/`.
+
+`index` (`/index`):
+- logged-in GET -> 200 (k8s.get_statistics failure is swallowed; assert it
+  renders). Seed a `UserLikes` for the user and assert `has_liked` path works.
+- feedback modal: with no `UserFeedbacks` for the user and an old
+  `created_at`, `show_feedback_modal` becomes True (assert via rendered marker
+  or by seeding/reading cache); with an existing feedback it stays False.
+
+`feedback_view` (`/feedback_view`):
+- admin sees hidden + visible feedbacks; non-admin sees only non-hidden
+  (assert the hidden comment string is absent for the student).
+
+`hide_feedback` (POST `/feedback/hide`, admin-only):
+- non-admin -> "Unauthorized request".
+- admin missing `feedback_id` or bad `action` -> 302 redirect, no change.
+- admin `action=hide` -> feedback `is_hidden` True; `action=unhide` -> False.
+
+---
+
+## Files to create
+- `tests/test_lab_instances.py`
+- `tests/test_lab_answers.py`
+- `tests/test_lab_uploads.py`
+- `tests/test_misc_pages.py`
+
+No production changes expected. If any handler surfaces a real bug (as the
+group-delete `dict_keys` issue did earlier), stop and confirm the fix before
+asserting a happy path.
+
+## Verification
+```
+pip install -r requirements-dev.txt
+pytest tests/test_lab_instances.py tests/test_lab_answers.py \
+       tests/test_lab_uploads.py tests/test_misc_pages.py -v
+pytest tests/ -v          # whole suite must stay green (unique prefixes prevent
+                          # cross-file username/name collisions in the shared DB)
+```
+Optionally measure the delta with `pytest --cov=apps.home.routes tests/`
+(requires `pytest-cov`, not currently in requirements-dev.txt).

--- a/doc/test-coverage-lab-schedule-plan.md
+++ b/doc/test-coverage-lab-schedule-plan.md
@@ -1,0 +1,97 @@
+# Implementation plan: unit tests for `apps/cli/lab_schedule.py`
+
+## Context
+
+`apps/cli/lab_schedule.py` holds the two scheduled-job helpers (invoked from
+`apps/cli/routes.py` as CLI commands) with no coverage:
+
+- `alert_expiring_labs(app, send_email=False)` - finds non-deleted lab
+  instances expiring within `LAB_EXPIRATION_WARN_SEC` (48h) and, when
+  `send_email` is set, emails each owner that has an address.
+- `run_delete_expired_labs(app)` - finds instances already past
+  `LAB_EXPIRATION_TOLERANACE_SEC` (48h) beyond expiry, deletes their k8s
+  resources and soft-deletes them.
+
+Both take the Flask `app`, query models via the global session (so tests push
+an app context and pass `flask_app`), and lean on external systems that are
+easily mocked: `Mail`/`Message` for e-mail and `k8s.delete_resources_by_name`
+for teardown. The mail template `mail/lab_expiration_alert.html` only references
+`config.BASE_URL`/`user`/`lab`/`end_time` (no `url_for`/`current_user`/request),
+so `render_template` works inside a plain app context.
+
+### Shared-DB isolation (important)
+
+Every test module shares one singleton SQLite DB (config reads `DATA_DIR` once),
+and these two functions scan **all** `LabInstances` in the DB - so instances
+seeded by other modules (e.g. `test_api_engagement` sets `expiration_ts` via the
+extend test) can leak into the result set. The plan handles this two ways:
+
+1. In session setup, **neutralise pre-existing instances** once
+   (`LabInstances.query ... update(expiration_ts=None)` / or set them deleted)
+   so only this file's rows can match; and
+2. a **function-scoped cleanup** that deletes this file's own instances (by the
+   `ls`-prefixed user ids) before each test, so each test controls its exact set
+   and can assert precise outbox counts.
+
+Assertions also stay targeted (this file's user emails / this file's instance
+flags) rather than relying on global state.
+
+## New file: `tests/test_lab_schedule.py`  (prefix `ls`)
+
+Standard harness (clabernetes stub + `from run import app`), wrapped in
+`flask_app.app_context()`. Import the two functions from
+`apps.cli.lab_schedule`. Seed: `ls_user` (with email), `ls_noemail` (email ""),
+and one `ls_lab`. Set `flask_app.config["MAIL_DEFAULT_SENDER"]`.
+
+Mocks:
+- `mail_outbox` fixture: `monkeypatch.setattr("apps.cli.lab_schedule.Mail", FakeMail)`
+  where `FakeMail(app).send(msg)` appends `msg` to a list (recipients readable
+  via `msg.recipients`). `Message` stays real.
+- `fake_k8s` fixture: `monkeypatch.setattr("apps.cli.lab_schedule.k8s", ns)` with
+  `delete_resources_by_name` returning `[]` (or raising, for the error test).
+- helper `make_instance(user_id, expiration_ts, is_deleted=False, lab_id=ls_lab)`
+  and `WARN`/`TOL` = 48h constants derived from `utcnow()`.
+
+### TestAlertExpiringLabs
+- **send_email=False** with an expiring instance for `ls_user` -> nothing sent
+  (`ls_user`'s email not in the outbox); the "No e-mail to send" branch runs.
+- **send_email=True**, expiring instance for `ls_user` -> exactly one message to
+  `ls_user@...`.
+- **send_email=True**, expiring instance for `ls_noemail` (no address) -> no send
+  (the `if user.email` guard skips it), no crash.
+- **send_email=True**, expiring instance whose `user_id` is a missing user id ->
+  the `if not user` branch continues; nothing sent, no crash.
+- **not-expiring**: an instance expiring well beyond the 48h window -> not
+  alerted (not in outbox).
+- **excluded rows**: an `expiration_ts=None` instance and an `is_deleted=True`
+  instance are never selected.
+
+### TestRunDeleteExpiredLabs
+- **expired instance**: `expiration_ts` older than `now - TOL`; `k8s`
+  faked -> the instance ends `is_deleted=True` with `finish_reason="Lab Expired"`,
+  and `delete_resources_by_name` was called with its resources.
+- **within tolerance**: `expiration_ts` recent (not yet past tolerance) -> left
+  untouched (`is_deleted` stays False).
+- **teardown error**: `k8s.delete_resources_by_name` raises -> the exception is
+  swallowed/logged and the instance is **not** soft-deleted (`is_deleted` stays
+  False).
+
+## Note (not a required fix)
+
+In `alert_expiring_labs`, the send path builds the body with `lab.title`; if an
+instance references a lab id that no longer exists, `lab` is `None` and this
+raises. Tests always use a valid `ls_lab`, so this edge isn't exercised. Worth a
+follow-up guard, but out of scope here unless you want it fixed.
+
+## Files to create
+- `tests/test_lab_schedule.py`
+
+No production changes expected.
+
+## Verification
+```
+pip install -r requirements-dev.txt
+pytest tests/test_lab_schedule.py -v
+pytest tests/ -v          # whole suite stays green
+pytest tests/ --cov=apps.cli.lab_schedule --cov-report=term-missing
+```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
 pytest==9.0.3
+pytest-cov==7.1.0
 djlint==1.40.1
 black==26.3.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+"""Shared pytest fixtures/hooks for the test suite.
+
+Every test module keeps a session-scoped Flask app context open for the whole
+run (the ``app`` fixture pattern). SQLAlchemy scopes a session - and thus a
+pooled DB connection - to each app context, and an uncommitted read leaves that
+connection checked out until the session is removed. With enough modules stacked
+that exhausts the connection pool (``QueuePool limit ... reached``).
+
+This autouse fixture ends the current test's (idle, read) transaction right
+after the test finishes, returning its DB connection to the pool, so at most a
+couple of connections are ever in use at once regardless of how many modules are
+collected. A rollback (rather than session.remove()) is used so that ORM objects
+stay attached to their session - the ordered/stateful suites lazy-load
+relationships across test methods and must not be detached. It is a no-op for
+the pure (non-DB) suites that never import the app.
+"""
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _return_db_connection():
+    yield
+    db = getattr(sys.modules.get("apps"), "db", None)
+    if db is None:
+        return
+    try:
+        db.session.rollback()
+    except Exception:
+        pass

--- a/tests/test_api_engagement.py
+++ b/tests/test_api_engagement.py
@@ -1,0 +1,274 @@
+"""Pytest suite for the /api engagement endpoints.
+
+Mirrors tests/test_lab_categories.py: covers feedback, add_user_like,
+del_user_like, join_group, extend_lab and bulk_approve_users in
+apps/api/routes.py - role gating, content validation, group access-token
+joining, lab-duration extension bounds, and bulk user approval. Exercises the
+UserFeedbacks and UserLikes models.
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3).
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_api_engagement.py -v
+
+Note: the classes below are ordered, stateful workflows rather than
+independent unit tests - pytest runs test methods within a class in
+definition order by default, which this suite relies on. Do not run with a
+random-order plugin (e.g. pytest-randomly) without disabling it for this file.
+
+The seeded usernames are all prefixed "an" so they never collide with the
+other test modules that share the same singleton app/database (apps/config.py
+reads DATA_DIR once at import time, so every module ends up on one DB). Cache
+keys shared across modules (user_likes, user_feedbacks) are cleared before use.
+"""
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db, cache  # noqa: E402
+from apps.authentication.models import Users, Groups  # noqa: E402
+from apps.home.models import Labs, LabInstances, UserFeedbacks, UserLikes  # noqa: E402
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def ids(app):
+    admin = Users(username="anadmin", password="admin123", email="anadmin@test.local", category="admin")
+    teacher = Users(username="anteacher", password="teach123", email="anteacher@test.local", category="teacher")
+    student = Users(username="anstudent", password="stud123", email="anstudent@test.local", category="student")
+    other = Users(username="another", password="stud123", email="another@test.local", category="student")
+    pending = Users(username="anpending", password="pend123", email="anpending@test.local", category="user")
+    bulk1 = Users(username="anbulk1", password="b123", email="anbulk1@test.local", category="user")
+    bulk2 = Users(username="anbulk2", password="b123", email="anbulk2@test.local", category="user")
+    db.session.add_all([admin, teacher, student, other, pending, bulk1, bulk2])
+    db.session.commit()
+
+    group = Groups(groupname="AnGroup", organization="ORG1", accesstoken="secret-token")
+    system = Groups(groupname="AnSystem", organization="SYSTEM", accesstoken="sys-token")
+    db.session.add_all([group, system])
+
+    lab = Labs(title="An Lab", description="lab for extend")
+    db.session.add(lab)
+    db.session.commit()
+    inst = LabInstances(user_id=student.id, lab_id=lab.id, is_deleted=False)
+    inst.k8s_resources = []
+    db.session.add(inst)
+    db.session.commit()
+
+    return {
+        "admin_id": admin.id,
+        "teacher_id": teacher.id,
+        "student_id": student.id,
+        "other_id": other.id,
+        "pending_id": pending.id,
+        "bulk1_id": bulk1.id,
+        "bulk2_id": bulk2.id,
+        "group_id": group.id,
+        "system_id": system.id,
+        "inst_id": inst.id,
+    }
+
+
+# --- helpers -----------------------------------------------------------
+def login(client, username, password):
+    resp = client.post(
+        "/login/",
+        data={"identifier": username, "password": password, "login": "1"},
+    )
+    return resp.status_code == 302
+
+
+def logout(client):
+    client.get("/logout")
+
+
+# --- feedback -----------------------------------------------------------
+class TestFeedback:
+    def test_unapproved_user_is_rejected(self, client, ids):
+        logout(client)
+        login(client, "anpending", "pend123")
+        resp = client.get("/api/feedback")
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_get_returns_recent_feedbacks(self, client, ids):
+        cache.delete("user_feedbacks")
+        login(client, "anstudent", "stud123")
+        resp = client.get("/api/feedback")
+        assert resp.status_code == 200
+        assert "recent_feedbacks" in resp.get_json()
+
+    def test_post_without_stars_is_rejected(self, client, ids):
+        resp = client.post("/api/feedback", json={"comment": "no stars"})
+        assert resp.status_code == 400
+
+    def test_post_creates_then_updates_feedback(self, client, ids):
+        resp = client.post("/api/feedback", json={"stars": 5, "comment": "great"})
+        assert resp.status_code == 200
+        fb = UserFeedbacks.query.filter_by(user_id=ids["student_id"]).all()
+        assert len(fb) == 1 and fb[0].stars == 5
+
+        resp = client.post("/api/feedback", json={"stars": 3, "comment": "meh"})
+        assert resp.status_code == 200
+        fb = UserFeedbacks.query.filter_by(user_id=ids["student_id"]).all()
+        assert len(fb) == 1 and fb[0].stars == 3  # updated in place
+        logout(client)
+
+
+# --- user likes ---------------------------------------------------------
+class TestUserLikes:
+    def test_add_and_remove_like(self, client, ids):
+        cache.delete("user_likes")
+        login(client, "anstudent", "stud123")
+
+        resp = client.post("/api/user_like")
+        assert resp.status_code == 200
+        assert db.session.get(UserLikes, ids["student_id"]) is not None
+
+        # liking again is idempotent
+        resp = client.post("/api/user_like")
+        assert resp.status_code == 200
+
+        resp = client.delete("/api/user_like")
+        assert resp.status_code == 200
+        assert db.session.get(UserLikes, ids["student_id"]) is None
+        logout(client)
+
+
+# --- join_group ---------------------------------------------------------
+class TestJoinGroup:
+    def test_empty_content_is_rejected(self, client, ids):
+        login(client, "anstudent", "stud123")
+        resp = client.post(f"/api/groups/join/{ids['group_id']}", json={})
+        assert resp.status_code == 400
+
+    def test_unknown_group(self, client, ids):
+        resp = client.post("/api/groups/join/999999", json={"accessToken": "secret-token"})
+        assert resp.status_code == 404
+
+    def test_system_group_non_admin_is_rejected(self, client, ids):
+        resp = client.post(f"/api/groups/join/{ids['system_id']}", json={"accessToken": "sys-token"})
+        assert resp.status_code == 404
+
+    def test_wrong_token_is_rejected(self, client, ids):
+        resp = client.post(f"/api/groups/join/{ids['group_id']}", json={"accessToken": "nope"})
+        assert resp.status_code == 400
+
+    def test_correct_token_joins_then_reports_already_member(self, client, ids):
+        resp = client.post(f"/api/groups/join/{ids['group_id']}", json={"accessToken": "secret-token"})
+        assert resp.status_code == 200
+        group = db.session.get(Groups, ids["group_id"])
+        assert group.is_member(ids["student_id"])
+
+        resp = client.post(f"/api/groups/join/{ids['group_id']}", json={"accessToken": "secret-token"})
+        assert resp.status_code == 200
+        assert b"Already member" in resp.data
+        logout(client)
+
+
+# --- extend_lab ---------------------------------------------------------
+class TestExtendLab:
+    def test_missing_instance(self, client, ids):
+        login(client, "anstudent", "stud123")
+        resp = client.post("/api/lab/does-not-exist/extend", json={"extend_hours": 4})
+        assert resp.status_code == 404
+
+    def test_non_owner_is_rejected(self, client, ids):
+        logout(client)
+        login(client, "another", "stud123")
+        resp = client.post(f"/api/lab/{ids['inst_id']}/extend", json={"extend_hours": 4})
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_missing_extend_hours_is_rejected(self, client, ids):
+        login(client, "anstudent", "stud123")
+        resp = client.post(f"/api/lab/{ids['inst_id']}/extend", json={})
+        assert resp.status_code == 400
+
+    def test_out_of_range_hours_is_rejected(self, client, ids):
+        resp = client.post(f"/api/lab/{ids['inst_id']}/extend", json={"extend_hours": 800})
+        assert resp.status_code == 400
+
+    def test_valid_extension(self, client, ids):
+        resp = client.post(f"/api/lab/{ids['inst_id']}/extend", json={"extend_hours": 24})
+        assert resp.status_code == 200
+        inst = db.session.get(LabInstances, ids["inst_id"])
+        assert inst.expiration_ts is not None
+        logout(client)
+
+
+# --- bulk_approve_users -------------------------------------------------
+class TestBulkApproveUsers:
+    def test_non_staff_is_rejected(self, client, ids):
+        login(client, "anstudent", "stud123")
+        resp = client.post("/api/users/bulk-approve", json=[str(ids["bulk1_id"])])
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_empty_content_is_rejected(self, client, ids):
+        login(client, "anadmin", "admin123")
+        resp = client.post("/api/users/bulk-approve", json=[])
+        assert resp.status_code == 400
+
+    def test_non_user_category_in_list_is_rejected(self, client, ids):
+        # student is not a category=="user" account -> invalid to approve
+        resp = client.post("/api/users/bulk-approve", json=[str(ids["student_id"])])
+        assert resp.status_code == 400
+
+    def test_valid_list_is_approved(self, client, ids):
+        resp = client.post("/api/users/bulk-approve", json=[str(ids["bulk1_id"]), str(ids["bulk2_id"])])
+        assert resp.status_code == 200
+        assert db.session.get(Users, ids["bulk1_id"]).category == "student"
+        assert db.session.get(Users, ids["bulk2_id"]).category == "student"
+        logout(client)

--- a/tests/test_api_k8s.py
+++ b/tests/test_api_k8s.py
@@ -1,0 +1,277 @@
+"""Pytest suite for the k8s/git-backed /api endpoints.
+
+Mirrors tests/test_lab_categories.py: covers get_pods, get_lab_status,
+delete_lab, get_nodes, list_kubernetes_templates and get_kubernetes_template in
+apps/api/routes.py. Only the happy paths touch Kubernetes/git, so those are
+covered by monkeypatching the `k8s`/`git` modules used by the routes; every
+role/ownership/validation branch returns before any external call.
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3).
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_api_k8s.py -v
+
+Note: the classes below are ordered, stateful workflows rather than
+independent unit tests - pytest runs test methods within a class in
+definition order by default, which this suite relies on. Do not run with a
+random-order plugin (e.g. pytest-randomly) without disabling it for this file.
+
+The seeded usernames are all prefixed "ak" so they never collide with the
+other test modules that share the same singleton app/database (apps/config.py
+reads DATA_DIR once at import time, so every module ends up on one DB).
+"""
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db  # noqa: E402
+from apps.authentication.models import Users  # noqa: E402
+from apps.home.models import Labs, LabInstances  # noqa: E402
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def ids(app):
+    admin = Users(username="akadmin", password="admin123", email="akadmin@test.local", category="admin")
+    student = Users(username="akstudent", password="stud123", email="akstudent@test.local", category="student")
+    other = Users(username="akother", password="stud123", email="akother@test.local", category="student")
+    pending = Users(username="akpending", password="pend123", email="akpending@test.local", category="user")
+    db.session.add_all([admin, student, other, pending])
+    db.session.commit()
+
+    lab = Labs(title="Ak Lab", description="lab for k8s api")
+    db.session.add(lab)
+    db.session.commit()
+    inst = LabInstances(user_id=student.id, lab_id=lab.id, is_deleted=False)
+    inst.k8s_resources = []
+    inst_del = LabInstances(user_id=student.id, lab_id=lab.id, is_deleted=False)
+    inst_del.k8s_resources = []
+    db.session.add_all([inst, inst_del])
+    db.session.commit()
+
+    return {
+        "admin_id": admin.id,
+        "student_id": student.id,
+        "other_id": other.id,
+        "lab_id": lab.id,
+        "inst_id": inst.id,
+        "inst_del_id": inst_del.id,
+    }
+
+
+# --- helpers -----------------------------------------------------------
+def login(client, username, password):
+    resp = client.post(
+        "/login/",
+        data={"identifier": username, "password": password, "login": "1"},
+    )
+    return resp.status_code == 302
+
+
+def logout(client):
+    client.get("/logout")
+
+
+# --- get_pods -----------------------------------------------------------
+class TestGetPods:
+    def test_unapproved_user_is_rejected(self, client, ids):
+        logout(client)
+        login(client, "akpending", "pend123")
+        resp = client.get("/api/pods/somelab")
+        assert resp.status_code == 404
+        logout(client)
+
+    def test_missing_auth_header_is_rejected(self, client, ids):
+        login(client, "akstudent", "stud123")
+        resp = client.get("/api/pods/somelab")
+        assert resp.status_code == 400
+
+    def test_invalid_token_is_rejected(self, client, ids, monkeypatch):
+        monkeypatch.setattr("apps.api.routes.k8s.validate_token", lambda t: False)
+        resp = client.get("/api/pods/somelab", headers={"Authorization": "Bearer bad"})
+        assert resp.status_code == 404
+
+    def test_valid_token_returns_pods(self, client, ids, monkeypatch):
+        monkeypatch.setattr("apps.api.routes.k8s.validate_token", lambda t: True)
+        monkeypatch.setattr("apps.api.routes.k8s.get_pods_by_lab_id", lambda lab_id: [{"name": "p1"}])
+        resp = client.get("/api/pods/somelab", headers={"Authorization": "Bearer good"})
+        assert resp.status_code == 200
+        logout(client)
+
+
+# --- get_lab_status -----------------------------------------------------
+class TestGetLabStatus:
+    def test_unapproved_user_is_rejected(self, client, ids):
+        login(client, "akpending", "pend123")
+        resp = client.get(f"/api/lab/status/{ids['inst_id']}")
+        assert resp.status_code == 404
+        logout(client)
+
+    def test_missing_instance(self, client, ids):
+        login(client, "akstudent", "stud123")
+        resp = client.get("/api/lab/status/does-not-exist")
+        assert resp.status_code == 404
+
+    def test_non_owner_is_rejected(self, client, ids):
+        logout(client)
+        login(client, "akother", "stud123")
+        resp = client.get(f"/api/lab/status/{ids['inst_id']}")
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_owner_gets_status(self, client, ids, monkeypatch):
+        monkeypatch.setattr(
+            "apps.api.routes.k8s.get_resources_by_name",
+            lambda res: [{"kind": "pod", "metadata": {"name": "p1"}, "is_ok": True}],
+        )
+        login(client, "akstudent", "stud123")
+        resp = client.get(f"/api/lab/status/{ids['inst_id']}")
+        assert resp.status_code == 200
+        logout(client)
+
+
+# --- delete_lab ---------------------------------------------------------
+class TestDeleteLab:
+    def test_unapproved_user_is_rejected(self, client, ids):
+        login(client, "akpending", "pend123")
+        resp = client.delete(f"/api/lab/{ids['inst_del_id']}")
+        assert resp.status_code == 404
+        logout(client)
+
+    def test_missing_instance(self, client, ids):
+        login(client, "akstudent", "stud123")
+        resp = client.delete("/api/lab/does-not-exist")
+        assert resp.status_code == 404
+
+    def test_non_owner_is_rejected(self, client, ids):
+        logout(client)
+        login(client, "akother", "stud123")
+        resp = client.delete(f"/api/lab/{ids['inst_del_id']}")
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_owner_can_delete(self, client, ids, monkeypatch):
+        monkeypatch.setattr("apps.api.routes.k8s.delete_resources_by_name", lambda res: [])
+        login(client, "akstudent", "stud123")
+        resp = client.delete(f"/api/lab/{ids['inst_del_id']}")
+        assert resp.status_code == 200
+
+        inst = db.session.get(LabInstances, ids["inst_del_id"])
+        assert inst.is_deleted is True
+        logout(client)
+
+
+# --- get_nodes ----------------------------------------------------------
+class TestGetNodes:
+    def test_unapproved_user_is_rejected(self, client, ids):
+        login(client, "akpending", "pend123")
+        resp = client.get("/api/nodes")
+        assert resp.status_code == 404
+        logout(client)
+
+    def test_returns_nodes(self, client, ids, monkeypatch):
+        monkeypatch.setattr(
+            "apps.api.routes.k8s.get_nodes",
+            lambda: [{"name": "n1", "latitude": 1.0, "longitude": 2.0, "status": "Ready"}],
+        )
+        login(client, "akstudent", "stud123")
+        resp = client.get("/api/nodes")
+        assert resp.status_code == 200
+        logout(client)
+
+
+# --- list_kubernetes_templates (public) ---------------------------------
+class TestListTemplates:
+    def test_not_defined_when_no_git_url(self, client, ids, monkeypatch):
+        monkeypatch.setitem(flask_app.config, "LAB_TEMPLATES_GIT_URL", "")
+        resp = client.get("/api/templates/list")
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "not-defined"
+
+    def test_lists_templates(self, client, ids, monkeypatch):
+        monkeypatch.setattr("apps.api.routes.git.update_repo", lambda *a, **k: None)
+        monkeypatch.setattr("apps.api.routes.git.list_files", lambda *a, **k: ["a.yaml", "sub/b.yaml"])
+        resp = client.get("/api/templates/list")
+        assert resp.status_code == 200
+        assert resp.get_json()["result"] == ["a", "sub/b"]
+
+    def test_failure_is_reported(self, client, ids, monkeypatch):
+        monkeypatch.setattr("apps.api.routes.git.update_repo", lambda *a, **k: None)
+        def boom(*a, **k):
+            raise RuntimeError("git blew up")
+        monkeypatch.setattr("apps.api.routes.git.list_files", boom)
+        resp = client.get("/api/templates/list")
+        assert resp.status_code == 400
+
+
+# --- get_kubernetes_template --------------------------------------------
+class TestGetTemplate:
+    def test_non_staff_is_rejected(self, client, ids):
+        login(client, "akstudent", "stud123")
+        resp = client.get("/api/templates/foo")
+        assert b"Unauthorized request" in resp.data
+        logout(client)
+
+    def test_admin_gets_template(self, client, ids, monkeypatch):
+        monkeypatch.setattr("apps.api.routes.git.get_file", lambda d, f: (True, "yaml-content"))
+        login(client, "akadmin", "admin123")
+        resp = client.get("/api/templates/foo")
+        assert resp.status_code == 200
+        assert resp.get_json()["result"] == "yaml-content"
+
+    def test_admin_missing_template_is_reported(self, client, ids, monkeypatch):
+        monkeypatch.setattr("apps.api.routes.git.get_file", lambda d, f: (False, "not found"))
+        resp = client.get("/api/templates/foo")
+        assert resp.status_code == 400
+        logout(client)

--- a/tests/test_api_lab_answers.py
+++ b/tests/test_api_lab_answers.py
@@ -1,0 +1,291 @@
+"""Pytest suite for the /api lab-answers endpoints.
+
+Mirrors tests/test_lab_categories.py: covers get_lab_answers,
+save_lab_answers, save_grades_comments and check_lab_answer in
+apps/api/routes.py - role/ownership gating, content validation, grade-range
+validation, the answer-sheet requirement, and the scoring happy path.
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3).
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_api_lab_answers.py -v
+
+Note: the classes below are ordered, stateful workflows rather than
+independent unit tests - pytest runs test methods within a class in
+definition order by default, which this suite relies on. Do not run with a
+random-order plugin (e.g. pytest-randomly) without disabling it for this file.
+
+The seeded usernames are all prefixed "ae" so they never collide with the
+other test modules that share the same singleton app/database (apps/config.py
+reads DATA_DIR once at import time, so every module ends up on one DB).
+"""
+import json
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db  # noqa: E402
+from apps.authentication.models import Users, Groups  # noqa: E402
+from apps.home.models import Labs, LabInstances, LabAnswers, LabAnswerSheet  # noqa: E402
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def ids(app):
+    admin = Users(username="aeadmin", password="admin123", email="aeadmin@test.local", category="admin")
+    teacher = Users(username="aeteacher", password="teach123", email="aeteacher@test.local", category="teacher")
+    teacher2 = Users(username="aeteacher2", password="teach123", email="aeteacher2@test.local", category="teacher")
+    student = Users(username="aestudent", password="stud123", email="aestudent@test.local", category="student")
+    other = Users(username="aeother", password="stud123", email="aeother@test.local", category="student")
+    pending = Users(username="aepending", password="pend123", email="aepending@test.local", category="user")
+    db.session.add_all([admin, teacher, teacher2, student, other, pending])
+    db.session.commit()
+
+    group = Groups(groupname="AeGroup", organization="ORG1")
+    group.owners.append(teacher)
+    group.members.append(student)
+    db.session.add(group)
+
+    lab = Labs(title="Ae Lab", description="lab with a sheet")
+    lab.allowed_groups.append(group)
+    lab2 = Labs(title="Ae Lab No Sheet", description="lab without a sheet")
+    lab2.allowed_groups.append(group)
+    db.session.add_all([lab, lab2])
+    db.session.commit()
+
+    sheet = LabAnswerSheet()
+    sheet.lab_id = lab.id
+    sheet.set_answers({"q1": "foo"})
+    db.session.add(sheet)
+
+    inst = LabInstances(user_id=student.id, lab_id=lab.id, is_deleted=False)
+    inst.k8s_resources = []
+    # the student's own answer (mutated by the save/grade tests)
+    answer = LabAnswers(user_id=student.id, lab_id=lab.id)
+    answer.answers = json.dumps({"q1": "foo"})
+    answer.grades = json.dumps({})
+    # a dedicated answer for the check_lab_answer scoring test (never mutated)
+    answer_check = LabAnswers(user_id=other.id, lab_id=lab.id)
+    answer_check.answers = json.dumps({"q1": "foo"})
+    answer_check.grades = json.dumps({})
+    db.session.add_all([inst, answer, answer_check])
+    db.session.commit()
+
+    return {
+        "admin_id": admin.id,
+        "teacher_id": teacher.id,
+        "teacher2_id": teacher2.id,
+        "student_id": student.id,
+        "other_id": other.id,
+        "lab_id": lab.id,
+        "lab2_id": lab2.id,
+        "inst_id": inst.id,
+        "answer_id": answer.id,
+        "answer_check_id": answer_check.id,
+    }
+
+
+# --- helpers -----------------------------------------------------------
+def login(client, username, password):
+    resp = client.post(
+        "/login/",
+        data={"identifier": username, "password": password, "login": "1"},
+    )
+    return resp.status_code == 302
+
+
+def logout(client):
+    client.get("/logout")
+
+
+# --- get_lab_answers ----------------------------------------------------
+class TestGetLabAnswers:
+    def test_unapproved_user_is_rejected(self, client, ids):
+        logout(client)
+        login(client, "aepending", "pend123")
+        resp = client.get(f"/api/lab_answers/{ids['inst_id']}")
+        assert resp.status_code == 404
+        logout(client)
+
+    def test_missing_instance(self, client, ids):
+        login(client, "aestudent", "stud123")
+        resp = client.get("/api/lab_answers/does-not-exist")
+        assert resp.status_code == 404
+
+    def test_non_owner_is_rejected(self, client, ids):
+        logout(client)
+        login(client, "aeother", "stud123")
+        resp = client.get(f"/api/lab_answers/{ids['inst_id']}")
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_owner_gets_answers(self, client, ids):
+        login(client, "aestudent", "stud123")
+        resp = client.get(f"/api/lab_answers/{ids['inst_id']}")
+        assert resp.status_code == 200
+        assert resp.get_json()["result"] == {"q1": "foo"}
+        logout(client)
+
+
+# --- save_lab_answers ---------------------------------------------------
+class TestSaveLabAnswers:
+    def test_unapproved_user_is_rejected(self, client, ids):
+        login(client, "aepending", "pend123")
+        resp = client.post(f"/api/lab_answers/{ids['inst_id']}", json={"q1": "x"})
+        assert resp.status_code == 404
+        logout(client)
+
+    def test_empty_content_is_rejected(self, client, ids):
+        login(client, "aestudent", "stud123")
+        resp = client.post(f"/api/lab_answers/{ids['inst_id']}")
+        assert resp.status_code == 400
+
+    def test_missing_instance(self, client, ids):
+        resp = client.post("/api/lab_answers/does-not-exist", json={"q1": "x"})
+        assert resp.status_code == 404
+
+    def test_non_owner_is_rejected(self, client, ids):
+        logout(client)
+        login(client, "aeother", "stud123")
+        resp = client.post(f"/api/lab_answers/{ids['inst_id']}", json={"q1": "x"})
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_owner_saves_answers(self, client, ids):
+        login(client, "aestudent", "stud123")
+        resp = client.post(f"/api/lab_answers/{ids['inst_id']}", json={"q1": "myans"})
+        assert resp.status_code == 200
+
+        answer = db.session.get(LabAnswers, ids["answer_id"])
+        assert answer.answers_dict == {"q1": "myans"}
+        logout(client)
+
+
+# --- save_grades_comments -----------------------------------------------
+class TestSaveGradesComments:
+    def test_non_staff_is_rejected(self, client, ids):
+        login(client, "aestudent", "stud123")
+        resp = client.post(f"/api/lab_answers/grades_comments/{ids['answer_id']}", json={"grades": {"q1": 50}})
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_missing_answer(self, client, ids):
+        login(client, "aeadmin", "admin123")
+        resp = client.post("/api/lab_answers/grades_comments/999999", json={"grades": {}})
+        assert resp.status_code == 404
+
+    def test_teacher_not_owner_is_rejected(self, client, ids):
+        logout(client)
+        login(client, "aeteacher2", "teach123")
+        resp = client.post(f"/api/lab_answers/grades_comments/{ids['answer_id']}", json={"grades": {"q1": 50}})
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_admin_empty_content_is_rejected(self, client, ids):
+        login(client, "aeadmin", "admin123")
+        resp = client.post(f"/api/lab_answers/grades_comments/{ids['answer_id']}")
+        assert resp.status_code == 400
+
+    def test_admin_invalid_grade_is_rejected(self, client, ids):
+        resp = client.post(f"/api/lab_answers/grades_comments/{ids['answer_id']}", json={"grades": {"q1": 150}})
+        assert resp.status_code == 400
+        assert b"Invalid grade" in resp.data
+
+    def test_admin_saves_grades(self, client, ids):
+        resp = client.post(
+            f"/api/lab_answers/grades_comments/{ids['answer_id']}",
+            json={"grades": {"q1": 80}, "comments": {"q1": "good"}},
+        )
+        assert resp.status_code == 200
+
+        answer = db.session.get(LabAnswers, ids["answer_id"])
+        assert answer.grades_dict == {"q1": 80}
+        logout(client)
+
+
+# --- check_lab_answer ---------------------------------------------------
+class TestCheckLabAnswer:
+    def test_non_staff_is_rejected(self, client, ids):
+        login(client, "aestudent", "stud123")
+        resp = client.get(f"/api/lab_answers/check/{ids['lab_id']}/{ids['answer_check_id']}")
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_unknown_lab_is_rejected(self, client, ids):
+        login(client, "aeteacher", "teach123")
+        resp = client.get(f"/api/lab_answers/check/does-not-exist/{ids['answer_check_id']}")
+        assert resp.status_code == 401
+
+    def test_lab_outside_privileged_groups_is_rejected(self, client, ids):
+        logout(client)
+        login(client, "aeteacher2", "teach123")
+        resp = client.get(f"/api/lab_answers/check/{ids['lab_id']}/{ids['answer_check_id']}")
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_missing_answer_is_rejected(self, client, ids):
+        login(client, "aeteacher", "teach123")
+        resp = client.get(f"/api/lab_answers/check/{ids['lab_id']}/999999")
+        assert resp.status_code == 401
+
+    def test_lab_without_sheet_is_rejected(self, client, ids):
+        resp = client.get(f"/api/lab_answers/check/{ids['lab2_id']}/{ids['answer_check_id']}")
+        assert resp.status_code == 400
+        assert b"No Lab Answer Sheet available" in resp.data
+
+    def test_score_is_returned(self, client, ids):
+        resp = client.get(f"/api/lab_answers/check/{ids['lab_id']}/{ids['answer_check_id']}")
+        assert resp.status_code == 200
+        assert resp.get_json()["result"] == "100.00"
+        logout(client)

--- a/tests/test_auth_password_reset.py
+++ b/tests/test_auth_password_reset.py
@@ -1,0 +1,173 @@
+"""Pytest suite for the password-reset flow.
+
+Mirrors tests/test_email_required.py: covers reset_password and
+confirm_reset_password in apps/authentication/routes.py - form validation, the
+no-user-enumeration generic response, the mail send, and the token-confirmation
+branches (invalid/expired token, mismatched passwords, deleted user, success).
+The reset token is seeded straight into the cache so confirm_reset_password can
+be exercised without parsing the (random, email-embedded) token. No real email
+is ever sent.
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3).
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_auth_password_reset.py -v
+
+Note: the classes below are ordered, stateful workflows rather than
+independent unit tests - pytest runs test methods within a class in
+definition order by default, which this suite relies on. Do not run with a
+random-order plugin (e.g. pytest-randomly) without disabling it for this file.
+
+The seeded usernames are all prefixed "ap" so they never collide with the
+other test modules that share the same singleton app/database (apps/config.py
+reads DATA_DIR once at import time, so every module ends up on one DB).
+"""
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db, cache  # noqa: E402
+from apps.authentication import routes as auth_routes  # noqa: E402
+from apps.authentication.models import Users  # noqa: E402
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def ids(app):
+    user = Users(username="apuser", password="pass123", email="apuser@example.com", category="student")
+    deleted = Users(username="apdeleted", password="pass123", email="apdeleted@example.com", category="student", is_deleted=True)
+    db.session.add_all([user, deleted])
+    db.session.commit()
+    return {"user_id": user.id, "deleted_id": deleted.id}
+
+
+@pytest.fixture
+def mail_outbox(monkeypatch):
+    outbox = []
+    monkeypatch.setitem(flask_app.config, "MAIL_SERVER", "smtp.test.local")
+    monkeypatch.setitem(flask_app.config, "MAIL_USERNAME", "noreply@test.local")
+    monkeypatch.setattr(auth_routes.mail, "send", lambda msg: outbox.append(msg))
+    return outbox
+
+
+# --- helpers -----------------------------------------------------------
+def login(client, username, password):
+    resp = client.post(
+        "/login/",
+        data={"identifier": username, "password": password, "login": "1"},
+    )
+    return resp.status_code == 302
+
+
+def logout(client):
+    client.get("/logout")
+
+
+# --- reset_password -----------------------------------------------------
+class TestResetPassword:
+    def test_get_renders_form(self, client, ids):
+        resp = client.get("/reset-password")
+        assert resp.status_code == 200
+
+    def test_missing_identifier_is_rejected(self, client, ids):
+        resp = client.post("/reset-password", data={})
+        assert b"Errors validating form" in resp.data
+
+    def test_unknown_user_gets_generic_message(self, client, ids):
+        resp = client.post("/reset-password", data={"identifier": "nobody-here"})
+        assert resp.status_code == 200
+        assert b"If the user provided is valid" in resp.data
+
+    def test_valid_user_sends_mail(self, client, ids, mail_outbox):
+        resp = client.post("/reset-password", data={"identifier": "apuser"})
+        assert resp.status_code == 200
+        assert b"If the user provided is valid" in resp.data
+        assert len(mail_outbox) == 1
+
+
+# --- confirm_reset_password ---------------------------------------------
+class TestConfirmResetPassword:
+    def test_invalid_token_is_rejected(self, client, ids):
+        resp = client.get("/confirm-reset-password/not-a-real-token")
+        assert b"Invalid or expired token" in resp.data
+
+    def test_mismatched_passwords_are_rejected(self, client, ids):
+        cache.set("resetpw-tok-mismatch", ids["user_id"], timeout=3600)
+        resp = client.post(
+            "/confirm-reset-password/tok-mismatch",
+            data={"password": "newpass123", "password_confirm": "different123"},
+        )
+        assert b"Passwords must match" in resp.data
+
+    def test_deleted_user_is_rejected(self, client, ids):
+        cache.set("resetpw-tok-deleted", ids["deleted_id"], timeout=3600)
+        resp = client.post(
+            "/confirm-reset-password/tok-deleted",
+            data={"password": "newpass123", "password_confirm": "newpass123"},
+        )
+        assert b"Invalid password reset request" in resp.data
+
+    def test_valid_token_resets_password(self, client, ids):
+        cache.set("resetpw-tok-ok", ids["user_id"], timeout=3600)
+        resp = client.post(
+            "/confirm-reset-password/tok-ok",
+            data={"password": "brandnew123", "password_confirm": "brandnew123"},
+        )
+        assert b"Password changed successfully" in resp.data
+        assert cache.get("resetpw-tok-ok") is None
+
+        logout(client)
+        assert login(client, "apuser", "brandnew123")
+        logout(client)
+        assert not login(client, "apuser", "pass123")

--- a/tests/test_auth_register.py
+++ b/tests/test_auth_register.py
@@ -1,0 +1,217 @@
+"""Pytest suite for the account registration flow.
+
+Mirrors tests/test_email_required.py: covers register, confirm_page and
+resend_code in apps/authentication/routes.py - form validation, duplicate
+username/email rejection, the no-MAIL_SERVER fast path (user created directly),
+the token-confirmation path (user stashed in session until confirmed), and the
+wrong/expired token branches. No real email is ever sent.
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3).
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_auth_register.py -v
+
+Note: the classes below are ordered, stateful workflows rather than
+independent unit tests - pytest runs test methods within a class in
+definition order by default, which this suite relies on. Do not run with a
+random-order plugin (e.g. pytest-randomly) without disabling it for this file.
+
+The seeded usernames are all prefixed "ar" so they never collide with the
+other test modules that share the same singleton app/database (apps/config.py
+reads DATA_DIR once at import time, so every module ends up on one DB).
+"""
+import os
+import sys
+import tempfile
+import types
+from datetime import timedelta
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db  # noqa: E402
+from apps.authentication import routes as auth_routes  # noqa: E402
+from apps.authentication.models import Users  # noqa: E402
+from apps.audit_mixin import utcnow  # noqa: E402
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def ids(app):
+    existing = Users(username="arexisting", password="pass123", email="arexisting@example.com", category="student")
+    db.session.add(existing)
+    db.session.commit()
+    return {"existing_id": existing.id}
+
+
+@pytest.fixture
+def no_mail_server(monkeypatch):
+    """Force the no-MAIL_SERVER fast path regardless of ambient env vars."""
+    monkeypatch.setitem(flask_app.config, "MAIL_SERVER", "")
+
+
+@pytest.fixture
+def mail_outbox(monkeypatch):
+    """Force the token path and capture sent messages instead of hitting the network."""
+    outbox = []
+    monkeypatch.setitem(flask_app.config, "MAIL_SERVER", "smtp.test.local")
+    monkeypatch.setitem(flask_app.config, "MAIL_USERNAME", "noreply@test.local")
+    monkeypatch.setattr(auth_routes.mail, "send", lambda msg: outbox.append(msg))
+    return outbox
+
+
+# --- helpers -----------------------------------------------------------
+def register_form(**overrides):
+    data = {"username": "", "email": "", "password": "pass123", "terms": "y"}
+    data.update(overrides)
+    return data
+
+
+def get_session_value(client, key):
+    with client.session_transaction() as sess:
+        return sess.get(key)
+
+
+def seed_pending(client, username, email, token="123456", when=None):
+    """Populate the session as register()'s token path would."""
+    with client.session_transaction() as sess:
+        sess["confirmation_token"] = token
+        sess["user"] = {"username": username, "email": email, "password": "pass123", "issuer": "LOCAL"}
+        sess["datetime"] = when or utcnow()
+
+
+def clear_pending(client):
+    with client.session_transaction() as sess:
+        sess.pop("confirmation_token", None)
+        sess.pop("user", None)
+        sess.pop("datetime", None)
+
+
+# --- register -----------------------------------------------------------
+class TestRegister:
+    def test_get_form(self, client, ids):
+        resp = client.get("/register")
+        assert resp.status_code == 200
+
+    def test_invalid_form_missing_terms(self, client, ids):
+        resp = client.post("/register", data=register_form(username="arnope", email="arnope@example.com", terms=""))
+        assert b"Failed to validate form" in resp.data
+
+    def test_duplicate_username(self, client, ids):
+        resp = client.post("/register", data=register_form(username="arexisting", email="fresh@example.com"))
+        assert b"Username already registered" in resp.data
+
+    def test_duplicate_email(self, client, ids):
+        resp = client.post("/register", data=register_form(username="arbrandnew", email="arexisting@example.com"))
+        assert b"Email already registered" in resp.data
+
+    def test_fast_path_creates_user(self, client, ids, no_mail_server):
+        resp = client.post("/register", data=register_form(username="arfast", email="arfast@example.com"))
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+        user = Users.query.filter_by(username="arfast").first()
+        assert user is not None
+        assert user.email == "arfast@example.com"
+
+    def test_token_path_stashes_user_and_sends_mail(self, client, ids, mail_outbox):
+        resp = client.post("/register", data=register_form(username="artoken", email="artoken@example.com"))
+        assert resp.status_code == 302
+        assert "/confirm" in resp.headers["Location"]
+        assert len(mail_outbox) == 1
+        # user is not created until the token is confirmed
+        assert Users.query.filter_by(username="artoken").first() is None
+
+
+# --- confirm_page -------------------------------------------------------
+class TestConfirmPage:
+    def test_no_pending_registration_redirects_to_register(self, client, ids):
+        clear_pending(client)
+        resp = client.get("/confirm")
+        assert resp.status_code == 302
+        assert "/register" in resp.headers["Location"]
+
+    def test_wrong_token_is_rejected(self, client, ids):
+        seed_pending(client, "arconfa", "arconfa@test.local", token="654321")
+        resp = client.post("/confirm", data={"confirmation_token": "000000", "confirm": "1"})
+        assert b"Invalid token" in resp.data
+        assert Users.query.filter_by(username="arconfa").first() is None
+
+    def test_expired_token_is_rejected(self, client, ids):
+        seed_pending(client, "arconfb", "arconfb@test.local", token="111111", when=utcnow() - timedelta(minutes=30))
+        resp = client.post("/confirm", data={"confirmation_token": "111111", "confirm": "1"})
+        assert b"Token expired" in resp.data
+        assert Users.query.filter_by(username="arconfb").first() is None
+
+    def test_correct_token_creates_user(self, client, ids):
+        seed_pending(client, "arconfc", "arconfc@test.local", token="222222")
+        resp = client.post("/confirm", data={"confirmation_token": "222222", "confirm": "1"})
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+        assert Users.query.filter_by(username="arconfc").first() is not None
+        assert get_session_value(client, "confirmation_token") is None
+
+
+# --- resend_code --------------------------------------------------------
+class TestResendCode:
+    def test_no_pending_registration_redirects_with_error(self, client, ids):
+        clear_pending(client)
+        resp = client.get("/resend-code")
+        assert resp.status_code == 302
+        assert "/confirm" in resp.headers["Location"]
+        assert get_session_value(client, "error_msg")
+
+    def test_resend_sends_mail(self, client, ids, mail_outbox):
+        seed_pending(client, "arresend", "arresend@test.local", token="333333")
+        resp = client.get("/resend-code")
+        assert resp.status_code == 302
+        assert "/confirm" in resp.headers["Location"]
+        assert len(mail_outbox) == 1

--- a/tests/test_auth_session.py
+++ b/tests/test_auth_session.py
@@ -1,0 +1,173 @@
+"""Pytest suite for the login/session auth routes.
+
+Mirrors tests/test_email_required.py: covers the branches of
+apps/authentication/routes.py not touched by the e-mail suite - route_default,
+the login GET/bad-password/already-authenticated paths, login_oauth,
+reload_profile, logout, and the unauthorized_handler next_url capture.
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3).
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_auth_session.py -v
+
+Note: the classes below are ordered, stateful workflows rather than
+independent unit tests - pytest runs test methods within a class in
+definition order by default, which this suite relies on. Do not run with a
+random-order plugin (e.g. pytest-randomly) without disabling it for this file.
+
+The seeded usernames are all prefixed "as" so they never collide with the
+other test modules that share the same singleton app/database (apps/config.py
+reads DATA_DIR once at import time, so every module ends up on one DB).
+"""
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+from flask import redirect
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db  # noqa: E402
+from apps.authentication import routes as auth_routes  # noqa: E402
+from apps.authentication.models import Users, LoginLogging  # noqa: E402
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def ids(app):
+    user = Users(username="asuser", password="pass123", email="asuser@example.com", category="student")
+    db.session.add(user)
+    db.session.commit()
+    return {"user_id": user.id}
+
+
+# --- helpers -----------------------------------------------------------
+def login(client, username, password):
+    return client.post(
+        "/login/",
+        data={"identifier": username, "password": password, "login": "1"},
+    )
+
+
+def logout(client):
+    client.get("/logout")
+
+
+def get_session_value(client, key):
+    with client.session_transaction() as sess:
+        return sess.get(key)
+
+
+# --- route_default & login ----------------------------------------------
+class TestRouteDefaultAndLogin:
+    def test_route_default_redirects_to_login(self, client, ids):
+        logout(client)
+        resp = client.get("/")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_login_get_renders_form(self, client, ids):
+        resp = client.get("/login/")
+        assert resp.status_code == 200
+
+    def test_bad_password_is_rejected_and_logged(self, client, ids):
+        resp = login(client, "asuser", "wrongpass")
+        assert resp.status_code == 200
+        assert b"Wrong user or password" in resp.data
+        assert LoginLogging.query.filter_by(login="asuser", success=False).first() is not None
+
+    def test_login_get_while_authenticated_redirects_home(self, client, ids):
+        assert login(client, "asuser", "pass123").status_code == 302
+        resp = client.get("/login/")
+        assert resp.status_code == 302
+        assert "/index" in resp.headers["Location"]
+        logout(client)
+
+
+# --- login_oauth --------------------------------------------------------
+class TestLoginOauth:
+    def test_oauth_login_redirects_to_provider(self, client, ids, monkeypatch):
+        monkeypatch.setattr(
+            auth_routes.oauth.provider,
+            "authorize_redirect",
+            lambda *a, **k: redirect("https://idp.example.com/authorize"),
+        )
+        resp = client.get("/login/oauth")
+        assert resp.status_code == 302
+        assert "idp.example.com" in resp.headers["Location"]
+
+
+# --- reload_profile & logout --------------------------------------------
+class TestReloadProfileAndLogout:
+    def test_reload_profile_redirects_to_default(self, client, ids):
+        login(client, "asuser", "pass123")
+        resp = client.get("/profile/reload")
+        assert resp.status_code == 302
+
+    def test_logout_clears_session(self, client, ids):
+        login(client, "asuser", "pass123")
+        resp = client.get("/logout")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+        # now a protected page bounces back to login
+        resp = client.get("/index")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+
+# --- unauthorized_handler -----------------------------------------------
+class TestUnauthorizedHandler:
+    def test_protected_page_stashes_next_url(self, client, ids):
+        logout(client)
+        resp = client.get("/index")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+        assert get_session_value(client, "next_url") == "/index"

--- a/tests/test_clabernetes.py
+++ b/tests/test_clabernetes.py
@@ -1,0 +1,248 @@
+"""Pytest suite for the C9sController (ContainerLab topology processing).
+
+Unlike the route suites, apps/controllers/clabernetes.py is pure logic (stdlib +
+yaml, no apps imports) and needs no Flask app or database - so this is a plain
+unit-test file. The only wrinkle is that the module raises at *import* time when
+the `clabverter` binary is missing (which is why every other suite stubs it out).
+We load the module directly from its file with `os.path.exists`/`os.access`
+patched so the guard passes; loading by path sidesteps apps/controllers/__init__
+(which eagerly imports the real k8s/git controllers) and never touches
+sys.modules["apps.controllers.clabernetes"], so it can't disturb the shared stub
+the other suites rely on. `subprocess` is mocked for convert_clab.
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_clabernetes.py -v
+"""
+import importlib.util
+import os
+import subprocess
+import sys
+import types
+
+import pytest
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_PATH = os.path.join(REPO_ROOT, "apps", "controllers", "clabernetes.py")
+_CLABVERTER_BIN = "/usr/local/bin/clabverter"
+
+# --- import the module past its clabverter binary guard ---------------------
+_real_exists, _real_access = os.path.exists, os.access
+os.path.exists = lambda p, *a, **k: True if p == _CLABVERTER_BIN else _real_exists(p, *a, **k)
+os.access = lambda p, m, *a, **k: True if p == _CLABVERTER_BIN else _real_access(p, m, *a, **k)
+try:
+    _spec = importlib.util.spec_from_file_location("clabernetes_under_test", _PATH)
+    c9s_mod = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(c9s_mod)
+finally:
+    os.path.exists, os.access = _real_exists, _real_access
+
+C9sController = c9s_mod.C9sController
+
+
+# --- fixtures / helpers -------------------------------------------------
+@pytest.fixture()
+def c9s():
+    return C9sController()
+
+
+def write_topology(directory, topology, filename="test.clab.yaml"):
+    path = os.path.join(directory, filename)
+    with open(path, "w") as f:
+        yaml.dump(topology, f)
+    return path
+
+
+def valid_topology():
+    return {
+        "name": "mylab",
+        "topology": {
+            "nodes": {
+                "r1": {
+                    "kind": "linux",
+                    "ports": ["8080:80", "53/udp"],
+                    "startup-config": "configs/r1.cfg",
+                    "binds": ["configs/r1.cfg:/etc/config"],
+                    "imagePullSecrets": ["myreg"],
+                }
+            }
+        },
+    }
+
+
+# --- filename_from_uploads ----------------------------------------------
+class TestFilenameFromUploads:
+    def test_resolves_to_uploaded_basename(self, c9s):
+        assert c9s.filename_from_uploads("configs/r1.cfg", ["r1.cfg", "other.txt"]) == "r1.cfg"
+
+    def test_returns_original_when_no_match(self, c9s):
+        assert c9s.filename_from_uploads("startup.cfg", ["r1.cfg"]) == "startup.cfg"
+
+
+# --- clean_up_for_clab_graph --------------------------------------------
+class TestCleanUpForClabGraph:
+    def test_removes_binds_everywhere(self, c9s):
+        topology = {
+            "topology": {
+                "defaults": {"binds": ["a:b"], "image": "x"},
+                "kinds": {"linux": {"binds": ["c:d"]}},
+                "groups": {"g1": {"binds": ["e:f"]}},
+                "nodes": {"n1": {"binds": ["g:h"], "kind": "linux"}},
+            }
+        }
+        result = c9s.clean_up_for_clab_graph(topology)
+        assert "binds" not in result["topology"]["defaults"]
+        assert "binds" not in result["topology"]["kinds"]["linux"]
+        assert "binds" not in result["topology"]["groups"]["g1"]
+        assert "binds" not in result["topology"]["nodes"]["n1"]
+        assert result["topology"]["defaults"]["image"] == "x"  # untouched
+
+    def test_minimal_topology_without_optional_blocks(self, c9s):
+        topology = {"topology": {"nodes": {"n1": {"binds": ["x:y"]}}}}
+        result = c9s.clean_up_for_clab_graph(topology)
+        assert "binds" not in result["topology"]["nodes"]["n1"]
+
+
+# --- check_topology_secrets ---------------------------------------------
+class TestCheckTopologySecrets:
+    def test_all_known_secrets_are_rewritten(self, c9s):
+        topology = {"topology": {"nodes": {"n1": {"imagePullSecrets": ["s1"]}}}}
+        failed = c9s.check_topology_secrets(topology, {"s1": "ks1"})
+        assert failed == []
+        assert topology["topology"]["nodes"]["n1"]["imagePullSecrets"] == ["ks1"]
+
+    def test_unknown_secret_is_reported(self, c9s):
+        topology = {"topology": {"nodes": {"n1": {"imagePullSecrets": ["s1", "s2"]}}}}
+        failed = c9s.check_topology_secrets(topology, {"s1": "ks1"})
+        assert len(failed) == 1
+        assert "s2" in failed[0]
+        # known one still rewritten, unknown one left as-is
+        assert topology["topology"]["nodes"]["n1"]["imagePullSecrets"] == ["ks1", "s2"]
+
+    def test_defaults_and_kinds_are_covered(self, c9s):
+        topology = {
+            "topology": {
+                "nodes": {},
+                "defaults": {"imagePullSecrets": ["d1"]},
+                "kinds": {"linux": {"imagePullSecrets": ["k1"]}},
+            }
+        }
+        failed = c9s.check_topology_secrets(topology, {"d1": "kd1", "k1": "kk1"})
+        assert failed == []
+        assert topology["topology"]["defaults"]["imagePullSecrets"] == ["kd1"]
+        assert topology["topology"]["kinds"]["linux"]["imagePullSecrets"] == ["kk1"]
+
+
+# --- process_clab_topology ----------------------------------------------
+class TestProcessClabTopology:
+    def test_no_topology_file(self, c9s, tmp_path):
+        status, msg = c9s.process_clab_topology(str(tmp_path), clab_uuid="abc")
+        assert status is False
+        assert "No ContainerLab topology file" in msg
+
+    def test_too_many_topology_files(self, c9s, tmp_path):
+        write_topology(str(tmp_path), valid_topology(), filename="a.clab.yaml")
+        write_topology(str(tmp_path), valid_topology(), filename="b.clab.yaml")
+        status, msg = c9s.process_clab_topology(str(tmp_path), clab_uuid="abc")
+        assert status is False
+        assert "Too many ContainerLab topology files" in msg
+
+    def test_invalid_topology_content(self, c9s, tmp_path):
+        # a file with no "topology" key
+        write_topology(str(tmp_path), {"name": "x"}, filename="bad.clab.yaml")
+        status, msg = c9s.process_clab_topology(str(tmp_path), clab_uuid="abc")
+        assert status is False
+        assert "Failed to load ContainerLab topology" in msg
+
+    def test_happy_path(self, c9s, tmp_path):
+        write_topology(str(tmp_path), valid_topology())
+        # an uploaded file that the startup-config/binds paths resolve to
+        with open(os.path.join(str(tmp_path), "r1.cfg"), "w") as f:
+            f.write("hostname r1\n")
+
+        status, topology = c9s.process_clab_topology(
+            str(tmp_path), clab_uuid="abc", secrets={"myreg": "clab-secret-x"}
+        )
+        assert status is True
+        assert topology["name"] == "clab-abc"
+        assert topology["ports"] == {"r1": {"80": "8080:80", "53": "53/udp"}}
+        assert topology["topology"]["nodes"]["r1"]["imagePullSecrets"] == ["clab-secret-x"]
+        assert topology["topology"]["nodes"]["r1"]["startup-config"] == "r1.cfg"
+        # binds are stripped from the returned (visualizer) topology
+        assert "binds" not in topology["topology"]["nodes"]["r1"]
+        # file was renamed to the uuid form; the original was removed
+        assert os.path.exists(os.path.join(str(tmp_path), "clab-abc.clab.yaml"))
+        assert not os.path.exists(os.path.join(str(tmp_path), "test.clab.yaml"))
+
+    def test_missing_secret_fails(self, c9s, tmp_path):
+        write_topology(str(tmp_path), valid_topology())
+        status, msg = c9s.process_clab_topology(str(tmp_path), clab_uuid="abc", secrets={})
+        assert status is False
+        assert "Failed to find imagePullSecrets" in msg
+
+
+# --- convert_clab (subprocess mocked) -----------------------------------
+def _fake_subprocess(run):
+    return types.SimpleNamespace(run=run, CalledProcessError=subprocess.CalledProcessError)
+
+
+class TestConvertClab:
+    def test_success_strips_namespace(self, c9s, monkeypatch):
+        stdout = (
+            "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm1\n"
+            "---\n"
+            "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: clab-ns\n"
+            "---\n"
+            "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: d1\n"
+        )
+        monkeypatch.setattr(
+            c9s_mod, "subprocess",
+            _fake_subprocess(lambda *a, **k: types.SimpleNamespace(stdout=stdout, returncode=0)),
+        )
+        status, result = c9s.convert_clab("/tmp/whatever", destination_namespace="ns")
+        assert status is True
+        assert "kind: Namespace" not in result
+        assert "kind: ConfigMap" in result
+        assert "kind: Deployment" in result
+
+    def test_no_namespace_component(self, c9s, monkeypatch):
+        stdout = "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm1\n"
+        monkeypatch.setattr(
+            c9s_mod, "subprocess",
+            _fake_subprocess(lambda *a, **k: types.SimpleNamespace(stdout=stdout, returncode=0)),
+        )
+        status, result = c9s.convert_clab("/tmp/whatever", destination_namespace="ns")
+        assert status is False
+        assert "could not find Namespace component" in result
+
+    def test_called_process_error(self, c9s, monkeypatch):
+        def boom(*a, **k):
+            raise subprocess.CalledProcessError(returncode=1, cmd=["clabverter"], stderr="clabverter exploded")
+        monkeypatch.setattr(c9s_mod, "subprocess", _fake_subprocess(boom))
+        status, result = c9s.convert_clab("/tmp/whatever", destination_namespace="ns")
+        assert status is False
+        assert "clabverter exploded" in result
+
+    def test_generic_exception(self, c9s, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("kaboom")
+        monkeypatch.setattr(c9s_mod, "subprocess", _fake_subprocess(boom))
+        status, result = c9s.convert_clab("/tmp/whatever", destination_namespace="ns")
+        assert status is False
+        assert "kaboom" in result
+
+
+# --- get_topology_visualizer_manifest -----------------------------------
+class TestVisualizerManifest:
+    def test_substitutes_uuid_and_embeds_topology(self, c9s):
+        topology = {"name": "clab-myid", "topology": {"nodes": {"n1": {"kind": "linux"}}}}
+        manifest = c9s.get_topology_visualizer_manifest("myid", topology)
+        assert "%CLAB_UUID%" not in manifest
+        assert "topo-viewer-clab-myid" in manifest
+        assert "kind: Deployment" in manifest
+        assert "kind: Service" in manifest
+        assert "kind: ConfigMap" in manifest
+        # the topology is embedded in the ConfigMap's data
+        assert "topology-data-clab-myid" in manifest
+        assert "clab-myid" in manifest

--- a/tests/test_clabs.py
+++ b/tests/test_clabs.py
@@ -1,0 +1,404 @@
+"""Pytest suite for the ContainerLab upsert route.
+
+Mirrors tests/test_lab_categories.py: covers upsert in apps/clabs/routes.py -
+role gating, load/permission branches (not-found, non-clab redirect, labcreator
+ownership, no-categories guard), the manifest-only create/edit happy path, the
+registry-secret path (k8s faked), the file-upload/topology-conversion path (c9s
+faked) with its failure branches, the too-many-files guard, and the automatic
+"ContainerLab" category attachment.
+
+The `c9s`/`k8s` controllers are lazy proxies pointed at a stub that raises on
+attribute access; they are only reached when secrets or files are submitted, so
+those tests replace the whole module-level name with a small fake. Every other
+branch returns before any controller call.
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3). Uploaded files land in the temp DATA_DIR's containerlab/.
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_clabs.py -v
+
+Note: the classes below are ordered, stateful workflows rather than
+independent unit tests - pytest runs test methods within a class in
+definition order by default, which this suite relies on. Do not run with a
+random-order plugin (e.g. pytest-randomly) without disabling it for this file.
+
+The seeded usernames are all prefixed "cl" so they never collide with the
+other test modules that share the same singleton app/database (apps/config.py
+reads DATA_DIR once at import time, so every module ends up on one DB).
+"""
+import io
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db  # noqa: E402
+from apps.authentication.models import Users, Groups  # noqa: E402
+from apps.home.models import Labs, LabCategories, LabMetadata  # noqa: E402
+import apps.clabs.routes  # noqa: E402,F401  (attaches the routes to the blueprint)
+from apps.clabs import blueprint as clabs_blueprint  # noqa: E402
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+# The clabs blueprint is an optional module; the shared test harness disables
+# OPTIONAL_MODULES, so register it here if it isn't already (idempotent, and
+# safe because no request has been served yet at import time).
+if "clabs_blueprint" not in flask_app.blueprints:
+    flask_app.register_blueprint(clabs_blueprint)
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def ids(app):
+    admin = Users(username="cladmin", password="admin123", email="cladmin@test.local", category="admin")
+    creator = Users(username="clcreator", password="lc123", email="clcreator@test.local", category="labcreator")
+    creator2 = Users(username="clcreator2", password="lc123", email="clcreator2@test.local", category="labcreator")
+    student = Users(username="clstudent", password="stud123", email="clstudent@test.local", category="student")
+    db.session.add_all([admin, creator, creator2, student])
+    db.session.commit()
+
+    category = LabCategories(category="ClCat", color_cls="dark")
+    category.updated_by = None
+    db.session.add(category)
+
+    group = Groups(groupname="ClGroup", organization="ORG1")
+    db.session.add(group)
+
+    # a plain (non-clab) lab -> upsert must redirect it to the normal editor
+    plain = Labs(title="Plain Lab", description="not a containerlab")
+    db.session.add(plain)
+    db.session.commit()
+
+    # an existing clab owned by cladmin -> used for the labcreator gate
+    existing = Labs(title="Existing Clab", description="owned by cladmin")
+    existing.updated_by = admin.id
+    db.session.add(existing)
+    db.session.commit()
+    existing_md = LabMetadata(lab=existing, is_clab=True)
+    db.session.add(existing_md)
+    db.session.commit()
+
+    return {
+        "admin_id": admin.id,
+        "creator_id": creator.id,
+        "creator2_id": creator2.id,
+        "student_id": student.id,
+        "category_id": category.id,
+        "group_id": group.id,
+        "plain_lab_id": plain.id,
+        "existing_clab_id": existing.id,
+    }
+
+
+# --- helpers -----------------------------------------------------------
+def login(client, username, password):
+    resp = client.post(
+        "/login/",
+        data={"identifier": username, "password": password, "login": "1"},
+    )
+    return resp.status_code == 302
+
+
+def logout(client):
+    client.get("/logout")
+
+
+def clab_form(**overrides):
+    """A complete /containerlabs/upsert POST body; override individual fields as needed."""
+    data = {
+        "clab_title": "",
+        "clab_desc": "",
+        "clab_extended_desc": "extended description",
+        "clab_guide": "# guide",
+        "clab_yaml": "",
+        "clab_goals": "",
+    }
+    data.update(overrides)
+    return data
+
+
+def fake_k8s():
+    return types.SimpleNamespace(
+        create_registry_secret=lambda **kwargs: (True, ""),
+        delete_secret_by_name=lambda name: None,
+    )
+
+
+def fake_c9s(process=(True, {"ports": {}, "nodes": {}}), convert=(True, "converted-manifest")):
+    return types.SimpleNamespace(
+        process_clab_topology=lambda *a, **k: process,
+        convert_clab=lambda *a, **k: convert,
+        check_topology_secrets=lambda *a, **k: [],
+    )
+
+
+# --- role gating --------------------------------------------------------
+class TestRoleGating:
+    def test_student_is_rejected(self, client, ids):
+        logout(client)
+        login(client, "clstudent", "stud123")
+        resp = client.get("/containerlabs/upsert/new")
+        assert b"Unauthorized request" in resp.data
+        logout(client)
+
+
+# --- load & permissions -------------------------------------------------
+class TestLoadAndPermissions:
+    def test_missing_clab(self, client, ids):
+        login(client, "cladmin", "admin123")
+        resp = client.get("/containerlabs/upsert/does-not-exist")
+        assert b"ContainerLab not found" in resp.data
+
+    def test_non_clab_redirects_to_edit_lab(self, client, ids):
+        resp = client.get(f"/containerlabs/upsert/{ids['plain_lab_id']}")
+        assert resp.status_code == 302
+        assert f"/labs/edit/{ids['plain_lab_id']}" in resp.headers["Location"]
+        logout(client)
+
+    def test_labcreator_cannot_edit_others_clab(self, client, ids):
+        login(client, "clcreator", "lc123")
+        resp = client.get(f"/containerlabs/upsert/{ids['existing_clab_id']}")
+        assert b"You don&#39;t have permission to edit this Lab." in resp.data
+        logout(client)
+
+    def test_no_categories_guard(self, client, ids):
+        login(client, "cladmin", "admin123")
+        active = LabCategories.query.filter_by(is_deleted=False).all()
+        for cat in active:
+            cat.is_deleted = True
+        db.session.commit()
+        try:
+            resp = client.get("/containerlabs/upsert/new")
+            assert b"No Lab Categories found" in resp.data
+        finally:
+            for cat in active:
+                cat.is_deleted = False
+            db.session.commit()
+            logout(client)
+
+
+# --- GET form -----------------------------------------------------------
+class TestGetForm:
+    def test_get_new_renders_form(self, client, ids):
+        login(client, "cladmin", "admin123")
+        resp = client.get("/containerlabs/upsert/new")
+        assert resp.status_code == 200
+        logout(client)
+
+
+# --- create (manifest-only, no controllers) -----------------------------
+class TestCreate:
+    def test_requires_git_or_files_or_manifest(self, client, ids):
+        login(client, "cladmin", "admin123")
+        resp = client.post(
+            "/containerlabs/upsert/new",
+            data=clab_form(clab_title="Empty Clab", clab_categories=str(ids["category_id"])),
+        )
+        assert resp.status_code == 400
+        assert b"Provide GIT URL or files" in resp.data
+
+    def test_requires_a_category(self, client, ids):
+        resp = client.post(
+            "/containerlabs/upsert/new",
+            data=clab_form(clab_title="No Cat Clab", clab_yaml="name: topo"),
+        )
+        assert b"Please select at least one category" in resp.data
+
+    def test_manifest_only_create_succeeds(self, client, ids):
+        resp = client.post(
+            "/containerlabs/upsert/new",
+            data=clab_form(
+                clab_title="Manifest Clab",
+                clab_desc="made from a manifest",
+                clab_yaml="name: topo",
+                clab_categories=str(ids["category_id"]),
+                clab_allowed_groups=str(ids["group_id"]),
+            ),
+        )
+        assert resp.status_code == 201
+        assert resp.get_json()["ok"] is True
+
+        clab = Labs.query.filter_by(title="Manifest Clab").first()
+        assert clab is not None
+        assert clab.is_clab is True
+        assert clab.manifest == "name: topo"
+        logout(client)
+
+
+# --- edit existing ------------------------------------------------------
+class TestEditExisting:
+    def test_get_existing_renders(self, client, ids):
+        login(client, "cladmin", "admin123")
+        clab = Labs.query.filter_by(title="Manifest Clab").first()
+        resp = client.get(f"/containerlabs/upsert/{clab.id}")
+        assert resp.status_code == 200
+
+    def test_edit_updates_title(self, client, ids):
+        clab = Labs.query.filter_by(title="Manifest Clab").first()
+        resp = client.post(
+            f"/containerlabs/upsert/{clab.id}",
+            data=clab_form(
+                clab_title="Manifest Clab v2",
+                clab_yaml="name: topo",
+                clab_categories=str(ids["category_id"]),
+            ),
+        )
+        assert resp.status_code == 201
+
+        db.session.refresh(clab)
+        assert clab.title == "Manifest Clab v2"
+        logout(client)
+
+
+# --- registry secrets (k8s faked) ---------------------------------------
+class TestSecrets:
+    def test_create_with_secret_persists_it(self, client, ids, monkeypatch):
+        monkeypatch.setattr("apps.clabs.routes.k8s", fake_k8s())
+        login(client, "cladmin", "admin123")
+        resp = client.post(
+            "/containerlabs/upsert/new",
+            data=clab_form(
+                clab_title="Secret Clab",
+                clab_yaml="name: topo",
+                clab_categories=str(ids["category_id"]),
+                **{
+                    "secret-name": "myreg",
+                    "secret-server": "registry.example.com",
+                    "secret-user": "bob",
+                    "secret-pass": "s3cr3t",
+                },
+            ),
+        )
+        assert resp.status_code == 201
+
+        clab = Labs.query.filter_by(title="Secret Clab").first()
+        assert "myreg" in clab.lab_metadata.md.get("secrets", {}).get("name", {})
+        logout(client)
+
+
+# --- file upload / topology conversion (c9s faked) ----------------------
+class TestFileUpload:
+    def _upload(self, client, ids, title, content=b"nodes: {}"):
+        return client.post(
+            "/containerlabs/upsert/new",
+            data=clab_form(
+                clab_title=title,
+                clab_categories=str(ids["category_id"]),
+                clab_files=(io.BytesIO(content), "topo.yaml"),
+                relative_paths="topo.yaml",
+            ),
+            content_type="multipart/form-data",
+        )
+
+    def test_upload_converts_and_saves_manifest(self, client, ids, monkeypatch):
+        monkeypatch.setattr("apps.clabs.routes.c9s", fake_c9s())
+        login(client, "cladmin", "admin123")
+        resp = self._upload(client, ids, "Uploaded Clab")
+        assert resp.status_code == 201
+
+        clab = Labs.query.filter_by(title="Uploaded Clab").first()
+        assert clab.manifest == "converted-manifest"
+
+    def test_topology_parse_failure_is_reported(self, client, ids, monkeypatch):
+        monkeypatch.setattr("apps.clabs.routes.c9s", fake_c9s(process=(False, "bad topo")))
+        resp = self._upload(client, ids, "Bad Topo Clab")
+        assert resp.status_code == 400
+        assert b"Failed to parse ContainerLab topology" in resp.data
+
+    def test_conversion_failure_is_reported(self, client, ids, monkeypatch):
+        monkeypatch.setattr("apps.clabs.routes.c9s", fake_c9s(convert=(False, "convert err")))
+        resp = self._upload(client, ids, "Bad Convert Clab")
+        assert resp.status_code == 400
+        assert b"convert err" in resp.data
+        logout(client)
+
+
+# --- too many files (needs the files_count -> len(files) fix) -----------
+class TestTooManyFiles:
+    def test_over_the_limit_is_rejected(self, client, ids, monkeypatch):
+        monkeypatch.setitem(flask_app.config, "CLABS_UPLOAD_MAX_FILES", 1)
+        login(client, "cladmin", "admin123")
+        resp = client.post(
+            "/containerlabs/upsert/new",
+            data=clab_form(
+                clab_title="Too Many Files Clab",
+                clab_categories=str(ids["category_id"]),
+                clab_files=[
+                    (io.BytesIO(b"a"), "a.yaml"),
+                    (io.BytesIO(b"b"), "b.yaml"),
+                ],
+                relative_paths=["a.yaml", "b.yaml"],
+            ),
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert b"Too many files" in resp.data
+        logout(client)
+
+
+# --- automatic "ContainerLab" category (runs last: seeds that category) --
+class TestAutoAppendContainerLabCategory:
+    def test_container_lab_category_is_auto_attached(self, client, ids):
+        clab_cat = LabCategories(category="ContainerLab", color_cls="info")
+        clab_cat.updated_by = None
+        db.session.add(clab_cat)
+        db.session.commit()
+
+        login(client, "cladmin", "admin123")
+        resp = client.post(
+            "/containerlabs/upsert/new",
+            data=clab_form(clab_title="Auto Cat Clab", clab_yaml="name: topo"),
+        )
+        assert resp.status_code == 201
+
+        clab = Labs.query.filter_by(title="Auto Cat Clab").first()
+        assert clab_cat.id in [c.id for c in clab.categories]
+        logout(client)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,252 @@
+"""Pytest suite for apps/events.py (xterm/PTY Socket.IO handlers).
+
+The app uses Socket.IO with gevent, and these handlers do PTY/stream I/O and
+spawn background tasks - so instead of driving a real socketio test client
+(slow/flaky), the functions are called directly with their boundaries mocked,
+inside plain Flask app/request contexts. No database is used.
+
+Techniques:
+- @login_required on the handlers is bypassed with LOGIN_DISABLED=True plus a
+  monkeypatched module-global `events.current_user`.
+- request.sid is set inside a test_request_context; pty_connect's host comes from
+  the query string.
+- os/select/socketio/k8s are monkeypatched on the module so nothing real runs.
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_events.py -v
+"""
+import os
+import sys
+import tempfile
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+import apps.events as events  # noqa: E402
+from flask import request  # noqa: E402
+
+flask_app.config["TESTING"] = True
+
+DEFAULT_START = 'if [ -x /bin/bash ]; then exec /bin/bash; else exec /bin/sh; fi'
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(autouse=True)
+def _clear_clients():
+    events.xterm_clients.clear()
+    yield
+    events.xterm_clients.clear()
+
+
+@pytest.fixture()
+def logged_in(monkeypatch):
+    """Neutralise @login_required and give the handlers a current_user."""
+    monkeypatch.setitem(flask_app.config, "LOGIN_DISABLED", True)
+    monkeypatch.setattr(events, "current_user", types.SimpleNamespace(username="tester", is_authenticated=True))
+
+
+@pytest.fixture()
+def captured_emits(monkeypatch):
+    emits = []
+    monkeypatch.setattr(events.socketio, "emit", lambda *a, **k: emits.append((a, k)))
+    monkeypatch.setattr(events.socketio, "sleep", lambda *a, **k: None)
+    return emits
+
+
+# --- standalone helpers -------------------------------------------------
+class TestHelpers:
+    def test_check_authorization(self):
+        assert events.check_authorization("user", "pod", "container") is True
+
+    def test_resize_terminal(self):
+        stream = MagicMock()
+        events.resize_terminal(stream, 24, 80)
+        stream.write_channel.assert_called_once_with(4, '{"Width":80,"Height":24}')
+
+    def test_set_winsize(self):
+        import fcntl
+        import struct
+        import termios
+
+        master, slave = os.openpty()
+        try:
+            events.set_winsize(slave, 24, 80)
+            packed = fcntl.ioctl(slave, termios.TIOCGWINSZ, struct.pack("HHHH", 0, 0, 0, 0))
+            rows, cols, _, _ = struct.unpack("HHHH", packed)
+            assert (rows, cols) == (24, 80)
+        finally:
+            os.close(master)
+            os.close(slave)
+
+    def test_read_and_forward_k8s_stream_output(self, captured_emits):
+        stream = MagicMock()
+        stream.is_open.side_effect = [True, True, False]
+        stream.read_stdout.return_value = "hello"
+
+        events.read_and_forward_k8s_stream_output("sid1", stream)
+
+        assert captured_emits[0][0][0] == "pty-output"
+        assert captured_emits[0][0][1] == {"output": "hello"}
+        assert captured_emits[-1][0][0] == "server-disconnected"
+
+    def test_read_and_forward_pty_output(self, captured_emits, monkeypatch):
+        fd, pid = 5, 4321
+        fake_select = MagicMock(side_effect=[([fd], [], []), ([fd], [], [fd])])
+        monkeypatch.setattr(events, "select", types.SimpleNamespace(select=fake_select))
+        monkeypatch.setattr(events, "os", types.SimpleNamespace(
+            read=lambda f, n: b"hello",
+            waitpid=lambda p, opt: (pid, 0),
+            waitstatus_to_exitcode=lambda s: 0,
+            WNOHANG=os.WNOHANG,
+        ))
+
+        events.read_and_forward_pty_output("sid1", fd, pid)
+
+        assert captured_emits[0][0][0] == "pty-output"
+        assert captured_emits[0][0][1] == {"output": "hello"}
+        assert captured_emits[-1][0][0] == "server-disconnected"
+        assert captured_emits[-1][0][1] == {"returncode": 0}
+
+
+# --- pty_connect --------------------------------------------------------
+class TestPtyConnect:
+    def test_invalid_host_is_rejected(self, logged_in):
+        with flask_app.test_request_context("/"):
+            request.sid = "sid1"
+            assert events.pty_connect(None) is False
+        assert events.xterm_clients == {}
+
+    def test_happy_path_registers_session(self, logged_in, monkeypatch):
+        fake_stream = MagicMock()
+        get_stream = MagicMock(return_value=fake_stream)
+        monkeypatch.setattr(events, "k8s", types.SimpleNamespace(get_pod_exec_stream=get_stream))
+        bg = MagicMock()
+        monkeypatch.setattr(events.socketio, "start_background_task", bg)
+
+        with flask_app.test_request_context("/?host=pod/mypod/mycont"):
+            request.sid = "sid1"
+            events.pty_connect(None)
+
+        assert events.xterm_clients["sid1"] is fake_stream
+        get_stream.assert_called_once_with("mypod", "mycont", DEFAULT_START)
+        bg.assert_called_once()
+
+    def test_clab_kind_uses_ssh_start_script(self, logged_in, monkeypatch):
+        get_stream = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr(events, "k8s", types.SimpleNamespace(get_pod_exec_stream=get_stream))
+        monkeypatch.setattr(events.socketio, "start_background_task", MagicMock())
+
+        with flask_app.test_request_context("/?host=clab/mypod/mycont"):
+            request.sid = "sid1"
+            events.pty_connect(None)
+
+        get_stream.assert_called_once_with("mypod", "mycont", "ssh mycont")
+
+    def test_already_connected_is_rejected(self, logged_in, monkeypatch):
+        sentinel = object()
+        events.xterm_clients["sid1"] = sentinel
+        monkeypatch.setattr(events, "k8s", types.SimpleNamespace(get_pod_exec_stream=MagicMock()))
+
+        with flask_app.test_request_context("/?host=pod/mypod/mycont"):
+            request.sid = "sid1"
+            assert events.pty_connect(None) is False
+
+        assert events.xterm_clients["sid1"] is sentinel  # not overwritten
+
+
+# --- pty_input ----------------------------------------------------------
+class TestPtyInput:
+    def test_not_connected_returns_false(self, logged_in):
+        with flask_app.test_request_context("/"):
+            request.sid = "sid1"
+            assert events.pty_input({"input": "ls\n"}) is False
+
+    def test_connected_writes_stdin(self, logged_in):
+        stream = MagicMock()
+        stream.is_open.return_value = True
+        events.xterm_clients["sid1"] = stream
+
+        with flask_app.test_request_context("/"):
+            request.sid = "sid1"
+            events.pty_input({"input": "ls\n"})
+
+        stream.write_stdin.assert_called_once_with(b"ls\n")
+
+
+# --- resize -------------------------------------------------------------
+class TestResize:
+    def test_not_connected_returns_false(self, logged_in):
+        with flask_app.test_request_context("/"):
+            request.sid = "sid1"
+            assert events.resize({"dims": {"rows": 24, "cols": 80}}) is False
+
+    def test_connected_resizes(self, logged_in):
+        stream = MagicMock()
+        events.xterm_clients["sid1"] = stream
+
+        with flask_app.test_request_context("/"):
+            request.sid = "sid1"
+            events.resize({"dims": {"rows": 24, "cols": 80}})
+
+        stream.write_channel.assert_called_once_with(4, '{"Width":80,"Height":24}')
+
+
+# --- pty_disconnect -----------------------------------------------------
+class TestPtyDisconnect:
+    def test_not_connected_returns_false(self, logged_in):
+        with flask_app.test_request_context("/"):
+            request.sid = "sid1"
+            assert events.pty_disconnect() is False
+
+    def test_connected_closes_and_removes(self, logged_in):
+        stream = MagicMock()
+        events.xterm_clients["sid1"] = stream
+
+        with flask_app.test_request_context("/"):
+            request.sid = "sid1"
+            events.pty_disconnect()
+
+        stream.close.assert_called_once()
+        assert "sid1" not in events.xterm_clients
+
+    def test_close_error_is_swallowed(self, logged_in):
+        stream = MagicMock()
+        stream.close.side_effect = RuntimeError("boom")
+        events.xterm_clients["sid1"] = stream
+
+        with flask_app.test_request_context("/"):
+            request.sid = "sid1"
+            events.pty_disconnect()
+
+        assert "sid1" not in events.xterm_clients

--- a/tests/test_git_controller.py
+++ b/tests/test_git_controller.py
@@ -1,0 +1,164 @@
+"""Pytest suite for apps/controllers/git.py (GitController).
+
+Covers update_repo (refresh short-circuit, clone, pull, and both error
+branches), list_files, and get_file. GitPython is mocked via monkeypatch on
+apps.controllers.git.git; the filesystem helpers use a real tmp dir. Runs inside
+an app context so current_app.logger works in the error paths.
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_git_controller.py -v
+"""
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+import importlib  # noqa: E402
+
+from run import app as flask_app  # noqa: E402
+
+# NB: `apps.controllers.git` the *name* is a lazy proxy in the package
+# namespace; import the real submodule so we can patch GitPython on it.
+git_module = importlib.import_module("apps.controllers.git")
+GitController = git_module.GitController
+
+flask_app.config["TESTING"] = True
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(autouse=True)
+def _app_context():
+    with flask_app.app_context():
+        yield
+
+
+@pytest.fixture()
+def ctrl():
+    return GitController()
+
+
+# --- update_repo --------------------------------------------------------
+class TestUpdateRepo:
+    def test_refresh_interval_short_circuits(self, ctrl, monkeypatch, tmp_path):
+        calls = {"clone": 0}
+
+        def fake_clone(*a, **k):
+            calls["clone"] += 1
+
+        monkeypatch.setattr(git_module.git.Repo, "clone_from", staticmethod(fake_clone))
+        target = str(tmp_path / "repo")
+
+        assert ctrl.update_repo("http://x", target, refresh_interval=9999) is True
+        # second call within the interval must not clone again
+        assert ctrl.update_repo("http://x", target, refresh_interval=9999) is True
+        assert calls["clone"] == 1
+
+    def test_clone_when_missing(self, ctrl, monkeypatch, tmp_path):
+        called = {}
+
+        def fake_clone(url, dest, **k):
+            called["url"] = url
+
+        monkeypatch.setattr(git_module.git.Repo, "clone_from", staticmethod(fake_clone))
+        target = str(tmp_path / "newrepo")
+        assert ctrl.update_repo("http://example/repo.git", target, refresh_interval=0) is True
+        assert called["url"] == "http://example/repo.git"
+
+    def test_pull_when_present(self, ctrl, monkeypatch, tmp_path):
+        target = tmp_path / "existing"
+        target.mkdir()
+        pulled = {"n": 0}
+
+        class FakeOrigin:
+            def pull(self, **k):
+                pulled["n"] += 1
+
+        class FakeRepo:
+            def __init__(self, path):
+                self.remotes = types.SimpleNamespace(origin=FakeOrigin())
+
+        monkeypatch.setattr(git_module.git, "Repo", FakeRepo)
+        assert ctrl.update_repo("http://x", str(target), refresh_interval=0) is True
+        assert pulled["n"] == 1
+
+    def test_git_command_error_returns_false(self, ctrl, monkeypatch, tmp_path):
+        def boom(*a, **k):
+            raise git_module.git.GitCommandError("clone", "failed")
+
+        monkeypatch.setattr(git_module.git.Repo, "clone_from", staticmethod(boom))
+        target = str(tmp_path / "willfail")
+        assert ctrl.update_repo("http://x", target, refresh_interval=0) is False
+
+    def test_generic_error_returns_false(self, ctrl, monkeypatch, tmp_path):
+        def boom(*a, **k):
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(git_module.git.Repo, "clone_from", staticmethod(boom))
+        target = str(tmp_path / "willfail2")
+        assert ctrl.update_repo("http://x", target, refresh_interval=0) is False
+
+
+# --- list_files ---------------------------------------------------------
+class TestListFiles:
+    def test_lists_matching_files(self, ctrl, tmp_path):
+        (tmp_path / "a.yaml").write_text("a")
+        (tmp_path / "b.yaml").write_text("b")
+        (tmp_path / "c.txt").write_text("c")
+        result = ctrl.list_files(str(tmp_path), pattern="*.yaml", recursive=False)
+        assert sorted(result) == ["a.yaml", "b.yaml"]
+
+
+# --- get_file -----------------------------------------------------------
+class TestGetFile:
+    def test_missing_file(self, ctrl, tmp_path):
+        status, result = ctrl.get_file(str(tmp_path), "nope.yaml")
+        assert status is False
+        assert result == "Template not found"
+
+    def test_existing_file(self, ctrl, tmp_path):
+        (tmp_path / "t.yaml").write_text("hello: world")
+        status, result = ctrl.get_file(str(tmp_path), "t.yaml")
+        assert status is True
+        assert result == "hello: world"
+
+    def test_read_error(self, ctrl, tmp_path, monkeypatch):
+        (tmp_path / "t.yaml").write_text("x")
+
+        def boom(self, *a, **k):
+            raise OSError("disk gone")
+
+        monkeypatch.setattr(git_module.Path, "read_text", boom)
+        status, result = ctrl.get_file(str(tmp_path), "t.yaml")
+        assert status is False
+        assert "Failed to read template file" in result

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,0 +1,343 @@
+"""Pytest suite for the Groups CRUD feature.
+
+Mirrors tests/test_lab_categories.py: exercises list visibility per role
+(including the SYSTEM-organization restriction), create/edit workflows,
+teacher ownership rules, approved-users e-mail validation, membership
+mutation, and the admin/teacher-owner soft-delete API.
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3).
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_groups.py -v
+
+Note: the classes below are ordered, stateful workflows rather than
+independent unit tests - pytest runs test methods within a class in
+definition order by default, which this suite relies on. Do not run with a
+random-order plugin (e.g. pytest-randomly) without disabling it for this file.
+
+The seeded usernames are all prefixed "gr" so they never collide with the
+other test modules that share the same singleton app/database (apps/config.py
+reads DATA_DIR once at import time, so every module ends up on one DB).
+"""
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db  # noqa: E402
+from apps.authentication.models import Users, Groups  # noqa: E402
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def ids(app):
+    """Seed the users/groups fixtures shared by every test."""
+    admin = Users(username="gradmin", password="admin123", email="gradmin@test.local", category="admin")
+    teacher_a = Users(username="grteachera", password="teach123", email="grta@test.local", category="teacher")
+    teacher_b = Users(username="grteacherb", password="teach123", email="grtb@test.local", category="teacher")
+    student = Users(username="grstudent", password="stud123", email="grsa@test.local", category="student")
+    labcreator = Users(username="grlabcreator", password="lc123", email="grlc@test.local", category="labcreator")
+    db.session.add_all([admin, teacher_a, teacher_b, student, labcreator])
+    db.session.commit()
+
+    normal = Groups(groupname="NormalGroup", organization="ORG1")
+    system = Groups(groupname="SystemGroup", organization="SYSTEM")
+    # a group owned by teacherA, used for the ownership tests
+    owned = Groups(groupname="TeacherOwned", organization="ORG2")
+    owned.owners.append(teacher_a)
+    # a group with a member, deleted by admin (guards the dict_keys fix)
+    deleteme = Groups(groupname="DeleteMe", organization="ORG3")
+    deleteme.members.append(student)
+    db.session.add_all([normal, system, owned, deleteme])
+    db.session.commit()
+
+    return {
+        "admin_id": admin.id,
+        "teacher_a_id": teacher_a.id,
+        "teacher_b_id": teacher_b.id,
+        "student_id": student.id,
+        "labcreator_id": labcreator.id,
+        "normal_gid": normal.id,
+        "system_gid": system.id,
+        "owned_gid": owned.id,
+        "deleteme_gid": deleteme.id,
+    }
+
+
+# --- helpers -----------------------------------------------------------
+def login(client, username, password):
+    resp = client.post(
+        "/login/",
+        data={"identifier": username, "password": password, "login": "1"},
+    )
+    return resp.status_code == 302
+
+
+def logout(client):
+    client.get("/logout")
+
+
+def group_form(**overrides):
+    """A complete /groups/edit POST body; override individual fields as needed."""
+    data = {
+        "groupname": "",
+        "description": "",
+        "organization": "",
+        "expiration": "",
+        "accesstoken": "",
+        "approved_users": "",
+    }
+    data.update(overrides)
+    return data
+
+
+# --- list visibility ----------------------------------------------------
+class TestListVisibility:
+    def test_student_sees_normal_but_not_system_group(self, client, ids):
+        logout(client)
+        login(client, "grstudent", "stud123")
+        resp = client.get("/groups/list")
+        assert resp.status_code == 200
+        assert b"NormalGroup" in resp.data
+        assert b"SystemGroup" not in resp.data
+
+    def test_admin_sees_system_group(self, client, ids):
+        login(client, "gradmin", "admin123")
+        resp = client.get("/groups/list")
+        assert resp.status_code == 200
+        assert b"SystemGroup" in resp.data
+        assert b"NormalGroup" in resp.data
+        logout(client)
+
+
+# --- create workflow ----------------------------------------------------
+class TestCreate:
+    def test_admin_can_create_group(self, client, ids):
+        login(client, "gradmin", "admin123")
+        resp = client.post(
+            "/groups/edit/new",
+            data=group_form(groupname="AdminCreated", organization="ORG-NEW"),
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert b"Group updated successfully" in resp.data
+
+        group = Groups.query.filter_by(groupname="AdminCreated").first()
+        assert group is not None
+        assert group.organization == "ORG-NEW"
+        logout(client)
+
+    def test_student_cannot_create_group(self, client, ids):
+        login(client, "grstudent", "stud123")
+        resp = client.post("/groups/edit/new", data=group_form(groupname="StudentGroup"))
+        assert b"You don&#39;t have permission to edit this group." in resp.data
+        logout(client)
+
+    def test_non_admin_cannot_create_system_group(self, client, ids):
+        login(client, "grteachera", "teach123")
+        resp = client.post(
+            "/groups/edit/new",
+            data=group_form(groupname="SneakySystem", organization="SYSTEM"),
+        )
+        assert b"Only admins can create/change System groups." in resp.data
+        logout(client)
+
+
+# --- teacher ownership rules --------------------------------------------
+class TestOwnership:
+    def test_teacher_non_owner_cannot_edit(self, client, ids):
+        login(client, "grteacherb", "teach123")
+        resp = client.get(f"/groups/edit/{ids['owned_gid']}")
+        assert b"You don&#39;t have permission to edit this group." in resp.data
+        logout(client)
+
+    def test_teacher_owner_can_edit(self, client, ids):
+        login(client, "grteachera", "teach123")
+        resp = client.post(
+            f"/groups/edit/{ids['owned_gid']}",
+            data=group_form(
+                groupname="TeacherOwned",
+                organization="ORG2",
+                description="edited by owner",
+            ),
+        )
+        assert b"Group updated successfully" in resp.data
+
+        group = db.session.get(Groups, ids["owned_gid"])
+        assert group.description == "edited by owner"
+        logout(client)
+
+
+# --- approved-users validation ------------------------------------------
+class TestApprovedUsers:
+    def test_invalid_email_is_rejected(self, client, ids):
+        login(client, "gradmin", "admin123")
+        resp = client.post(
+            f"/groups/edit/{ids['normal_gid']}",
+            data=group_form(groupname="NormalGroup", organization="ORG1", approved_users="not-an-email"),
+        )
+        assert b"invalid approved users" in resp.data
+
+    def test_valid_approved_users_are_saved(self, client, ids):
+        resp = client.post(
+            f"/groups/edit/{ids['normal_gid']}",
+            data=group_form(
+                groupname="NormalGroup",
+                organization="ORG1",
+                approved_users="a@b.com, c@d.com",
+            ),
+        )
+        assert b"Group updated successfully" in resp.data
+
+        group = db.session.get(Groups, ids["normal_gid"])
+        assert group.approved_users_list == ["a@b.com", "c@d.com"]
+        logout(client)
+
+
+# --- no-op detection ----------------------------------------------------
+class TestNoOp:
+    def test_resubmitting_identical_values_reports_no_changes(self, client, ids):
+        login(client, "gradmin", "admin123")
+        # first create the group (approved_users "" is normalized to '[]')
+        client.post(
+            "/groups/edit/new",
+            data=group_form(groupname="NoOpGroup", organization="ORG-NOOP"),
+            follow_redirects=True,
+        )
+        group = Groups.query.filter_by(groupname="NoOpGroup").first()
+
+        # re-submit the exact stored values (approved_users '[]' matches, so
+        # nothing changes)
+        resp = client.post(
+            f"/groups/edit/{group.id}",
+            data=group_form(groupname="NoOpGroup", organization="ORG-NOOP", approved_users="[]"),
+        )
+        assert b"No changes were made to the group." in resp.data
+        logout(client)
+
+
+# --- membership mutation ------------------------------------------------
+class TestMembership:
+    def test_add_then_remove_member(self, client, ids):
+        login(client, "gradmin", "admin123")
+        client.post(
+            "/groups/edit/new",
+            data=group_form(groupname="MemberGroup", organization="ORG-MEM"),
+            follow_redirects=True,
+        )
+        group = Groups.query.filter_by(groupname="MemberGroup").first()
+
+        # add studentA as a member
+        resp = client.post(
+            f"/groups/edit/{group.id}",
+            data=group_form(
+                groupname="MemberGroup",
+                organization="ORG-MEM",
+                approved_users="[]",
+                group_members=str(ids["student_id"]),
+            ),
+        )
+        assert b"Group updated successfully" in resp.data
+        db.session.refresh(group)
+        assert ids["student_id"] in group.members_dict
+
+        # remove the member (submit with no group_members)
+        resp = client.post(
+            f"/groups/edit/{group.id}",
+            data=group_form(groupname="MemberGroup", organization="ORG-MEM", approved_users="[]"),
+        )
+        assert b"Group updated successfully" in resp.data
+        db.session.refresh(group)
+        assert ids["student_id"] not in group.members_dict
+        logout(client)
+
+
+# --- soft-delete API ----------------------------------------------------
+class TestDeleteApi:
+    def test_student_cannot_delete_group(self, client, ids):
+        login(client, "grstudent", "stud123")
+        resp = client.delete(f"/api/groups/{ids['normal_gid']}")
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_labcreator_cannot_delete_group(self, client, ids):
+        login(client, "grlabcreator", "lc123")
+        resp = client.delete(f"/api/groups/{ids['normal_gid']}")
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_teacher_non_owner_cannot_delete_group(self, client, ids):
+        login(client, "grteacherb", "teach123")
+        resp = client.delete(f"/api/groups/{ids['normal_gid']}")
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_non_admin_cannot_delete_system_group(self, client, ids):
+        login(client, "grteachera", "teach123")
+        resp = client.delete(f"/api/groups/{ids['system_gid']}")
+        assert resp.status_code == 404
+        assert b"Only admins can change System groups" in resp.data
+        logout(client)
+
+    def test_delete_missing_group_returns_404(self, client, ids):
+        login(client, "gradmin", "admin123")
+        resp = client.delete("/api/groups/999999")
+        assert resp.status_code == 404
+
+    def test_admin_can_delete_group_with_member(self, client, ids):
+        resp = client.delete(f"/api/groups/{ids['deleteme_gid']}")
+        assert resp.status_code == 200
+
+        group = db.session.get(Groups, ids["deleteme_gid"])
+        assert group.is_deleted is True
+        logout(client)

--- a/tests/test_k8s_controller.py
+++ b/tests/test_k8s_controller.py
@@ -1,0 +1,227 @@
+"""Pytest suite for apps/controllers/kubernetes.py (K8sController).
+
+Targets the pure-logic and thinly-wrapped methods (the heavy create_lab /
+get_lab_resources / get_statistics orchestration is out of scope). A fixture
+builds a fully-initialised controller without a real cluster: it sets a dummy
+K8S_NAMESPACE and mocks kube config loading + the client API classes, so the
+constructor wires self.identifiers / self.nodes / self.v1_api (a MagicMock).
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_k8s_controller.py -v
+"""
+import importlib
+import os
+import sys
+import tempfile
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+
+# real submodule (the package name `kubernetes`/`k8s` proxy would shadow it)
+k8s_module = importlib.import_module("apps.controllers.kubernetes")
+K8sController = k8s_module.K8sController
+
+flask_app.config["TESTING"] = True
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(autouse=True)
+def _app_context():
+    with flask_app.app_context():
+        yield
+
+
+@pytest.fixture()
+def ctrl(monkeypatch):
+    """A fully-wired K8sController with the kube client mocked out."""
+    monkeypatch.setattr(k8s_module.app_config, "K8S_NAMESPACE", "test-ns")
+    monkeypatch.setattr(k8s_module.config, "load_kube_config", lambda **k: None)
+    monkeypatch.setattr(k8s_module.client, "CoreV1Api", lambda: MagicMock())
+    monkeypatch.setattr(k8s_module.client, "AppsV1Api", lambda: MagicMock())
+    monkeypatch.setattr(k8s_module.client, "ApiClient", lambda: MagicMock())
+    controller = K8sController()
+    return controller
+
+
+def _fake_node(name, ready=True, ip="10.0.0.1"):
+    cond = types.SimpleNamespace(type="Ready", status="True" if ready else "False")
+    addr = types.SimpleNamespace(type="InternalIP", address=ip)
+    return types.SimpleNamespace(
+        metadata=types.SimpleNamespace(name=name),
+        status=types.SimpleNamespace(conditions=[cond], addresses=[addr]),
+    )
+
+
+# --- pure logic ---------------------------------------------------------
+class TestPureLogic:
+    def test_try_get_app(self, ctrl):
+        assert ctrl.try_get_app("") == "http://"
+        assert ctrl.try_get_app("https-web") == "https://"
+        assert ctrl.try_get_app("ssh-console") == "ssh://"
+        assert ctrl.try_get_app("mystery") == "http://"
+
+    def test_humanbytes(self, ctrl):
+        assert "KB" in ctrl.humanbytes(2048)
+        assert "MB" in ctrl.humanbytes(5 * 1024 * 1024)
+        assert "GB" in ctrl.humanbytes(3 * 1024 ** 3)
+
+    def test_validate_token_and_pods_by_lab(self, ctrl):
+        assert ctrl.validate_token("anything") is True
+        assert ctrl.get_pods_by_lab_id("lab1") == []
+
+    def test_get_pod_hash(self, ctrl):
+        assert ctrl.get_pod_hash(pod_hash="fixed") == "fixed"
+        generated = ctrl.get_pod_hash()
+        assert len(generated) == 14
+
+    def test_allowed_nodes_branches(self, ctrl):
+        assert ctrl.get_allowed_nodes(dry_run=True) == ["nodeA", "nodeB", "nodeC"]
+        assert ctrl.get_allowed_nodes(allowed_nodes=["x", "y"]) == ["x", "y"]
+        assert ctrl.get_allowed_nodes_str(allowed_nodes=["x", "y"]) == "x,y"
+
+    def test_choose_one_node_branches(self, ctrl):
+        assert ctrl.choose_one_node(dry_run=True) == "nodeA"
+        assert ctrl.choose_one_node(allowed_nodes=["only"]) == "only"
+
+    def test_get_identifier_func(self, ctrl):
+        assert ctrl.get_identifier_func("pod_hash") == ctrl.get_pod_hash
+        assert ctrl.get_identifier_func("bogus") is None
+
+    def test_substitute_identifiers_ok(self, ctrl):
+        status, data = ctrl.substitute_identifiers("id=${pod_hash}", pod_hash="abc", dry_run=True)
+        assert status is True
+        assert data == "id=abc"
+
+    def test_substitute_identifiers_invalid_placeholder(self, ctrl):
+        status, data = ctrl.substitute_identifiers("x=${bogus}", dry_run=True)
+        assert status is False
+        assert "Invalid placeholder bogus" in data
+
+
+# --- registry secret ----------------------------------------------------
+class TestRegistrySecret:
+    def test_success(self, ctrl):
+        ctrl.v1_api.create_namespaced_secret = MagicMock()
+        status, msg = ctrl.create_registry_secret("s1", "reg.io", "bob", "pw")
+        assert status is True
+        ctrl.v1_api.create_namespaced_secret.assert_called_once()
+
+    def test_failure(self, ctrl):
+        ctrl.v1_api.create_namespaced_secret = MagicMock(side_effect=RuntimeError("boom"))
+        status, msg = ctrl.create_registry_secret("s1", "reg.io", "bob", "pw")
+        assert status is False
+        assert "Failed to create secret" in msg
+
+
+# --- get_*_by_name ------------------------------------------------------
+class TestGetByName:
+    def test_get_pod_running(self, ctrl):
+        pod = MagicMock()
+        pod.to_dict.return_value = {"metadata": {"name": "p1"}}
+        pod.status.phase = "Running"
+        ctrl.v1_api.read_namespaced_pod = MagicMock(return_value=pod)
+        result = ctrl.get_pod_by_name({"name": "p1"})
+        assert result["is_ok"] is True
+
+    def test_get_pod_not_running(self, ctrl):
+        pod = MagicMock()
+        pod.to_dict.return_value = {}
+        pod.status.phase = "Pending"
+        ctrl.v1_api.read_namespaced_pod = MagicMock(return_value=pod)
+        result = ctrl.get_pod_by_name({"name": "p1"})
+        assert result["is_ok"] is False
+
+    def test_get_service_is_ok(self, ctrl):
+        svc = MagicMock()
+        svc.to_dict.return_value = {}
+        ctrl.v1_api.read_namespaced_service = MagicMock(return_value=svc)
+        assert ctrl.get_service_by_name({"name": "s1"})["is_ok"] is True
+
+    def test_get_resources_by_name_dispatch(self, ctrl):
+        ctrl.get_pod_by_name = MagicMock(return_value={"kind": "Pod"})
+        ctrl.get_service_by_name = MagicMock(return_value={"kind": "Service"})
+        results = ctrl.get_resources_by_name([{"kind": "Pod", "name": "p"}, {"kind": "Service", "name": "s"}])
+        assert len(results) == 2
+        ctrl.get_pod_by_name.assert_called_once()
+        ctrl.get_service_by_name.assert_called_once()
+
+
+# --- delete_*_by_name ---------------------------------------------------
+class TestDeleteByName:
+    def test_delete_pod_success(self, ctrl):
+        ctrl.v1_api.delete_namespaced_pod = MagicMock()
+        assert ctrl.delete_pod_by_name({"name": "p1"}) is True
+
+    def test_delete_pod_failure(self, ctrl):
+        ctrl.v1_api.delete_namespaced_pod = MagicMock(side_effect=RuntimeError("boom"))
+        assert ctrl.delete_pod_by_name({"name": "p1"}) is False
+
+    def test_delete_secret_accepts_dict_and_str(self, ctrl):
+        ctrl.v1_api.delete_namespaced_secret = MagicMock()
+        assert ctrl.delete_secret_by_name({"name": "sec"}) is True
+        assert ctrl.delete_secret_by_name("sec2") is True
+
+    def test_delete_resources_by_name_dispatch(self, ctrl):
+        ctrl.delete_pod_by_name = MagicMock(return_value=True)
+        ctrl.delete_service_by_name = MagicMock(return_value=True)
+        ctrl.delete_secret_by_name = MagicMock(return_value=True)
+        results = ctrl.delete_resources_by_name([
+            {"kind": "Pod", "name": "p"},
+            {"kind": "Service", "name": "s"},
+            {"kind": "Secret", "name": "sec"},
+        ])
+        assert results == [True, True, True]
+
+
+# --- nodes --------------------------------------------------------------
+class TestNodes:
+    def test_update_and_get_nodes(self, ctrl):
+        ctrl.k8s_avoid_nodes = {"nodeB"}
+        resp = types.SimpleNamespace(items=[_fake_node("nodeA"), _fake_node("nodeB")])
+        ctrl.v1_api.list_node = MagicMock(return_value=resp)
+        ctrl.nodes_last_updated = 0
+
+        nodes = ctrl.get_nodes()
+        names = {n["name"]: n["status"] for n in nodes}
+        assert names["nodeA"] == "Ready"
+        assert names["nodeB"] == "NotReady"  # avoided -> not in ready_nodes
+
+    def test_get_node_ip(self, ctrl):
+        resp = types.SimpleNamespace(items=[_fake_node("nodeA", ip="10.1.2.3")])
+        ctrl.v1_api.list_node = MagicMock(return_value=resp)
+        ctrl.nodes_last_updated = 0
+
+        assert ctrl.get_node_ip("nodeA") == "10.1.2.3"
+        assert ctrl.get_node_ip("missing") is None

--- a/tests/test_k8s_routes.py
+++ b/tests/test_k8s_routes.py
@@ -1,0 +1,132 @@
+"""Pytest suite for apps/k8s/routes.py.
+
+Covers the three admin-only listing routes (/k8s/pods, /k8s/deployments,
+/k8s/services): role gating, the success render, and the swallow-and-render
+behaviour when the controller raises. The controller calls are monkeypatched.
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3).
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_k8s_routes.py -v
+
+The seeded usernames are prefixed "kr" so they never collide with the other
+test modules that share the same singleton app/database.
+"""
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db  # noqa: E402
+from apps.authentication.models import Users  # noqa: E402
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def ids(app):
+    admin = Users(username="kradmin", password="admin123", email="kradmin@test.local", category="admin")
+    teacher = Users(username="krteacher", password="teach123", email="krteacher@test.local", category="teacher")
+    db.session.add_all([admin, teacher])
+    db.session.commit()
+    return {"admin_id": admin.id, "teacher_id": teacher.id}
+
+
+# --- helpers -----------------------------------------------------------
+def login(client, username, password):
+    resp = client.post(
+        "/login/",
+        data={"identifier": username, "password": password, "login": "1"},
+    )
+    return resp.status_code == 302
+
+
+def logout(client):
+    client.get("/logout")
+
+
+ROUTES = [
+    ("/k8s/pods", "list_pods"),
+    ("/k8s/deployments", "list_deployments"),
+    ("/k8s/services", "list_services"),
+]
+
+
+# --- role gating --------------------------------------------------------
+class TestRoleGating:
+    def test_non_admin_is_rejected(self, client, ids):
+        logout(client)
+        login(client, "krteacher", "teach123")
+        for path, _ in ROUTES:
+            resp = client.get(path)
+            assert b"Unauthorized request" in resp.data, path
+        logout(client)
+
+
+# --- admin success + error swallow --------------------------------------
+class TestAdminAccess:
+    def test_admin_success(self, client, ids, monkeypatch):
+        login(client, "kradmin", "admin123")
+        for path, fn in ROUTES:
+            monkeypatch.setattr(f"apps.k8s.routes.k8s.{fn}", lambda: [])
+            resp = client.get(path)
+            assert resp.status_code == 200, path
+
+    def test_controller_error_is_swallowed(self, client, ids, monkeypatch):
+        def boom():
+            raise RuntimeError("cluster down")
+
+        for path, fn in ROUTES:
+            monkeypatch.setattr(f"apps.k8s.routes.k8s.{fn}", boom)
+            resp = client.get(path)
+            assert resp.status_code == 200, path  # error is logged, page still renders
+        logout(client)

--- a/tests/test_lab_answers.py
+++ b/tests/test_lab_answers.py
@@ -1,0 +1,237 @@
+"""Pytest suite for the Lab Answers feature.
+
+Mirrors tests/test_lab_categories.py: covers list_lab_answers and
+add_answer_sheet in apps/home/routes.py, exercising the LabAnswers and
+LabAnswerSheet models - role gating, lab/group filtering and their validation,
+answer-sheet scoring (both the numeric-grade and the regex-match branches),
+and creating/updating an answer sheet.
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3).
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_lab_answers.py -v
+
+Note: the classes below are ordered, stateful workflows rather than
+independent unit tests - pytest runs test methods within a class in
+definition order by default, which this suite relies on. Do not run with a
+random-order plugin (e.g. pytest-randomly) without disabling it for this file.
+
+The seeded usernames are all prefixed "la" so they never collide with the
+other test modules that share the same singleton app/database (apps/config.py
+reads DATA_DIR once at import time, so every module ends up on one DB).
+"""
+import json
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db  # noqa: E402
+from apps.authentication.models import Users, Groups  # noqa: E402
+from apps.home.models import Labs, LabAnswers, LabAnswerSheet  # noqa: E402
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def ids(app):
+    """Seed the users/group/lab/answers fixtures shared by every test."""
+    admin = Users(username="laadmin", password="admin123", email="laadmin@test.local", category="admin")
+    teacher = Users(username="lateacher", password="teach123", email="lateacher@test.local", category="teacher")
+    student = Users(username="lastudent", password="stud123", email="lastudent@test.local", category="student")
+    student2 = Users(username="lastudent2", password="stud123", email="lastudent2@test.local", category="student")
+    db.session.add_all([admin, teacher, student, student2])
+    db.session.commit()
+
+    # a group the teacher owns and the student belongs to
+    group = Groups(groupname="LaGroup", organization="ORG1")
+    group.owners.append(teacher)
+    group.members.append(student)
+    db.session.add(group)
+
+    lab = Labs(title="Answers Lab", description="lab with answers")
+    lab.allowed_groups.append(group)
+    lab2 = Labs(title="Sheetless Lab", description="lab without an answer sheet")
+    db.session.add_all([lab, lab2])
+    db.session.commit()
+
+    # answer sheet for `lab` - question q2 is graded by regex match
+    sheet = LabAnswerSheet()
+    sheet.lab_id = lab.id
+    sheet.set_answers({"q2": "bar"})
+    db.session.add(sheet)
+
+    # student's answer: q1 has a numeric grade (90), q2 matches the sheet
+    ans1 = LabAnswers(user_id=student.id, lab_id=lab.id)
+    ans1.answers = json.dumps({"q1": "foo", "q2": "bar"})
+    ans1.grades = json.dumps({"q1": 90})
+    # a non-member's answer (used to prove group filtering excludes it)
+    ans2 = LabAnswers(user_id=student2.id, lab_id=lab.id)
+    ans2.answers = json.dumps({"q1": "ZZZ-notmember"})
+    ans2.grades = json.dumps({})
+    db.session.add_all([ans1, ans2])
+    db.session.commit()
+
+    return {
+        "admin_id": admin.id,
+        "teacher_id": teacher.id,
+        "student_id": student.id,
+        "student2_id": student2.id,
+        "group_id": group.id,
+        "lab_id": lab.id,
+        "lab2_id": lab2.id,
+    }
+
+
+# --- helpers -----------------------------------------------------------
+def login(client, username, password):
+    resp = client.post(
+        "/login/",
+        data={"identifier": username, "password": password, "login": "1"},
+    )
+    return resp.status_code == 302
+
+
+def logout(client):
+    client.get("/logout")
+
+
+# --- list_lab_answers ---------------------------------------------------
+class TestListLabAnswers:
+    def test_student_is_rejected(self, client, ids):
+        logout(client)
+        login(client, "lastudent", "stud123")
+        resp = client.get("/lab_answers/list")
+        assert b"Unauthorized request" in resp.data
+        logout(client)
+
+    def test_admin_sees_answers_with_score(self, client, ids):
+        login(client, "laadmin", "admin123")
+        resp = client.get("/lab_answers/list")
+        assert resp.status_code == 200
+        # no sheet requested -> score comes from the numeric grade only (90%)
+        assert b"90.00" in resp.data
+
+    def test_score_uses_answer_sheet_when_requested(self, client, ids):
+        resp = client.get(f"/lab_answers/list?filter_lab={ids['lab_id']}&check_answer_sheet=1")
+        assert resp.status_code == 200
+        # q1 grade 90 (0.9) + q2 regex match (1.0) over 2 questions -> 95%
+        assert b"95.00" in resp.data
+
+    def test_invalid_lab_filter_is_rejected(self, client, ids):
+        resp = client.get("/lab_answers/list?filter_lab=does-not-exist")
+        assert b"Invalid Lab provided for filtering." in resp.data
+
+    def test_invalid_group_filter_is_rejected(self, client, ids):
+        resp = client.get("/lab_answers/list?filter_group=999999")
+        assert b"Invalid Group provided for filtering." in resp.data
+
+    def test_check_sheet_without_lab_is_rejected(self, client, ids):
+        resp = client.get("/lab_answers/list?check_answer_sheet=1")
+        assert b"To check with the Answer Sheet you must provide a Lab" in resp.data
+
+    def test_check_sheet_without_existing_sheet_is_rejected(self, client, ids):
+        resp = client.get(f"/lab_answers/list?filter_lab={ids['lab2_id']}&check_answer_sheet=1")
+        assert b"No Lab Answer Sheet available" in resp.data
+
+    def test_group_filter_excludes_non_members(self, client, ids):
+        resp = client.get(f"/lab_answers/list?filter_group={ids['group_id']}")
+        assert resp.status_code == 200
+        assert b"90.00" in resp.data                 # the member's answer
+        assert b"ZZZ-notmember" not in resp.data      # the non-member's answer
+        logout(client)
+
+    def test_teacher_sees_answers_for_owned_group_labs(self, client, ids):
+        login(client, "lateacher", "teach123")
+        resp = client.get("/lab_answers/list")
+        assert resp.status_code == 200
+        assert b"90.00" in resp.data
+        logout(client)
+
+
+# --- add_answer_sheet ---------------------------------------------------
+class TestAddAnswerSheet:
+    def test_get_without_lab_shows_picker(self, client, ids):
+        login(client, "laadmin", "admin123")
+        resp = client.get("/lab_answers/answer_sheet/")
+        assert resp.status_code == 200
+
+    def test_get_invalid_lab_is_rejected(self, client, ids):
+        resp = client.get("/lab_answers/answer_sheet/?lab_id=does-not-exist")
+        assert b"Invalid Lab provided." in resp.data
+
+    def test_get_valid_lab_prefills_existing(self, client, ids):
+        resp = client.get(f"/lab_answers/answer_sheet/?lab_id={ids['lab_id']}")
+        assert resp.status_code == 200
+
+    def test_post_creates_new_sheet(self, client, ids):
+        resp = client.post(
+            f"/lab_answers/answer_sheet/?lab_id={ids['lab2_id']}",
+            data={"question": ["q1", "q2"], "answer": ["a1", "a2"]},
+        )
+        assert b"Lab answer sheet saved!" in resp.data
+
+        sheet = LabAnswerSheet.query.filter_by(lab_id=ids["lab2_id"]).first()
+        assert sheet is not None
+        assert sheet.answers_dict == {"q1": "a1", "q2": "a2"}
+
+    def test_post_updates_existing_sheet(self, client, ids):
+        resp = client.post(
+            f"/lab_answers/answer_sheet/?lab_id={ids['lab2_id']}",
+            data={"question": ["q1"], "answer": ["changed"]},
+        )
+        assert b"Lab answer sheet saved!" in resp.data
+
+        sheets = LabAnswerSheet.query.filter_by(lab_id=ids["lab2_id"]).all()
+        assert len(sheets) == 1  # updated in place, not duplicated
+        assert sheets[0].answers_dict == {"q1": "changed"}
+        logout(client)

--- a/tests/test_lab_instances.py
+++ b/tests/test_lab_instances.py
@@ -1,0 +1,321 @@
+"""Pytest suite for the Lab Instance lifecycle routes.
+
+Mirrors tests/test_lab_categories.py: covers running_labs, run_lab,
+check_lab_status, xterm, view_lab_instance, cancel_restart_lab_instance and
+view_finished_labs in apps/home/routes.py, exercising the LabInstances and
+HomeLogging models - ownership/visibility gating, per-group filtering,
+expiration validation and the running/finished/cancel flows.
+
+The handful of paths that talk to Kubernetes are covered by monkeypatching the
+`k8s` module used by apps/home/routes.py; every permission/validation branch
+returns before any k8s call and needs no stubbing.
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3).
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_lab_instances.py -v
+
+Note: the classes below are ordered, stateful workflows rather than
+independent unit tests - pytest runs test methods within a class in
+definition order by default, which this suite relies on (e.g. the cancel tests
+run last because they soft-delete a shared instance). Do not run with a
+random-order plugin (e.g. pytest-randomly) without disabling it for this file.
+
+The seeded usernames are all prefixed "li" so they never collide with the
+other test modules that share the same singleton app/database (apps/config.py
+reads DATA_DIR once at import time, so every module ends up on one DB).
+"""
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db  # noqa: E402
+from apps.authentication.models import Users, Groups  # noqa: E402
+from apps.home.models import Labs, LabInstances, HomeLogging  # noqa: E402
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def ids(app):
+    """Seed the users/group/labs/instances fixtures shared by every test."""
+    admin = Users(username="liadmin", password="admin123", email="liadmin@test.local", category="admin")
+    teacher = Users(username="liteacher", password="teach123", email="liteacher@test.local", category="teacher")
+    student = Users(username="listudent", password="stud123", email="listudent@test.local", category="student")
+    other = Users(username="liother", password="stud123", email="liother@test.local", category="student")
+    db.session.add_all([admin, teacher, student, other])
+    db.session.commit()
+
+    # teacher owns the group; student is a member (owner => privileged group)
+    group = Groups(groupname="LiGroup", organization="ORG1")
+    group.owners.append(teacher)
+    group.members.append(student)
+    db.session.add(group)
+
+    lab_a = Labs(title="Instance Lab A", description="lab with instances")
+    lab_a.set_lab_guide_md("# guide")  # view_lab_instance renders lab_guide_html_str
+    lab_a.allowed_groups.append(group)
+    lab_b = Labs(title="Run Lab B", description="used for run_lab GET/POST")
+    lab_c = Labs(title="Run Lab C", description="used for run_lab failure path")
+    db.session.add_all([lab_a, lab_b, lab_c])
+    db.session.commit()
+
+    inst_student = LabInstances(user_id=student.id, lab_id=lab_a.id, is_deleted=False)
+    inst_student.k8s_resources = []
+    inst_other = LabInstances(user_id=other.id, lab_id=lab_a.id, is_deleted=False)
+    inst_other.k8s_resources = []
+    inst_finished = LabInstances(user_id=student.id, lab_id=lab_a.id, is_deleted=True, finish_reason="done-reason")
+    inst_finished.k8s_resources = []
+    db.session.add_all([inst_student, inst_other, inst_finished])
+    db.session.commit()
+
+    return {
+        "admin_id": admin.id,
+        "teacher_id": teacher.id,
+        "student_id": student.id,
+        "other_id": other.id,
+        "group_id": group.id,
+        "lab_a_id": lab_a.id,
+        "lab_b_id": lab_b.id,
+        "lab_c_id": lab_c.id,
+        "inst_student_id": inst_student.id,
+        "inst_other_id": inst_other.id,
+        "inst_finished_id": inst_finished.id,
+    }
+
+
+# --- helpers -----------------------------------------------------------
+def login(client, username, password):
+    resp = client.post(
+        "/login/",
+        data={"identifier": username, "password": password, "login": "1"},
+    )
+    return resp.status_code == 302
+
+
+def logout(client):
+    client.get("/logout")
+
+
+# --- running_labs -------------------------------------------------------
+class TestRunningLabs:
+    def test_student_sees_own_running_instance(self, client, ids):
+        logout(client)
+        login(client, "listudent", "stud123")
+        resp = client.get("/running/")
+        assert resp.status_code == 200
+        assert b"Instance Lab A" in resp.data
+
+    def test_bad_group_filter_is_rejected(self, client, ids):
+        resp = client.get("/running/?filter_group=999999")
+        assert b"Group not found" in resp.data
+        logout(client)
+
+    def test_admin_group_filter_shows_only_members(self, client, ids):
+        login(client, "liadmin", "admin123")
+        resp = client.get(f"/running/?filter_group={ids['group_id']}")
+        assert resp.status_code == 200
+        assert b"listudent@test.local" in resp.data      # member's instance
+        assert b"liother@test.local" not in resp.data     # non-member's instance
+        logout(client)
+
+    def test_group_owner_sees_member_instance(self, client, ids):
+        login(client, "liteacher", "teach123")
+        resp = client.get(f"/running/?filter_group={ids['group_id']}")
+        assert resp.status_code == 200
+        assert b"listudent@test.local" in resp.data
+        logout(client)
+
+
+# --- run_lab ------------------------------------------------------------
+class TestRunLab:
+    def test_get_missing_lab(self, client, ids):
+        login(client, "listudent", "stud123")
+        resp = client.get("/run_lab/does-not-exist")
+        assert b"Lab not found" in resp.data
+
+    def test_get_renders_form(self, client, ids):
+        resp = client.get(f"/run_lab/{ids['lab_b_id']}")
+        assert resp.status_code == 200
+
+    def test_admin_gets_never_expires_option(self, client, ids):
+        logout(client)
+        login(client, "liadmin", "admin123")
+        resp = client.get(f"/run_lab/{ids['lab_b_id']}")
+        assert b"Never expires" in resp.data
+        logout(client)
+        login(client, "listudent", "stud123")
+
+    def test_already_running_redirects(self, client, ids):
+        resp = client.get(f"/run_lab/{ids['lab_a_id']}")
+        assert resp.status_code == 302
+        assert f"/lab_instance/view/{ids['inst_student_id']}" in resp.headers["Location"]
+
+    def test_post_invalid_expiration(self, client, ids):
+        resp = client.post(f"/run_lab/{ids['lab_b_id']}", data={"lab_expiration": "99"})
+        assert b"Invalid lab duration/expiration" in resp.data
+
+    def test_post_success_creates_instance_and_log(self, client, ids, monkeypatch):
+        monkeypatch.setattr("apps.home.routes.k8s.create_lab", lambda *a, **k: (True, []))
+        resp = client.post(f"/run_lab/{ids['lab_b_id']}", data={"lab_expiration": "4"})
+        assert resp.status_code == 200
+
+        inst = LabInstances.query.filter_by(user_id=ids["student_id"], lab_id=ids["lab_b_id"], is_deleted=False).first()
+        assert inst is not None
+        log = HomeLogging.query.filter_by(action="create_lab", success=True, lab_id=ids["lab_b_id"], user_id=ids["student_id"]).first()
+        assert log is not None
+
+    def test_post_failure_logs_error(self, client, ids, monkeypatch):
+        monkeypatch.setattr("apps.home.routes.k8s.create_lab", lambda *a, **k: (False, "boom"))
+        resp = client.post(f"/run_lab/{ids['lab_c_id']}", data={"lab_expiration": "4"})
+        assert b"Error Running Labs" in resp.data
+
+        assert LabInstances.query.filter_by(user_id=ids["student_id"], lab_id=ids["lab_c_id"]).first() is None
+        log = HomeLogging.query.filter_by(action="create_lab", success=False, lab_id=ids["lab_c_id"], user_id=ids["student_id"]).first()
+        assert log is not None
+        logout(client)
+
+
+# --- check_lab_status ---------------------------------------------------
+class TestCheckLabStatus:
+    def test_missing_instance(self, client, ids):
+        login(client, "listudent", "stud123")
+        resp = client.get("/lab_status/does-not-exist")
+        assert b"Lab not found" in resp.data
+
+    def test_other_users_instance_is_rejected(self, client, ids):
+        resp = client.get(f"/lab_status/{ids['inst_other_id']}")
+        assert b"not authorized" in resp.data
+
+    def test_owner_sees_status(self, client, ids):
+        resp = client.get(f"/lab_status/{ids['inst_student_id']}")
+        assert resp.status_code == 200
+        logout(client)
+
+
+# --- xterm --------------------------------------------------------------
+class TestXterm:
+    def test_missing_instance(self, client, ids):
+        login(client, "listudent", "stud123")
+        resp = client.get("/xterm/does-not-exist/pod/p1/c1")
+        assert b"Lab not found" in resp.data
+
+    def test_other_users_instance_is_rejected(self, client, ids):
+        resp = client.get(f"/xterm/{ids['inst_other_id']}/pod/p1/c1")
+        assert b"not authorized" in resp.data
+
+    def test_owner_gets_terminal(self, client, ids):
+        resp = client.get(f"/xterm/{ids['inst_student_id']}/pod/p1/c1")
+        assert resp.status_code == 200
+        assert b"pod/p1/c1" in resp.data
+        logout(client)
+
+
+# --- view_lab_instance --------------------------------------------------
+class TestViewLabInstance:
+    def test_missing_instance(self, client, ids):
+        login(client, "listudent", "stud123")
+        resp = client.get("/lab_instance/view/does-not-exist")
+        assert b"Lab not found" in resp.data
+
+    def test_deleted_instance(self, client, ids):
+        resp = client.get(f"/lab_instance/view/{ids['inst_finished_id']}")
+        assert b"Lab finished" in resp.data
+
+    def test_unauthorized_user_is_rejected(self, client, ids):
+        # student is only a *member* (not owner/assistant) so has no privileged
+        # group access to another user's instance
+        resp = client.get(f"/lab_instance/view/{ids['inst_other_id']}")
+        assert b"Not authorized to access this Lab" in resp.data
+
+    def test_owner_views_instance(self, client, ids, monkeypatch):
+        monkeypatch.setattr("apps.home.routes.k8s.get_lab_resources", lambda *a, **k: [])
+        resp = client.get(f"/lab_instance/view/{ids['inst_student_id']}")
+        assert resp.status_code == 200
+        logout(client)
+
+
+# --- view_finished_labs -------------------------------------------------
+class TestFinishedLabs:
+    def test_student_sees_own_finished_instance(self, client, ids):
+        login(client, "listudent", "stud123")
+        resp = client.get("/finished_labs")
+        assert resp.status_code == 200
+        assert b"Instance Lab A" in resp.data
+        assert b"done-reason" in resp.data
+
+    def test_bad_group_filter_is_rejected(self, client, ids):
+        resp = client.get("/finished_labs?filter_group=999999")
+        assert b"Group not found" in resp.data
+        logout(client)
+
+
+# --- cancel_restart_lab_instance (runs last: soft-deletes inst_student) --
+class TestCancelInstance:
+    def test_missing_instance(self, client, ids):
+        login(client, "listudent", "stud123")
+        resp = client.get("/lab_instance/cancel/does-not-exist")
+        assert b"Lab not found" in resp.data
+
+    def test_unauthorized_user_is_rejected(self, client, ids):
+        resp = client.get(f"/lab_instance/cancel/{ids['inst_other_id']}")
+        assert b"Not authorized to access this Lab" in resp.data
+
+    def test_owner_can_cancel(self, client, ids, monkeypatch):
+        monkeypatch.setattr("apps.home.routes.k8s.delete_resources_by_name", lambda *a, **k: [])
+        resp = client.get(f"/lab_instance/cancel/{ids['inst_student_id']}")
+        assert resp.status_code == 302
+
+        inst = db.session.get(LabInstances, ids["inst_student_id"])
+        assert inst.is_deleted is True
+        logout(client)

--- a/tests/test_lab_schedule.py
+++ b/tests/test_lab_schedule.py
@@ -1,0 +1,205 @@
+"""Pytest suite for apps/cli/lab_schedule.py.
+
+Covers alert_expiring_labs (the send/skip branches) and run_delete_expired_labs
+(delete, keep-within-tolerance, and the teardown-error path). Mail and the k8s
+teardown are monkeypatched; no real email is sent and no cluster is touched.
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3).
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_lab_schedule.py -v
+
+Both functions scan *all* LabInstances in the (shared, singleton) DB, so this
+module neutralises pre-existing instances once at setup and wipes its own lab's
+instances before each test, then asserts on this file's users/instances only.
+The seeded names are prefixed "ls" to avoid collisions with other modules.
+"""
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db  # noqa: E402
+from apps.config import app_config  # noqa: E402
+from apps.authentication.models import Users  # noqa: E402
+from apps.home.models import Labs, LabInstances  # noqa: E402
+import apps.cli.lab_schedule as lab_schedule  # noqa: E402
+from apps.audit_mixin import utcnow  # noqa: E402
+
+flask_app.config["TESTING"] = True
+
+WARN = app_config.LAB_EXPIRATION_WARN_SEC
+TOL = app_config.LAB_EXPIRATION_TOLERANACE_SEC
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture(scope="session")
+def ids(app):
+    # neutralise any instances seeded by other modules so only ours can match
+    LabInstances.query.update({LabInstances.expiration_ts: None})
+    db.session.commit()
+
+    user = Users(username="ls_user", password="p", email="ls_user@test.local", category="student")
+    noemail = Users(username="ls_noemail", password="p", email="", category="student")
+    lab = Labs(title="Ls Lab", description="scheduled lab")
+    db.session.add_all([user, noemail, lab])
+    db.session.commit()
+    return {"user_id": user.id, "user_email": user.email, "noemail_id": noemail.id, "lab_id": lab.id}
+
+
+@pytest.fixture(autouse=True)
+def _clean_lab_instances(app, ids):
+    """Each test controls its own set of instances for this file's lab."""
+    LabInstances.query.filter_by(lab_id=ids["lab_id"]).delete()
+    db.session.commit()
+    yield
+
+
+@pytest.fixture()
+def mail_outbox(monkeypatch):
+    outbox = []
+
+    class FakeMail:
+        def __init__(self, app):
+            pass
+
+        def send(self, msg):
+            outbox.append(msg)
+
+    monkeypatch.setattr(lab_schedule, "Mail", FakeMail)
+    monkeypatch.setitem(flask_app.config, "MAIL_DEFAULT_SENDER", "noreply@test.local")
+    return outbox
+
+
+@pytest.fixture()
+def k8s_calls(monkeypatch):
+    calls = []
+    ns = types.SimpleNamespace(delete_resources_by_name=lambda res: calls.append(res) or [])
+    monkeypatch.setattr(lab_schedule, "k8s", ns)
+    return calls
+
+
+# --- helpers -----------------------------------------------------------
+def make_instance(ids, expiration_ts, user_id=None, is_deleted=False):
+    inst = LabInstances(
+        user_id=user_id if user_id is not None else ids["user_id"],
+        lab_id=ids["lab_id"],
+        is_deleted=is_deleted,
+        expiration_ts=expiration_ts,
+    )
+    inst.k8s_resources = []
+    db.session.add(inst)
+    db.session.commit()
+    return inst
+
+
+def now_ts():
+    return int(utcnow().timestamp())
+
+
+# --- alert_expiring_labs ------------------------------------------------
+class TestAlertExpiringLabs:
+    def test_no_send_when_send_email_false(self, app, ids, mail_outbox):
+        make_instance(ids, expiration_ts=now_ts() + 3600)  # expiring within 48h
+        lab_schedule.alert_expiring_labs(flask_app, send_email=False)
+        assert mail_outbox == []
+
+    def test_sends_to_user_with_email(self, app, ids, mail_outbox):
+        make_instance(ids, expiration_ts=now_ts() + 3600)
+        lab_schedule.alert_expiring_labs(flask_app, send_email=True)
+        assert len(mail_outbox) == 1
+        assert mail_outbox[0].recipients == [ids["user_email"]]
+
+    def test_no_send_for_user_without_email(self, app, ids, mail_outbox):
+        make_instance(ids, expiration_ts=now_ts() + 3600, user_id=ids["noemail_id"])
+        lab_schedule.alert_expiring_labs(flask_app, send_email=True)
+        assert mail_outbox == []
+
+    def test_missing_user_is_skipped(self, app, ids, mail_outbox):
+        make_instance(ids, expiration_ts=now_ts() + 3600, user_id=999999)
+        lab_schedule.alert_expiring_labs(flask_app, send_email=True)
+        assert mail_outbox == []
+
+    def test_far_future_not_alerted(self, app, ids, mail_outbox):
+        make_instance(ids, expiration_ts=now_ts() + WARN + 100000)
+        lab_schedule.alert_expiring_labs(flask_app, send_email=True)
+        assert mail_outbox == []
+
+    def test_none_expiration_and_deleted_excluded(self, app, ids, mail_outbox):
+        make_instance(ids, expiration_ts=None)  # no expiration set
+        make_instance(ids, expiration_ts=now_ts() + 3600, is_deleted=True)  # already gone
+        lab_schedule.alert_expiring_labs(flask_app, send_email=True)
+        assert mail_outbox == []
+
+
+# --- run_delete_expired_labs --------------------------------------------
+class TestRunDeleteExpiredLabs:
+    def test_deletes_expired_instance(self, app, ids, k8s_calls):
+        inst = make_instance(ids, expiration_ts=now_ts() - TOL - 3600)
+        lab_schedule.run_delete_expired_labs(flask_app)
+
+        db.session.refresh(inst)
+        assert inst.is_deleted is True
+        assert inst.finish_reason == "Lab Expired"
+        assert len(k8s_calls) == 1
+
+    def test_within_tolerance_is_kept(self, app, ids, k8s_calls):
+        inst = make_instance(ids, expiration_ts=now_ts() - 3600)  # expired recently, still tolerated
+        lab_schedule.run_delete_expired_labs(flask_app)
+
+        db.session.refresh(inst)
+        assert inst.is_deleted is False
+        assert k8s_calls == []
+
+    def test_teardown_error_keeps_instance(self, app, ids, monkeypatch):
+        def boom(resources):
+            raise RuntimeError("cluster unavailable")
+
+        monkeypatch.setattr(lab_schedule, "k8s", types.SimpleNamespace(delete_resources_by_name=boom))
+        inst = make_instance(ids, expiration_ts=now_ts() - TOL - 3600)
+        lab_schedule.run_delete_expired_labs(flask_app)
+
+        db.session.refresh(inst)
+        assert inst.is_deleted is False

--- a/tests/test_lab_uploads.py
+++ b/tests/test_lab_uploads.py
@@ -1,0 +1,264 @@
+"""Pytest suite for the Lab file-upload feature.
+
+Mirrors tests/test_lab_categories.py: covers upload_lab_file, serve_upload,
+get_lab_uploads and delete_lab_upload in apps/home/routes.py, exercising the
+LabMetadata model - extension/size validation, saving to the temp UPLOAD_DIR,
+persisting the upload reference into a lab's metadata, labcreator ownership
+gating, and delete edge cases.
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3). Uploaded files land in the temp DATA_DIR's uploads/.
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_lab_uploads.py -v
+
+Note: the classes below are ordered, stateful workflows rather than
+independent unit tests - pytest runs test methods within a class in
+definition order by default, which this suite relies on. Do not run with a
+random-order plugin (e.g. pytest-randomly) without disabling it for this file.
+
+The seeded usernames are all prefixed "up" so they never collide with the
+other test modules that share the same singleton app/database (apps/config.py
+reads DATA_DIR once at import time, so every module ends up on one DB).
+"""
+import io
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db  # noqa: E402
+from apps.authentication.models import Users  # noqa: E402
+from apps.home.models import Labs, LabMetadata  # noqa: E402
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def ids(app):
+    """Seed the users/lab/metadata fixtures shared by every test."""
+    admin = Users(username="upadmin", password="admin123", email="upadmin@test.local", category="admin")
+    teacher = Users(username="upteacher", password="teach123", email="upteacher@test.local", category="teacher")
+    creator = Users(username="upcreator", password="lc123", email="upcreator@test.local", category="labcreator")
+    creator2 = Users(username="upcreator2", password="lc123", email="upcreator2@test.local", category="labcreator")
+    student = Users(username="upstudent", password="stud123", email="upstudent@test.local", category="student")
+    db.session.add_all([admin, teacher, creator, creator2, student])
+    db.session.commit()
+
+    # a lab owned by `creator`, seeded with one upload in its metadata
+    owned = Labs(title="Owned Upload Lab", description="owned by upcreator")
+    owned.updated_by = creator.id
+    db.session.add(owned)
+    db.session.commit()
+    owned_md = LabMetadata(lab=owned, is_clab=False)
+    owned_md.md = {"uploads": [{"filename": "seed.txt", "original_name": "seed.txt", "url": "/uploads/seed.txt"}]}
+    db.session.add(owned_md)
+
+    # a lab with no metadata at all (delete -> "No uploads found")
+    nometa = Labs(title="No Meta Lab", description="no metadata")
+    nometa.updated_by = admin.id
+    db.session.add(nometa)
+    db.session.commit()
+
+    return {
+        "admin_id": admin.id,
+        "teacher_id": teacher.id,
+        "creator_id": creator.id,
+        "creator2_id": creator2.id,
+        "student_id": student.id,
+        "owned_lab_id": owned.id,
+        "nometa_lab_id": nometa.id,
+    }
+
+
+# --- helpers -----------------------------------------------------------
+def login(client, username, password):
+    resp = client.post(
+        "/login/",
+        data={"identifier": username, "password": password, "login": "1"},
+    )
+    return resp.status_code == 302
+
+
+def logout(client):
+    client.get("/logout")
+
+
+def upload(client, filename, content=b"hello", lab_id=None):
+    data = {"file": (io.BytesIO(content), filename)}
+    if lab_id is not None:
+        data["lab_id"] = lab_id
+    return client.post("/labs/upload-file", data=data, content_type="multipart/form-data")
+
+
+# --- upload_lab_file ----------------------------------------------------
+class TestUploadFile:
+    def test_student_is_rejected(self, client, ids):
+        logout(client)
+        login(client, "upstudent", "stud123")
+        resp = upload(client, "notes.txt")
+        assert b"Unauthorized request" in resp.data
+        logout(client)
+
+    def test_missing_file_part(self, client, ids):
+        login(client, "upcreator", "lc123")
+        resp = client.post("/labs/upload-file", data={}, content_type="multipart/form-data")
+        assert resp.status_code == 400
+        assert b"No file part" in resp.data
+
+    def test_empty_filename(self, client, ids):
+        resp = upload(client, "")
+        assert resp.status_code == 400
+        assert b"No file selected" in resp.data
+
+    def test_disallowed_extension(self, client, ids):
+        resp = upload(client, "malware.exe")
+        assert resp.status_code == 400
+        assert b"File extension not allowed" in resp.data
+
+    def test_file_too_large(self, client, ids, monkeypatch):
+        monkeypatch.setitem(flask_app.config, "LAB_UPLOAD_MAX_SIZE", 4)
+        resp = upload(client, "big.txt", content=b"way too big")
+        assert resp.status_code == 400
+        assert b"exceeds maximum allowed size" in resp.data
+
+    def test_valid_upload_without_lab(self, client, ids):
+        resp = upload(client, "notes.txt", content=b"file-body-1")
+        assert resp.status_code == 200
+        payload = resp.get_json()
+        assert payload["status"] == "ok"
+        saved = payload["saved_filename"]
+        assert os.path.exists(os.path.join(flask_app.config["UPLOAD_DIR"], saved))
+
+    def test_valid_upload_persists_metadata(self, client, ids):
+        resp = upload(client, "attached.txt", content=b"file-body-2", lab_id=ids["owned_lab_id"])
+        assert resp.status_code == 200
+        saved = resp.get_json()["saved_filename"]
+
+        lab = db.session.get(Labs, ids["owned_lab_id"])
+        filenames = [u["filename"] for u in lab.lab_metadata.md.get("uploads", [])]
+        assert saved in filenames
+        logout(client)
+
+
+# --- serve_upload -------------------------------------------------------
+class TestServeUpload:
+    def test_uploaded_file_is_served(self, client, ids):
+        login(client, "upcreator", "lc123")
+        resp = upload(client, "served.txt", content=b"served-body")
+        saved = resp.get_json()["saved_filename"]
+
+        resp = client.get(f"/uploads/{saved}")
+        assert resp.status_code == 200
+        assert resp.data == b"served-body"
+
+    def test_unknown_file_is_404(self, client, ids):
+        resp = client.get("/uploads/nope-does-not-exist.txt")
+        assert resp.status_code == 404
+        logout(client)
+
+
+# --- get_lab_uploads ----------------------------------------------------
+class TestGetLabUploads:
+    def test_missing_lab_is_404(self, client, ids):
+        login(client, "upadmin", "admin123")
+        resp = client.get("/labs/does-not-exist/uploads")
+        assert resp.status_code == 404
+        logout(client)
+
+    def test_labcreator_non_owner_is_forbidden(self, client, ids):
+        login(client, "upcreator2", "lc123")
+        resp = client.get(f"/labs/{ids['owned_lab_id']}/uploads")
+        assert resp.status_code == 403
+        logout(client)
+
+    def test_owner_gets_uploads(self, client, ids):
+        login(client, "upcreator", "lc123")
+        resp = client.get(f"/labs/{ids['owned_lab_id']}/uploads")
+        assert resp.status_code == 200
+        assert b"seed.txt" in resp.data
+        logout(client)
+
+
+# --- delete_lab_upload --------------------------------------------------
+class TestDeleteLabUpload:
+    def test_missing_lab_is_404(self, client, ids):
+        login(client, "upadmin", "admin123")
+        resp = client.delete("/labs/does-not-exist/uploads/seed.txt")
+        assert resp.status_code == 404
+
+    def test_lab_without_metadata_is_404(self, client, ids):
+        resp = client.delete(f"/labs/{ids['nometa_lab_id']}/uploads/seed.txt")
+        assert resp.status_code == 404
+        assert b"No uploads found" in resp.data
+
+    def test_unknown_filename_is_404(self, client, ids):
+        resp = client.delete(f"/labs/{ids['owned_lab_id']}/uploads/not-there.txt")
+        assert resp.status_code == 404
+        assert b"File not found in uploads list" in resp.data
+        logout(client)
+
+    def test_labcreator_non_owner_is_forbidden(self, client, ids):
+        login(client, "upcreator2", "lc123")
+        resp = client.delete(f"/labs/{ids['owned_lab_id']}/uploads/seed.txt")
+        assert resp.status_code == 403
+        logout(client)
+
+    def test_owner_can_delete_upload(self, client, ids):
+        login(client, "upcreator", "lc123")
+        resp = client.delete(f"/labs/{ids['owned_lab_id']}/uploads/seed.txt")
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "ok"
+
+        lab = db.session.get(Labs, ids["owned_lab_id"])
+        filenames = [u["filename"] for u in lab.lab_metadata.md.get("uploads", [])]
+        assert "seed.txt" not in filenames
+        logout(client)

--- a/tests/test_labs.py
+++ b/tests/test_labs.py
@@ -1,0 +1,299 @@
+"""Pytest suite for the Labs CRUD feature.
+
+Mirrors tests/test_lab_categories.py: exercises route/role gating,
+create/edit workflows, the "at least one category" and invalid-category
+validation, labcreator ownership rules, per-group view filtering, and the
+"no categories exist yet" guard.
+
+There is no soft-delete route for catalog Labs (the /api/lab/<id> DELETE
+endpoint removes LabInstances, which is out of scope here), so this suite
+covers view + edit only.
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3).
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_labs.py -v
+
+Note: the classes below are ordered, stateful workflows rather than
+independent unit tests - pytest runs test methods within a class in
+definition order by default, which this suite relies on. Do not run with a
+random-order plugin (e.g. pytest-randomly) without disabling it for this file.
+
+The seeded usernames are all prefixed "lb" so they never collide with the
+other test modules that share the same singleton app/database (apps/config.py
+reads DATA_DIR once at import time, so every module ends up on one DB).
+"""
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db  # noqa: E402
+from apps.authentication.models import Users, Groups  # noqa: E402
+from apps.home.models import Labs, LabCategories  # noqa: E402
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def ids(app):
+    """Seed the users/category/group fixtures shared by every test."""
+    admin = Users(username="lbadmin", password="admin123", email="lbadmin@test.local", category="admin")
+    teacher = Users(username="lbteacher", password="teach123", email="lbta@test.local", category="teacher")
+    student = Users(username="lbstudent", password="stud123", email="lbsa@test.local", category="student")
+    labcreator = Users(username="lblabcreator", password="lc123", email="lblc@test.local", category="labcreator")
+    db.session.add_all([admin, teacher, student, labcreator])
+    db.session.commit()
+
+    category = LabCategories(category="Networking", color_cls="dark")
+    category.updated_by = None
+    db.session.add(category)
+
+    # studentA is a member of this group; the admin-created lab will be
+    # restricted to it, exercising the per-group view filter.
+    student_group = Groups(groupname="StudentGroup", organization="ORG1")
+    student_group.members.append(student)
+    db.session.add(student_group)
+    db.session.commit()
+
+    return {
+        "admin_id": admin.id,
+        "teacher_id": teacher.id,
+        "student_id": student.id,
+        "labcreator_id": labcreator.id,
+        "category_id": category.id,
+        "student_group_id": student_group.id,
+    }
+
+
+# --- helpers -----------------------------------------------------------
+def login(client, username, password):
+    resp = client.post(
+        "/login/",
+        data={"identifier": username, "password": password, "login": "1"},
+    )
+    return resp.status_code == 302
+
+
+def logout(client):
+    client.get("/logout")
+
+
+def lab_form(**overrides):
+    """A complete /labs/edit POST body; override individual fields as needed."""
+    data = {
+        "lab_title": "",
+        "lab_description": "",
+        "lab_extended_desc": "extended description",
+        "lab_guide": "# guide",
+        "lab_manifest": "apiVersion: v1",
+        "lab_goals": "",
+    }
+    data.update(overrides)
+    return data
+
+
+# --- role gating --------------------------------------------------------
+class TestRoleGating:
+    def test_student_cannot_edit_labs(self, client, ids):
+        logout(client)
+        login(client, "lbstudent", "stud123")
+        resp = client.get("/labs/edit/new")
+        assert b"Unauthorized request" in resp.data
+
+    def test_student_can_view_labs(self, client, ids):
+        resp = client.get("/labs/view")
+        assert resp.status_code == 200
+        logout(client)
+
+
+# --- admin create/edit workflow -----------------------------------------
+class TestAdminCrudWorkflow:
+    def test_admin_can_create_lab(self, client, ids):
+        login(client, "lbadmin", "admin123")
+        resp = client.post(
+            "/labs/edit/new",
+            data=lab_form(
+                lab_title="Admin Networking Lab",
+                lab_description="created by admin",
+                lab_categories=str(ids["category_id"]),
+                lab_allowed_groups=str(ids["student_group_id"]),
+            ),
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+
+        lab = Labs.query.filter_by(title="Admin Networking Lab").first()
+        assert lab is not None
+        assert len(lab.categories) == 1 and lab.categories[0].id == ids["category_id"]
+        assert len(lab.allowed_groups) == 1 and lab.allowed_groups[0].id == ids["student_group_id"]
+
+    def test_create_requires_at_least_one_category(self, client, ids):
+        resp = client.post(
+            "/labs/edit/new",
+            data=lab_form(lab_title="No Category Lab", lab_description="x"),
+        )
+        assert b"Please select at least one category" in resp.data
+
+    def test_create_rejects_invalid_category(self, client, ids):
+        resp = client.post(
+            "/labs/edit/new",
+            data=lab_form(
+                lab_title="Bad Category Lab",
+                lab_description="x",
+                lab_categories="999999",
+            ),
+        )
+        assert b"Invalid Lab Category" in resp.data
+
+    def test_admin_can_edit_lab(self, client, ids):
+        lab = Labs.query.filter_by(title="Admin Networking Lab").first()
+        resp = client.post(
+            f"/labs/edit/{lab.id}",
+            data=lab_form(
+                lab_title="Admin Networking Lab v2",
+                lab_description="edited by admin",
+                lab_categories=str(ids["category_id"]),
+                lab_allowed_groups=str(ids["student_group_id"]),
+            ),
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+
+        db.session.refresh(lab)
+        assert lab.title == "Admin Networking Lab v2"
+
+    def test_edit_missing_lab_is_rejected(self, client, ids):
+        resp = client.get("/labs/edit/does-not-exist")
+        assert b"Lab not found" in resp.data
+        logout(client)
+
+
+# --- labcreator ownership rules -----------------------------------------
+class TestLabCreatorOwnership:
+    def test_labcreator_can_create_own_lab(self, client, ids):
+        login(client, "lblabcreator", "lc123")
+        resp = client.post(
+            "/labs/edit/new",
+            data=lab_form(
+                lab_title="LabCreator Private Lab",
+                lab_description="created by labcreator",
+                lab_categories=str(ids["category_id"]),
+            ),
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+
+        lab = Labs.query.filter_by(title="LabCreator Private Lab").first()
+        assert lab is not None
+        assert lab.updated_by == ids["labcreator_id"]
+
+    def test_labcreator_cannot_edit_others_lab(self, client, ids):
+        lab = Labs.query.filter_by(title="Admin Networking Lab v2").first()
+        resp = client.get(f"/labs/edit/{lab.id}")
+        assert b"You don&#39;t have permission to edit this Lab." in resp.data
+
+    def test_labcreator_can_edit_own_lab(self, client, ids):
+        lab = Labs.query.filter_by(title="LabCreator Private Lab").first()
+        resp = client.post(
+            f"/labs/edit/{lab.id}",
+            data=lab_form(
+                lab_title="LabCreator Private Lab v2",
+                lab_description="edited by labcreator",
+                lab_categories=str(ids["category_id"]),
+            ),
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+
+        db.session.refresh(lab)
+        assert lab.title == "LabCreator Private Lab v2"
+        logout(client)
+
+
+# --- per-group view filtering -------------------------------------------
+class TestViewFiltering:
+    def test_admin_sees_all_labs(self, client, ids):
+        login(client, "lbadmin", "admin123")
+        resp = client.get("/labs/view")
+        assert b"Admin Networking Lab v2" in resp.data
+        assert b"LabCreator Private Lab v2" in resp.data
+        logout(client)
+
+    def test_student_only_sees_labs_for_their_groups(self, client, ids):
+        login(client, "lbstudent", "stud123")
+        resp = client.get("/labs/view")
+        # admin lab is restricted to StudentGroup, which studentA belongs to
+        assert b"Admin Networking Lab v2" in resp.data
+        # labcreator's lab has no allowed groups and studentA didn't author it
+        assert b"LabCreator Private Lab v2" not in resp.data
+        logout(client)
+
+
+# --- "no categories yet" guard ------------------------------------------
+class TestNoCategoriesGuard:
+    def test_edit_lab_guard_when_no_categories_exist(self, client, ids):
+        login(client, "lbadmin", "admin123")
+        # Deactivate every currently-active category (other test modules that
+        # share this singleton DB may have seeded their own), then restore.
+        active = LabCategories.query.filter_by(is_deleted=False).all()
+        for category in active:
+            category.is_deleted = True
+        db.session.commit()
+        try:
+            resp = client.get("/labs/edit/new")
+            assert b"No Lab Categories found" in resp.data
+        finally:
+            for category in active:
+                category.is_deleted = False
+            db.session.commit()
+            logout(client)

--- a/tests/test_misc_pages.py
+++ b/tests/test_misc_pages.py
@@ -1,0 +1,215 @@
+"""Pytest suite for the dashboard, feedback, and static home pages.
+
+Mirrors tests/test_lab_categories.py: covers the routes in apps/home/routes.py
+that had no direct coverage - index (dashboard + feedback-prompt logic),
+feedback_view, hide_feedback, and the simple login-only pages (gallery,
+documentation, contact, finished-lab-infos). Exercises the UserFeedbacks and
+UserLikes models.
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3).
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_misc_pages.py -v
+
+Note: the classes below are ordered, stateful workflows rather than
+independent unit tests - pytest runs test methods within a class in
+definition order by default, which this suite relies on. Do not run with a
+random-order plugin (e.g. pytest-randomly) without disabling it for this file.
+
+The seeded usernames are all prefixed "mp" so they never collide with the
+other test modules that share the same singleton app/database (apps/config.py
+reads DATA_DIR once at import time, so every module ends up on one DB).
+"""
+import os
+import sys
+import tempfile
+import types
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db, cache  # noqa: E402
+from apps.authentication.models import Users  # noqa: E402
+from apps.home.models import UserFeedbacks, UserLikes  # noqa: E402
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def ids(app):
+    """Seed the users/feedback fixtures shared by every test."""
+    admin = Users(username="mpadmin", password="admin123", email="mpadmin@test.local", category="admin")
+    student = Users(username="mpstudent", password="stud123", email="mpstudent@test.local", category="student")
+    # a user whose account is old and has no feedback -> the index feedback
+    # modal should trigger for them
+    old_user = Users(username="mpolduser", password="old123", email="mpold@test.local", category="student")
+    old_user.created_at = datetime.now(timezone.utc) - timedelta(days=30)
+    # a user who already left feedback -> the modal must NOT trigger
+    fb_user = Users(username="mpfbuser", password="fb123", email="mpfb@test.local", category="student")
+    db.session.add_all([admin, student, old_user, fb_user])
+    db.session.commit()
+
+    like = UserLikes(user_id=student.id)
+    visible_fb = UserFeedbacks(user_id=student.id, stars=5, comment="VISIBLE-FB-mp", is_hidden=False)
+    hidden_fb = UserFeedbacks(user_id=admin.id, stars=1, comment="HIDDEN-FB-mp", is_hidden=True)
+    own_fb = UserFeedbacks(user_id=fb_user.id, stars=4, comment="OWN-FB-mp", is_hidden=False)
+    db.session.add_all([like, visible_fb, hidden_fb, own_fb])
+    db.session.commit()
+
+    return {
+        "admin_id": admin.id,
+        "student_id": student.id,
+        "old_user_id": old_user.id,
+        "fb_user_id": fb_user.id,
+        "visible_fb_id": visible_fb.id,
+        "hidden_fb_id": hidden_fb.id,
+    }
+
+
+# --- helpers -----------------------------------------------------------
+def login(client, username, password):
+    resp = client.post(
+        "/login/",
+        data={"identifier": username, "password": password, "login": "1"},
+    )
+    return resp.status_code == 302
+
+
+def logout(client):
+    client.get("/logout")
+
+
+# --- login-only static pages --------------------------------------------
+class TestStaticPages:
+    def test_pages_render_for_logged_in_user(self, client, ids):
+        logout(client)
+        login(client, "mpstudent", "stud123")
+        for path in ["/gallery", "/documentation", "/contact", "/finished-lab-infos/anything"]:
+            resp = client.get(path)
+            assert resp.status_code == 200, path
+
+    def test_pages_require_login(self, client, ids):
+        logout(client)
+        resp = client.get("/gallery")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+
+# --- dashboard / index --------------------------------------------------
+class TestIndex:
+    def test_index_renders(self, client, ids):
+        login(client, "mpstudent", "stud123")
+        resp = client.get("/index")
+        assert resp.status_code == 200
+
+    def test_feedback_modal_triggers_for_old_user_without_feedback(self, client, ids):
+        key = f"feedback_prompt_last_shown_{ids['old_user_id']}"
+        cache.delete(key)
+        login(client, "mpolduser", "old123")
+        resp = client.get("/index")
+        assert resp.status_code == 200
+        # the modal path stamps this cache key when it decides to show
+        assert cache.get(key) is not None
+
+    def test_feedback_modal_skipped_for_user_with_feedback(self, client, ids):
+        key = f"feedback_prompt_last_shown_{ids['fb_user_id']}"
+        cache.delete(key)
+        login(client, "mpfbuser", "fb123")
+        resp = client.get("/index")
+        assert resp.status_code == 200
+        assert cache.get(key) is None
+        logout(client)
+
+
+# --- feedback listing ---------------------------------------------------
+class TestFeedbackView:
+    def test_admin_sees_hidden_and_visible(self, client, ids):
+        login(client, "mpadmin", "admin123")
+        resp = client.get("/feedback_view")
+        assert resp.status_code == 200
+        assert b"HIDDEN-FB-mp" in resp.data
+        assert b"VISIBLE-FB-mp" in resp.data
+        logout(client)
+
+    def test_non_admin_only_sees_visible(self, client, ids):
+        login(client, "mpstudent", "stud123")
+        resp = client.get("/feedback_view")
+        assert resp.status_code == 200
+        assert b"VISIBLE-FB-mp" in resp.data
+        assert b"HIDDEN-FB-mp" not in resp.data
+        logout(client)
+
+
+# --- hide/unhide feedback (admin-only) ----------------------------------
+class TestHideFeedback:
+    def test_non_admin_is_rejected(self, client, ids):
+        login(client, "mpstudent", "stud123")
+        resp = client.post("/feedback/hide", data={"feedback_id": ids["visible_fb_id"], "action": "hide"})
+        assert b"Unauthorized request" in resp.data
+        logout(client)
+
+    def test_missing_params_redirect_without_change(self, client, ids):
+        login(client, "mpadmin", "admin123")
+        resp = client.post("/feedback/hide", data={"action": "hide"})
+        assert resp.status_code == 302
+        fb = db.session.get(UserFeedbacks, ids["visible_fb_id"])
+        assert fb.is_hidden is False
+
+    def test_admin_can_hide_and_unhide(self, client, ids):
+        resp = client.post("/feedback/hide", data={"feedback_id": ids["visible_fb_id"], "action": "hide"})
+        assert resp.status_code == 302
+        fb = db.session.get(UserFeedbacks, ids["visible_fb_id"])
+        assert fb.is_hidden is True
+
+        resp = client.post("/feedback/hide", data={"feedback_id": ids["visible_fb_id"], "action": "unhide"})
+        assert resp.status_code == 302
+        db.session.refresh(fb)
+        assert fb.is_hidden is False
+        logout(client)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,295 @@
+"""Pytest suite for the Users CRUD feature.
+
+Mirrors tests/test_lab_categories.py: exercises sidebar/route visibility per
+role, self-profile edit, admin cross-user edit, username validation, password
+change, and the admin-only soft-delete API (including the "user still has a
+running lab" block).
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3).
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_users.py -v
+
+Note: the classes below are ordered, stateful workflows (e.g. create, then
+edit, then delete) rather than independent unit tests - pytest runs test
+methods within a class in definition order by default, which this suite
+relies on. Do not run with a random-order plugin (e.g. pytest-randomly)
+without disabling it for this file.
+
+The seeded usernames are all prefixed "us" so they never collide with the
+other test modules that share the same singleton app/database (apps/config.py
+reads DATA_DIR once at import time, so every module ends up on one DB).
+"""
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+# Must happen before `apps`/`run` are imported below, since apps/config.py
+# reads DATA_DIR at import time.
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# apps/controllers/clabernetes.py hard-requires a 'clabverter' binary to be
+# installed on disk at *import* time; stub it out so these tests don't need it.
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db  # noqa: E402
+from apps.authentication.models import Users  # noqa: E402
+from apps.home.models import Labs, LabInstances  # noqa: E402
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def ids(app):
+    """Seed the users/lab fixtures shared by every test."""
+    admin = Users(username="usadmin", password="admin123", email="usadmin@test.local", category="admin")
+    teacher = Users(username="usteacher", password="teach123", email="usteacher@test.local", category="teacher")
+    student = Users(username="usstudent", password="stud123", email="usstudent@test.local", category="student")
+    labcreator = Users(username="uslabcreator", password="lc123", email="uslc@test.local", category="labcreator")
+    # an unapproved user - only these show up in a teacher's /users listing
+    pending = Users(username="uspending", password="pend123", email="uspending@test.local", category="user")
+    # dedicated targets so cross-user/delete tests don't mutate the actors above
+    edit_target = Users(username="usedittarget", password="et123", email="uset@test.local", category="student")
+    pw_target = Users(username="uspwtarget", password="pw123", email="uspw@test.local", category="student")
+    del_target = Users(username="usdeltarget", password="del123", email="usdel@test.local", category="student")
+    del_busy = Users(username="usdelbusy", password="busy123", email="usbusy@test.local", category="student")
+    db.session.add_all(
+        [admin, teacher, student, labcreator, pending, edit_target, pw_target, del_target, del_busy]
+    )
+    db.session.commit()
+
+    # del_busy has a still-running lab instance, which must block deletion
+    lab = Labs(title="Blocker Lab", description="lab used to block user delete")
+    db.session.add(lab)
+    db.session.commit()
+    lab_inst = LabInstances(user_id=del_busy.id, lab_id=lab.id, is_deleted=False)
+    db.session.add(lab_inst)
+    db.session.commit()
+
+    return {
+        "admin_id": admin.id,
+        "teacher_id": teacher.id,
+        "student_id": student.id,
+        "labcreator_id": labcreator.id,
+        "pending_id": pending.id,
+        "edit_target_id": edit_target.id,
+        "pw_target_id": pw_target.id,
+        "del_target_id": del_target.id,
+        "del_busy_id": del_busy.id,
+    }
+
+
+# --- helpers -----------------------------------------------------------
+def login(client, username, password):
+    """Log in and return True if the app accepted the credentials.
+
+    A 302 on POST /login/ (vs. a 200 re-render of the login form on bad
+    credentials) is the reliable signal that authentication succeeded.
+    """
+    resp = client.post(
+        "/login/",
+        data={"identifier": username, "password": password, "login": "1"},
+    )
+    return resp.status_code == 302
+
+
+def logout(client):
+    client.get("/logout")
+
+
+# --- role gating --------------------------------------------------------
+class TestRoleGating:
+    def test_admin_login_succeeds(self, client, ids):
+        logout(client)
+        assert login(client, "usadmin", "admin123")
+
+    def test_student_is_rejected_from_users_list(self, client, ids):
+        logout(client)
+        login(client, "usstudent", "stud123")
+        resp = client.get("/users")
+        assert b"Unauthorized request" in resp.data
+
+    def test_admin_can_view_users_list(self, client, ids):
+        login(client, "usadmin", "admin123")
+        resp = client.get("/users")
+        assert resp.status_code == 200
+        assert b"usstudent" in resp.data
+
+    def test_teacher_only_sees_unapproved_users(self, client, ids):
+        login(client, "usteacher", "teach123")
+        resp = client.get("/users")
+        assert resp.status_code == 200
+        # teachers only see category=="user" rows
+        assert b"uspending" in resp.data
+        assert b"usstudent" not in resp.data
+        logout(client)
+
+
+# --- self-service profile edit ------------------------------------------
+class TestSelfEdit:
+    def test_user_can_view_own_profile(self, client, ids):
+        login(client, "usstudent", "stud123")
+        resp = client.get("/profile")
+        assert resp.status_code == 200
+        assert b"usstudent" in resp.data
+
+    def test_user_can_update_own_profile(self, client, ids):
+        resp = client.post(
+            "/profile",
+            data={
+                "username": "usstudent",
+                "email": "usstudent-new@test.local",
+                "given_name": "Student",
+                "family_name": "Aye",
+                "password": "",
+            },
+        )
+        assert b"User profile updated successfully" in resp.data
+
+        user = db.session.get(Users, ids["student_id"])
+        assert user.email == "usstudent-new@test.local"
+        assert user.given_name == "Student"
+
+    def test_invalid_username_is_rejected(self, client, ids):
+        resp = client.post(
+            "/profile",
+            data={
+                "username": "ab",  # too short (min 3 chars)
+                "email": "usstudent-new@test.local",
+                "given_name": "Student",
+                "family_name": "Aye",
+                "password": "",
+            },
+        )
+        assert b"Invalid username" in resp.data
+        logout(client)
+
+    def test_password_change_takes_effect(self, client, ids):
+        login(client, "uspwtarget", "pw123")
+        resp = client.post(
+            "/profile",
+            data={
+                "username": "uspwtarget",
+                "email": "uspw@test.local",
+                "given_name": "",
+                "family_name": "",
+                "password": "newpw456",
+            },
+        )
+        assert b"User profile updated successfully" in resp.data
+        logout(client)
+
+        assert login(client, "uspwtarget", "newpw456")
+        logout(client)
+        assert not login(client, "uspwtarget", "pw123")
+
+
+# --- cross-user access rules --------------------------------------------
+class TestCrossUserAccess:
+    def test_non_admin_cannot_view_other_user(self, client, ids):
+        login(client, "usstudent", "stud123")
+        resp = client.get(f"/users/{ids['edit_target_id']}")
+        assert b"You dont have access for this page" in resp.data
+        logout(client)
+
+    def test_admin_can_edit_other_user_and_change_category(self, client, ids):
+        login(client, "usadmin", "admin123")
+        resp = client.post(
+            f"/users/{ids['edit_target_id']}",
+            data={
+                "username": "usedittarget",
+                "email": "uset@test.local",
+                "given_name": "Edited",
+                "family_name": "ByAdmin",
+                "password": "",
+                "user_category": "teacher",
+            },
+        )
+        assert b"User profile updated successfully" in resp.data
+
+        user = db.session.get(Users, ids["edit_target_id"])
+        assert user.category == "teacher"
+        assert user.given_name == "Edited"
+
+    def test_admin_edit_of_missing_user_is_rejected(self, client, ids):
+        resp = client.get("/users/999999")
+        assert b"User not found or deactivated" in resp.data
+        logout(client)
+
+
+# --- admin-only soft-delete API -----------------------------------------
+class TestDeleteApi:
+    def test_student_cannot_delete_user(self, client, ids):
+        login(client, "usstudent", "stud123")
+        resp = client.delete(f"/api/users/{ids['del_target_id']}")
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_teacher_cannot_delete_user(self, client, ids):
+        login(client, "usteacher", "teach123")
+        resp = client.delete(f"/api/users/{ids['del_target_id']}")
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_delete_blocked_while_user_has_running_lab(self, client, ids):
+        login(client, "usadmin", "admin123")
+        resp = client.delete(f"/api/users/{ids['del_busy_id']}")
+        assert resp.status_code == 400
+        assert b"labs running" in resp.data
+
+    def test_admin_can_delete_user(self, client, ids):
+        resp = client.delete(f"/api/users/{ids['del_target_id']}")
+        assert resp.status_code == 200
+
+        user = db.session.get(Users, ids["del_target_id"])
+        assert user.is_deleted is True
+
+    def test_deleting_already_deleted_user_returns_404(self, client, ids):
+        resp = client.delete(f"/api/users/{ids['del_target_id']}")
+        assert resp.status_code == 404
+        logout(client)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,226 @@
+"""Pytest suite for apps/utils.py.
+
+Covers the pure helpers (utcnow, parse_lab_expiration, datetime_from_ts,
+secure_filename, format_duration, list_files, remove_empty_folders) and the
+DB-backed helpers (check_pre_approved, update_running_labs_stats,
+update_category_stats, update_stats_lab_instances_answers).
+
+Runs entirely against a throwaway temporary SQLite database created in a temp
+directory - it never touches the real dev/production database
+(apps/data/db.sqlite3).
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_utils.py -v
+
+The seeded usernames/groups are prefixed "ut" so they never collide with the
+other test modules that share the same singleton app/database.
+"""
+import datetime
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+from apps import db, cache  # noqa: E402
+from apps import utils  # noqa: E402
+from apps.authentication.models import Users, Groups  # noqa: E402
+from apps.home.models import Labs, LabCategories, LabInstances, LabAnswers  # noqa: E402
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+
+# --- fixtures ----------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def app():
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+# ============================ pure helpers ============================
+class TestPureHelpers:
+    def test_utcnow_is_timezone_aware(self):
+        now = utils.utcnow()
+        assert now.tzinfo is not None
+        assert abs((datetime.datetime.now(datetime.timezone.utc) - now).total_seconds()) < 5
+
+    def test_parse_lab_expiration_never(self):
+        assert utils.parse_lab_expiration("0") is None
+
+    def test_parse_lab_expiration_hours(self):
+        ts = utils.parse_lab_expiration("4")
+        expected = utils.utcnow() + datetime.timedelta(hours=4)
+        assert abs(ts - int(expected.timestamp())) < 5
+
+    def test_datetime_from_ts_valid(self):
+        result = utils.datetime_from_ts(0)
+        assert result == "1970-01-01T00:00:00+00:00"
+
+    def test_datetime_from_ts_invalid(self):
+        assert utils.datetime_from_ts("not-a-timestamp") is None
+
+    def test_secure_filename_cases(self):
+        assert utils.secure_filename("My cool movie.mov") == "My_cool_movie.mov"
+        assert utils.secure_filename("../../../etc/passwd") == "etc/passwd"
+        assert utils.secure_filename("i contain cool \xfcml\xe4uts.txt") == "i_contain_cool_umlauts.txt"
+
+    def test_format_duration(self):
+        assert utils.format_duration(datetime.timedelta(0)) == "0s"
+        assert utils.format_duration(datetime.timedelta(seconds=-5)) == "--"
+        assert utils.format_duration(datetime.timedelta(minutes=2, seconds=3)) == "2m3s"
+        assert utils.format_duration(datetime.timedelta(days=10)) == "10d"
+
+    def test_list_files(self, tmp_path):
+        (tmp_path / "a.txt").write_text("a")
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "b.txt").write_text("b")
+        (tmp_path / "ignore-me.txt").write_text("x")
+
+        files = utils.list_files(str(tmp_path))
+        assert any(f.endswith("a.txt") for f in files)
+        assert any(f.endswith("b.txt") for f in files)
+
+        filtered = utils.list_files(str(tmp_path), ignore_prefix="ignore")
+        assert not any("ignore-me.txt" in f for f in filtered)
+
+    def test_remove_empty_folders(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        full = tmp_path / "full"
+        full.mkdir()
+        (full / "keep.txt").write_text("keep")
+
+        utils.remove_empty_folders(str(tmp_path))
+        assert not empty.exists()
+        assert full.exists()
+
+
+# ============================ DB-backed helpers ============================
+class TestCheckPreApproved:
+    def test_non_user_category_is_ignored(self, app):
+        student = Users(username="ut_student", password="p", email="ut_student@test.local", category="student")
+        db.session.add(student)
+        db.session.commit()
+        assert utils.check_pre_approved(student) is None
+        assert student.category == "student"
+
+    def test_member_of_normal_group_is_promoted(self, app):
+        user = Users(username="ut_member", password="p", email="ut_member@test.local", category="user")
+        group = Groups(groupname="UtNormal", organization="ORG1")
+        db.session.add_all([user, group])
+        db.session.commit()
+        group.members.append(user)
+        db.session.commit()
+
+        assert utils.check_pre_approved(user) is True
+        assert user.category == "student"
+
+    def test_system_only_group_does_not_promote(self, app):
+        user = Users(username="ut_sysonly", password="p", email="ut_sysonly@test.local", category="user")
+        sysgroup = Groups(groupname="UtSystem", organization="SYSTEM")
+        db.session.add_all([user, sysgroup])
+        db.session.commit()
+        sysgroup.members.append(user)
+        db.session.commit()
+
+        # no non-SYSTEM group and not in any approved_users list -> not promoted
+        assert not utils.check_pre_approved(user)
+        assert user.category == "user"
+
+    def test_approved_email_promotes_and_adds_to_group(self, app):
+        user = Users(username="ut_approved", password="p", email="ut_approved@test.local", category="user")
+        group = Groups(groupname="UtApproved", organization="ORG2")
+        db.session.add_all([user, group])
+        db.session.commit()
+        group.set_approved_users(["ut_approved@test.local"])
+        db.session.commit()
+
+        assert utils.check_pre_approved(user) is True
+        assert user.category == "student"
+        assert group.is_member(user.id)
+
+
+class TestStats:
+    def test_update_running_labs_stats_sets_g_and_cache(self, app):
+        user = Users(username="ut_runstats", password="p", email="ut_runstats@test.local", category="student")
+        lab = Labs(title="Ut Stats Lab", description="x")
+        db.session.add_all([user, lab])
+        db.session.commit()
+        inst = LabInstances(user_id=user.id, lab_id=lab.id, is_deleted=False)
+        inst.k8s_resources = []
+        db.session.add(inst)
+        db.session.commit()
+
+        cache.delete("running_labs-all")
+        with flask_app.test_request_context("/"):
+            from flask import g
+
+            utils.update_running_labs_stats()
+            assert g.running_labs >= 1
+        assert cache.get("running_labs-all") is not None
+
+    def test_update_category_stats(self, app):
+        cat = LabCategories(category="UtCatStats", color_cls="dark")
+        cat.updated_by = None
+        lab = Labs(title="Ut Cat Lab", description="x")
+        lab.categories.append(cat)
+        db.session.add_all([cat, lab])
+        db.session.commit()
+
+        stats = utils.update_category_stats()
+        assert "UtCatStats" in stats["category_names"]
+        idx = stats["category_names"].index("UtCatStats")
+        assert stats["usage_counts"][idx] >= 1
+
+    def test_update_stats_lab_instances_answers_shape(self, app):
+        user = Users(username="ut_answerstats", password="p", email="ut_answerstats@test.local", category="student")
+        lab = Labs(title="Ut Answer Lab", description="x")
+        db.session.add_all([user, lab])
+        db.session.commit()
+        finished = LabInstances(user_id=user.id, lab_id=lab.id, is_deleted=True, finish_reason="done")
+        finished.k8s_resources = []
+        # the stats window covers the *previous* 6 months (not the current one),
+        # so place this ~2 months back to guarantee it lands in a bucket
+        finished.created_at = utils.utcnow() - datetime.timedelta(days=60)
+        db.session.add(finished)
+        db.session.commit()
+
+        stats = utils.update_stats_lab_instances_answers()
+        assert len(stats["months"]) == 6
+        assert len(stats["labs"]) == 6
+        assert stats["total_labs"] >= 1


### PR DESCRIPTION
## What

Adds a comprehensive pytest suite for the Flask app plus a GitHub Actions workflow that runs the tests and checks coverage on every pull request.

**Tests (~338 tests, ~79% coverage of `apps`):**
- **home routes** — index/dashboard, running & finished labs, run/view/cancel lab instances, lab answers list + answer sheet, file uploads, feedback, and the static pages
- **auth** — register/confirm/resend, login & session (route_default, bad password, already-authed, oauth, reload, logout, unauthorized), password reset
- **/api** — lab answers (get/save/grade/check), engagement (feedback, likes, join group, extend, bulk approve), k8s-backed endpoints (pods/status/delete/nodes/templates)
- **clabs** — the ContainerLab `upsert` route (manifest / secrets / file-upload paths with `c9s`/`k8s` faked)
- **controllers** — `C9sController` (clabernetes), `K8sController` (pure + wrapper methods, kube client mocked), `GitController`
- **misc** — `k8s` routes, `utils` (pure helpers + DB-backed stats/approval), the `lab_schedule` CLI jobs, and the xterm/PTY `events` socket.io handlers

**Infra:**
- `tests/conftest.py` — returns each test's DB connection to the pool after it runs, so the many session-scoped app contexts don't exhaust the SQLAlchemy `QueuePool` as the suite grows.
- `.github/workflows/tests.yml` — runs on PRs to **any** branch (and pushes to `main`) on **Python 3.12** (matching the Dockerfile); prints a per-file coverage table in the run summary, uploads `coverage.xml`, and **fails if overall coverage drops below 75%**.
- `requirements-dev.txt` — add `pytest-cov`; `.gitignore` — ignore `coverage.xml` / `htmlcov/`.
- `doc/test-coverage-*.md` — the implementation plan for each test module.

## Why

Establish regression coverage for the core flows and enforce a coverage floor as part of the PR process.

## Notes for reviewers
- The production bug fixes these tests originally surfaced (`delete_group` `dict_keys`, clabs upload `files_count`, `remove_empty_folders`, deprecated `Query.get()`/`logger.warn()`) are **already on `main` via #250** — this PR is tests + CI only.
- The suite is self-contained: throwaway SQLite temp DBs, no external services, and the `clabverter`/kube/git/socketio boundaries are stubbed or mocked. All modules share one app instance, so tests use unique name prefixes per file.
- The 75% floor has ~4% headroom over current coverage; bump it up as coverage improves.