### PR TITLE
Fix djlint errors in templates and add lint CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,42 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: ['**']  # run for PRs targeting any branch
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref (e.g. new pushes to a PR branch)
+concurrency:
+  group: lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  djlint:
+    name: Template linter (djlint)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"  # matches the Dockerfile (python:3.12-bookworm)
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Install djlint
+        run: |
+          python -m pip install --upgrade pip
+          pip install "$(grep -i '^djlint' requirements-dev.txt)"
+
+      - name: Run djlint on templates
+        # Mail templates are excluded: inline styles and missing meta tags
+        # are intentional there (required for HTML email compatibility).
+        run: |
+          djlint --profile=jinja --ignore=H023,D004,H006,H021 --exclude="apps/templates/mail/" apps/templates/

--- a/apps/templates/includes/navigation.html
+++ b/apps/templates/includes/navigation.html
@@ -7,10 +7,10 @@
         <a class="nav-link" data-widget="pushmenu" href="#" role="button"><i class="fas fa-bars"></i></a>
       </li>
       <li class="nav-item d-none d-sm-inline-block">
-        <a href="{{url_for('home_blueprint.index')}}" class="nav-link">Home</a>
+        <a href="{{ url_for('home_blueprint.index') }}" class="nav-link">Home</a>
       </li>
       <li class="nav-item d-none d-sm-inline-block">
-        <a href="{{url_for('home_blueprint.view_contact')}}" class="nav-link">Contact</a>
+        <a href="{{ url_for('home_blueprint.view_contact') }}" class="nav-link">Contact</a>
       </li>
     </ul>
 

--- a/apps/templates/includes/scripts.html
+++ b/apps/templates/includes/scripts.html
@@ -1,34 +1,34 @@
 <!-- jQuery -->
-<script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
 <!-- jQuery UI 1.11.4 -->
-<script src="/static/assets/plugins/jquery-ui/jquery-ui.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/jquery-ui/jquery-ui.min.js') }}"></script>
 <!-- Resolve conflict in jQuery UI tooltip with Bootstrap tooltip -->
 <script>
   $.widget.bridge('uibutton', $.ui.button)
 </script>
 <!-- Bootstrap 4 -->
-<script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 <!-- ChartJS -->
-<script src="/static/assets/plugins/chart.js/Chart.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/chart.js/Chart.min.js') }}"></script>
 <!-- Sparkline -->
-<script src="/static/assets/plugins/sparklines/sparkline.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/sparklines/sparkline.js') }}"></script>
 <!-- JQVMap -->
-<script src="/static/assets/plugins/jqvmap/jquery.vmap.min.js"></script>
-<script src="/static/assets/plugins/jqvmap/maps/jquery.vmap.usa.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/jqvmap/jquery.vmap.min.js') }}"></script>
+<script src="{{ url_for('static', filename='assets/plugins/jqvmap/maps/jquery.vmap.usa.js') }}"></script>
 <!-- jQuery Knob Chart -->
-<script src="/static/assets/plugins/jquery-knob/jquery.knob.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/jquery-knob/jquery.knob.min.js') }}"></script>
 <!-- daterangepicker -->
-<script src="/static/assets/plugins/moment/moment.min.js"></script>
-<script src="/static/assets/plugins/daterangepicker/daterangepicker.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/moment/moment.min.js') }}"></script>
+<script src="{{ url_for('static', filename='assets/plugins/daterangepicker/daterangepicker.js') }}"></script>
 <!-- Tempusdominus Bootstrap 4 -->
-<script src="/static/assets/plugins/tempusdominus-bootstrap-4/js/tempusdominus-bootstrap-4.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/tempusdominus-bootstrap-4/js/tempusdominus-bootstrap-4.min.js') }}"></script>
 <!-- Summernote -->
-<script src="/static/assets/plugins/summernote/summernote-bs4.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/summernote/summernote-bs4.min.js') }}"></script>
 <!-- overlayScrollbars -->
-<script src="/static/assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
 <!-- AdminLTE App -->
-<script src="/static/assets/js/adminlte.js"></script>
+<script src="{{ url_for('static', filename='assets/js/adminlte.js') }}"></script>
 <!-- AdminLTE dashboard demo (This is only for demo purposes) -->
-<script src="/static/assets/js/pages/dashboard.js"></script>
+<script src="{{ url_for('static', filename='assets/js/pages/dashboard.js') }}"></script>
 <!-- AdminLTE for demo purposes -->
-<script src="/static/assets/js/demo.js"></script>
+<script src="{{ url_for('static', filename='assets/js/demo.js') }}"></script>

--- a/apps/templates/includes/sidebar.html
+++ b/apps/templates/includes/sidebar.html
@@ -12,7 +12,7 @@
       <!-- Sidebar user panel (optional) -->
       <div class="user-panel mt-3 pb-3 mb-3 d-flex">
         <div class="image">
-          <img src="/static/assets/img/user-avatar-1.png" class="img-circle elevation-2" alt="User Image">
+          <img src="{{ url_for('static', filename='assets/img/user-avatar-1.png') }}" class="img-circle elevation-2" alt="User Image">
         </div>
         <div class="info">
           <a href="{{ url_for('home_blueprint.edit_user') }}" class="d-block">

--- a/apps/templates/includes/sidebar.html
+++ b/apps/templates/includes/sidebar.html
@@ -39,7 +39,7 @@
           <!-- Add icons to the links using the .nav-icon class
                with font-awesome or any other icon font library -->
           <li class="nav-item">
-            <a href="{{url_for('home_blueprint.index')}}" class="nav-link {% if 'index' in segment %} active {% endif %}">
+            <a href="{{ url_for('home_blueprint.index') }}" class="nav-link {% if 'index' in segment %} active {% endif %}">
               <i class="nav-icon fas fa-tachometer-alt"></i>
               <p>
                 Dashboard
@@ -63,14 +63,14 @@
             </a>
             <ul class="nav nav-treeview">
               <li class="nav-item">
-                <a href="{{url_for('home_blueprint.view_labs')}}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.view_labs' %} active {% endif %}">
+                <a href="{{ url_for('home_blueprint.view_labs') }}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.view_labs' %} active {% endif %}">
                   <i class="far fa-circle nav-icon"></i>
                   <p>View Labs</p>
                 </a>
               </li>
               {% if current_user.category == "admin" or current_user.category == "teacher" or current_user.category == "labcreator" %}
               <li class="nav-item">
-                <a href="{{url_for('home_blueprint.edit_lab', lab_id='new')}}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.edit_lab' %} active {% endif %}">
+                <a href="{{ url_for('home_blueprint.edit_lab', lab_id='new') }}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.edit_lab' %} active {% endif %}">
                   <i class="far fa-circle nav-icon"></i>
                   <p>Create Lab</p>
                 </a>
@@ -86,20 +86,20 @@
 	      {% endif %}
               {% if current_user.category == "admin" or current_user.category == "teacher" %}
               <li class="nav-item">
-                <a href="{{url_for('home_blueprint.list_lab_answers')}}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.list_lab_answers' %} active {% endif %}">
+                <a href="{{ url_for('home_blueprint.list_lab_answers') }}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.list_lab_answers' %} active {% endif %}">
                   <i class="far fa-circle nav-icon"></i>
                   <p>Lab Answers</p>
                 </a>
               </li>
               <li class="nav-item">
-                <a href="{{url_for('home_blueprint.add_answer_sheet')}}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.add_answer_sheet' %} active {% endif %}">
+                <a href="{{ url_for('home_blueprint.add_answer_sheet') }}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.add_answer_sheet' %} active {% endif %}">
                   <i class="far fa-circle nav-icon"></i>
                   <p>Answer Sheet</p>
                 </a>
               </li>
               {% endif %}
               <li class="nav-item">
-                <a href="{{url_for('home_blueprint.view_finished_labs')}}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.view_finished_labs' %} active {% endif %}">
+                <a href="{{ url_for('home_blueprint.view_finished_labs') }}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.view_finished_labs' %} active {% endif %}">
                   <i class="far fa-circle nav-icon"></i>
                   <p>Finished Labs</p>
                 </a>
@@ -119,7 +119,7 @@
           <li class="nav-header">MANAGEMENT</li>
           {% if current_user.category == "admin" or current_user.category == "teacher" %}
           <li class="nav-item">
-            <a href="{{url_for('home_blueprint.view_users')}}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.view_users' %} active {% endif %}">
+            <a href="{{ url_for('home_blueprint.view_users') }}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.view_users' %} active {% endif %}">
               <i class="nav-icon fas fa-users"></i>
               <p>
                 Users
@@ -128,7 +128,7 @@
           </li>
           {% if current_user.category == "admin" %}
           <li class="nav-item">
-            <a href="{{url_for('home_blueprint.list_support_threads')}}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.list_support_threads' or request.url_rule.endpoint == 'home_blueprint.view_support_thread' %} active {% endif %}">
+            <a href="{{ url_for('home_blueprint.list_support_threads') }}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.list_support_threads' or request.url_rule.endpoint == 'home_blueprint.view_support_thread' %} active {% endif %}">
               <i class="nav-icon fas fa-comments"></i>
               <p>
                 Support
@@ -158,19 +158,19 @@
             </a>
             <ul class="nav nav-treeview">
               <li class="nav-item">
-                <a href="{{url_for('k8s_blueprint.list_pods')}}" class="nav-link {% if request.url_rule.endpoint == 'k8s_blueprint.list_pods' %} active {% endif %}">
+                <a href="{{ url_for('k8s_blueprint.list_pods') }}" class="nav-link {% if request.url_rule.endpoint == 'k8s_blueprint.list_pods' %} active {% endif %}">
                   <i class="far fa-circle nav-icon"></i>
                   <p>Pods</p>
                 </a>
               </li>
               <li class="nav-item">
-                <a href="{{url_for('k8s_blueprint.list_deployments')}}" class="nav-link {% if request.url_rule.endpoint == 'k8s_blueprint.list_deployments' %} active {% endif %}">
+                <a href="{{ url_for('k8s_blueprint.list_deployments') }}" class="nav-link {% if request.url_rule.endpoint == 'k8s_blueprint.list_deployments' %} active {% endif %}">
                   <i class="far fa-circle nav-icon"></i>
                   <p>Deployments</p>
                 </a>
               </li>
               <li class="nav-item">
-                <a href="{{url_for('k8s_blueprint.list_services')}}" class="nav-link {% if request.url_rule.endpoint == 'k8s_blueprint.list_services' %} active {% endif %}">
+                <a href="{{ url_for('k8s_blueprint.list_services') }}" class="nav-link {% if request.url_rule.endpoint == 'k8s_blueprint.list_services' %} active {% endif %}">
                   <i class="far fa-circle nav-icon"></i>
                   <p>Services</p>
                 </a>
@@ -180,7 +180,7 @@
           {% endif %}
           <li class="nav-header">MORE INFO</li>
           <li class="nav-item">
-            <a href="{{url_for('home_blueprint.view_documentation')}}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.view_documentation' %} active {% endif %}">
+            <a href="{{ url_for('home_blueprint.view_documentation') }}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.view_documentation' %} active {% endif %}">
               <i class="nav-icon fas fa-file"></i>
               <p>
                 Documentation
@@ -188,7 +188,7 @@
             </a>
           </li>
           <li class="nav-item">
-            <a href="{{url_for('home_blueprint.view_gallery')}}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.view_gallery' %} active {% endif %}">
+            <a href="{{ url_for('home_blueprint.view_gallery') }}" class="nav-link {% if request.url_rule.endpoint == 'home_blueprint.view_gallery' %} active {% endif %}">
               <i class="nav-icon far fa-plus-square"></i>
               <p>
                 Extra tools

--- a/apps/templates/includes/sidebar.html
+++ b/apps/templates/includes/sidebar.html
@@ -15,7 +15,7 @@
           <img src="/static/assets/img/user-avatar-1.png" class="img-circle elevation-2" alt="User Image">
         </div>
         <div class="info">
-          <a href="/profile" class="d-block">
+          <a href="{{ url_for('home_blueprint.edit_user') }}" class="d-block">
             {{ current_user.username }}
           </a>
         </div>

--- a/apps/templates/layouts/base-fullscreen.html
+++ b/apps/templates/layouts/base-fullscreen.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" href="/static/assets/favicon.ico">
+  <link rel="icon" href="{{ url_for('static', filename='assets/favicon.ico') }}">
   <meta name="description" content="A web platform for experimenting/training on cybersecurity and networking using Kubernetes.">
   <meta name="keywords" content="cybersecurity, networking, SDN, Kubernetes, training, labs, HackInSDN">
   <meta property="og:title" content="Dashboard HackInSDN"/>
   <meta property="og:description" content="A web platform for experimenting/training on cybersecurity and networking using Kubernetes."/>
   <meta property="og:url" content="https://hackinsdn.ufba.br"/>
-  <meta property="og:image" content="/static/assets/img/preview.png"/>
+  <meta property="og:image" content="{{ config.BASE_URL }}{{ url_for('static', filename='assets/img/preview.png') }}"/>
   
   <title>
     Dashboard HackInSDN - {% block title %}{% endblock title %}

--- a/apps/templates/layouts/base-fullscreen.html
+++ b/apps/templates/layouts/base-fullscreen.html
@@ -10,7 +10,7 @@
   <meta property="og:image"content="/static/assets/img/preview.png"/>
   
   <title>
-    Dashboard HackInSDN - {% block title %}{% endblock %}
+    Dashboard HackInSDN - {% block title %}{% endblock title %}
   </title> 
 
   <!-- Specific Page CSS goes HERE  -->  

--- a/apps/templates/layouts/base-fullscreen.html
+++ b/apps/templates/layouts/base-fullscreen.html
@@ -4,10 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" href="/static/assets/favicon.ico">
+  <meta name="description" content="A web platform for experimenting/training on cybersecurity and networking using Kubernetes.">
+  <meta name="keywords" content="cybersecurity, networking, SDN, Kubernetes, training, labs, HackInSDN">
   <meta property="og:title" content="Dashboard HackInSDN"/>
   <meta property="og:description" content="A web platform for experimenting/training on cybersecurity and networking using Kubernetes."/>
   <meta property="og:url" content="https://hackinsdn.ufba.br"/>
-  <meta property="og:image"content="/static/assets/img/preview.png"/>
+  <meta property="og:image" content="/static/assets/img/preview.png"/>
   
   <title>
     Dashboard HackInSDN - {% block title %}{% endblock title %}

--- a/apps/templates/layouts/base.html
+++ b/apps/templates/layouts/base.html
@@ -36,9 +36,9 @@
 
 <!-- Analytics measurements -->
 {% if config.GTAG %}
-<script async src="https://www.googletagmanager.com/gtag/js?id={{config.GTAG}}"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ config.GTAG }}"></script>
 <script>
-window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);};gtag('js',new Date());gtag('config', '{{config.GTAG}}');
+window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);};gtag('js',new Date());gtag('config', '{{ config.GTAG }}');
 </script>
 {% endif %}
 

--- a/apps/templates/layouts/base.html
+++ b/apps/templates/layouts/base.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" href="/static/assets/favicon.ico">
+  <meta name="description" content="A web platform for experimenting/training on cybersecurity and networking using Kubernetes.">
+  <meta name="keywords" content="cybersecurity, networking, SDN, Kubernetes, training, labs, HackInSDN">
 
   <title>
     Dashboard HackInSDN - {% block title %}{% endblock title %}
@@ -18,15 +20,15 @@
 <body class="hold-transition {% block body_class %}{% endblock body_class %}">
 <div class="wrapper">
 
-    {% include 'includes/navigation.html' %}
+    {% include "includes/navigation.html" %}
 
-    {% include 'includes/sidebar.html' %}
+    {% include "includes/sidebar.html" %}
 
     {% block content %}{% endblock content %}
 
-    {% include 'includes/footer.html' %}
+    {% include "includes/footer.html" %}
 
-    {% include 'includes/chatbot.html' %}
+    {% include "includes/chatbot.html" %}
 
 </div>
 <!-- ./wrapper -->

--- a/apps/templates/layouts/base.html
+++ b/apps/templates/layouts/base.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" href="/static/assets/favicon.ico">
+  <link rel="icon" href="{{ url_for('static', filename='assets/favicon.ico') }}">
   <meta name="description" content="A web platform for experimenting/training on cybersecurity and networking using Kubernetes.">
   <meta name="keywords" content="cybersecurity, networking, SDN, Kubernetes, training, labs, HackInSDN">
 
@@ -12,7 +12,7 @@
   </title>
 
   <!-- Font Awesome (loaded globally so the support chat widget renders on every page) -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
 
   {% block stylesheets %}{% endblock stylesheets %}
 

--- a/apps/templates/layouts/base.html
+++ b/apps/templates/layouts/base.html
@@ -6,7 +6,7 @@
   <link rel="icon" href="/static/assets/favicon.ico">
 
   <title>
-    Dashboard HackInSDN - {% block title %}{% endblock %}
+    Dashboard HackInSDN - {% block title %}{% endblock title %}
   </title>
 
   <!-- Font Awesome (loaded globally so the support chat widget renders on every page) -->

--- a/apps/templates/mail/confirmation_token.html
+++ b/apps/templates/mail/confirmation_token.html
@@ -18,7 +18,7 @@ body {margin: 0 !important; background-color: #e9ecef; padding: 0; text-align: c
 </tr>
 <tr class="header">
 <td style="font-family: &quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif; font-size: 13px; line-height: 1.6; color: #5c5c5c; padding: 25px 0;">
-<img alt="Dashboard HackInSDN" src="{{config.BASE_URL}}/static/assets/img/hackinsdn-110x110.png" width="80" height="80" />
+<img alt="Dashboard HackInSDN" src="{{ config.BASE_URL }}/static/assets/img/hackinsdn-110x110.png" width="80" height="80" />
 </td>
 </tr>
 <tr>
@@ -32,7 +32,7 @@ body {margin: 0 !important; background-color: #e9ecef; padding: 0; text-align: c
 <div style="color: #1F1F1F; line-height: 1.25em; max-width: 400px; margin: 0 auto;" align="center">
 <h3>Help us protect your account</h3>
 <p style="font-size: 0.9em;">Before you sign up, we need to verify your identity. Enter the following code on the sign-up page.</p>
-<div style="width: 207px; height: 53px; background-color: #F0F0F0; line-height: 53px; font-weight: 700; font-size: 1.5em; color: #303030; margin: 26px 0;">{{confirmation_token}}</div>
+<div style="width: 207px; height: 53px; background-color: #F0F0F0; line-height: 53px; font-weight: 700; font-size: 1.5em; color: #303030; margin: 26px 0;">{{ confirmation_token }}</div>
 <p style="font-size: 0.75em;">If you have not recently tried to sign up into Dashboard HackInSDN, you can ignore this e-mail.</p>
 </div>
 </tbody>
@@ -45,8 +45,8 @@ body {margin: 0 !important; background-color: #e9ecef; padding: 0; text-align: c
 </tr>
 <tr class="footer">
 <td style="font-family: &quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif; font-size: 13px; line-height: 1.6; color: #5c5c5c; padding: 25px 0;">
-<img alt="Dashboard HackInSDN" class="footer-logo" src="{{config.BASE_URL}}/static/assets/img/hackinsdn-horizontal.png" style="display: block; width: 240px; margin: 0 auto 1em;" />
-<div>You're receiving this email because of your account on <a target="_blank" rel="noopener noreferrer" href="{{config.BASE_URL}}" style="color: #3777b0; text-decoration: none;">Dashboard HackInSDN</a>.</div>
+<img alt="Dashboard HackInSDN" class="footer-logo" src="{{ config.BASE_URL }}/static/assets/img/hackinsdn-horizontal.png" style="display: block; width: 240px; margin: 0 auto 1em;" />
+<div>You're receiving this email because of your account on <a target="_blank" rel="noopener noreferrer" href="{{ config.BASE_URL }}" style="color: #3777b0; text-decoration: none;">Dashboard HackInSDN</a>.</div>
 </td>
 </tr>
 <tr><td class="footer-message" style="font-family: &quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif; font-size: 13px; line-height: 1.6; color: #5c5c5c; padding: 25px 0;"></td></tr>

--- a/apps/templates/mail/lab_expiration_alert.html
+++ b/apps/templates/mail/lab_expiration_alert.html
@@ -18,7 +18,7 @@ body {margin: 0 !important; background-color: #e9ecef; padding: 0; text-align: c
 </tr>
 <tr class="header">
 <td style="font-family: &quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif; font-size: 13px; line-height: 1.6; color: #5c5c5c; padding: 25px 0;">
-<img alt="Dashboard HackInSDN" src="{{config.BASE_URL}}/static/assets/img/hackinsdn-110x110.png" width="80" height="80" />
+<img alt="Dashboard HackInSDN" src="{{ config.BASE_URL }}/static/assets/img/hackinsdn-110x110.png" width="80" height="80" />
 </td>
 </tr>
 <tr>
@@ -31,8 +31,8 @@ body {margin: 0 !important; background-color: #e9ecef; padding: 0; text-align: c
 <tbody>
 <div style="color: #1F1F1F; line-height: 1.25em; max-width: 400px; margin: 0 auto;" align="center">
 <h3>Your lab is about to expire</h3>
-<p style="font-size: 0.9em;">Hello {{user.username}}, your lab "{{lab.title}}" is scheduled to expire on</p>
-<p style="font-size: 0.9em;">{{end_time}}</p>
+<p style="font-size: 0.9em;">Hello {{ user.username }}, your lab "{{ lab.title }}" is scheduled to expire on</p>
+<p style="font-size: 0.9em;">{{ end_time }}</p>
 <p style="font-size: 0.9em;">You can extend your lab execution and continue to use it! Visit the web interface to update your lab.</p>
 <p style="font-size: 0.75em;">Please make sure to save any important data before the expiration time</p>
 <p style="font-size: 0.75em;">Best regards, HackInSDN Team</p>
@@ -47,8 +47,8 @@ body {margin: 0 !important; background-color: #e9ecef; padding: 0; text-align: c
 </tr>
 <tr class="footer">
 <td style="font-family: &quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif; font-size: 13px; line-height: 1.6; color: #5c5c5c; padding: 25px 0;">
-<img alt="Dashboard HackInSDN" class="footer-logo" src="{{config.BASE_URL}}/static/assets/img/hackinsdn-horizontal.png" style="display: block; width: 240px; margin: 0 auto 1em;" />
-<div>You're receiving this email because of your account on <a target="_blank" rel="noopener noreferrer" href="{{config.BASE_URL}}" style="color: #3777b0; text-decoration: none;">Dashboard HackInSDN</a>.</div>
+<img alt="Dashboard HackInSDN" class="footer-logo" src="{{ config.BASE_URL }}/static/assets/img/hackinsdn-horizontal.png" style="display: block; width: 240px; margin: 0 auto 1em;" />
+<div>You're receiving this email because of your account on <a target="_blank" rel="noopener noreferrer" href="{{ config.BASE_URL }}" style="color: #3777b0; text-decoration: none;">Dashboard HackInSDN</a>.</div>
 </td>
 </tr>
 <tr><td class="footer-message" style="font-family: &quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif; font-size: 13px; line-height: 1.6; color: #5c5c5c; padding: 25px 0;"></td></tr>

--- a/apps/templates/mail/reset_password.html
+++ b/apps/templates/mail/reset_password.html
@@ -18,7 +18,7 @@ body {margin: 0 !important; background-color: #e9ecef; padding: 0; text-align: c
 </tr>
 <tr class="header">
 <td style="font-family: &quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif; font-size: 13px; line-height: 1.6; color: #5c5c5c; padding: 25px 0;">
-<img alt="Dashboard HackInSDN" src="{{config.BASE_URL}}/static/assets/img/hackinsdn-110x110.png" width="80" height="80" />
+<img alt="Dashboard HackInSDN" src="{{ config.BASE_URL }}/static/assets/img/hackinsdn-110x110.png" width="80" height="80" />
 </td>
 </tr>
 <tr>
@@ -32,7 +32,7 @@ body {margin: 0 !important; background-color: #e9ecef; padding: 0; text-align: c
 <div style="color: #1F1F1F; line-height: 1.25em; max-width: 400px; margin: 0 auto;" align="center">
 <h3>Help us protect your account</h3>
 <p style="font-size: 0.9em;">Your password can be reset by clicking the button below. If you did not request a new password, please ignore this email.</p>
-<div style="width: 207px; height: 53px; background-color: #F0F0F0; line-height: 53px; font-weight: 700; font-size: 1.5em; color: #303030; margin: 26px 0;"><a href="{{confirmation_url}}">Reset Password</a></div>
+<div style="width: 207px; height: 53px; background-color: #F0F0F0; line-height: 53px; font-weight: 700; font-size: 1.5em; color: #303030; margin: 26px 0;"><a href="{{ confirmation_url }}">Reset Password</a></div>
 <p style="font-size: 0.75em;">You are receiving this email because of your account on Dashboard HackInSDN.</p>
 </div>
 </tbody>
@@ -45,8 +45,8 @@ body {margin: 0 !important; background-color: #e9ecef; padding: 0; text-align: c
 </tr>
 <tr class="footer">
 <td style="font-family: &quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif; font-size: 13px; line-height: 1.6; color: #5c5c5c; padding: 25px 0;">
-<img alt="Dashboard HackInSDN" class="footer-logo" src="{{config.BASE_URL}}/static/assets/img/hackinsdn-horizontal.png" style="display: block; width: 240px; margin: 0 auto 1em;" />
-<div>You're receiving this email because of your account on <a target="_blank" rel="noopener noreferrer" href="{{config.BASE_URL}}" style="color: #3777b0; text-decoration: none;">Dashboard HackInSDN</a>.</div>
+<img alt="Dashboard HackInSDN" class="footer-logo" src="{{ config.BASE_URL }}/static/assets/img/hackinsdn-horizontal.png" style="display: block; width: 240px; margin: 0 auto 1em;" />
+<div>You're receiving this email because of your account on <a target="_blank" rel="noopener noreferrer" href="{{ config.BASE_URL }}" style="color: #3777b0; text-decoration: none;">Dashboard HackInSDN</a>.</div>
 </td>
 </tr>
 <tr><td class="footer-message" style="font-family: &quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif; font-size: 13px; line-height: 1.6; color: #5c5c5c; padding: 25px 0;"></td></tr>

--- a/apps/templates/mail/support_message.html
+++ b/apps/templates/mail/support_message.html
@@ -17,7 +17,7 @@ body {margin: 0 !important; background-color: #e9ecef; padding: 0; text-align: c
 </tr>
 <tr class="header">
 <td style="font-family: &quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif; font-size: 13px; line-height: 1.6; color: #5c5c5c; padding: 25px 0;">
-<img alt="Dashboard HackInSDN" src="{{config.BASE_URL}}/static/assets/img/hackinsdn-110x110.png" width="80" height="80" />
+<img alt="Dashboard HackInSDN" src="{{ config.BASE_URL }}/static/assets/img/hackinsdn-110x110.png" width="80" height="80" />
 </td>
 </tr>
 <tr>
@@ -53,7 +53,7 @@ body {margin: 0 !important; background-color: #e9ecef; padding: 0; text-align: c
 </tr>
 <tr class="footer">
 <td style="font-family: &quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif; font-size: 13px; line-height: 1.6; color: #5c5c5c; padding: 25px 0;">
-<div>You're receiving this email because you are a support contact for <a target="_blank" rel="noopener noreferrer" href="{{config.BASE_URL}}" style="color: #3777b0; text-decoration: none;">Dashboard HackInSDN</a>.</div>
+<div>You're receiving this email because you are a support contact for <a target="_blank" rel="noopener noreferrer" href="{{ config.BASE_URL }}" style="color: #3777b0; text-decoration: none;">Dashboard HackInSDN</a>.</div>
 </td>
 </tr>
 </tbody>

--- a/apps/templates/pages/clabs_upsert.html
+++ b/apps/templates/pages/clabs_upsert.html
@@ -68,21 +68,21 @@
                     <div class="alert alert-success alert-dismissible">
                       <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
                       <h5><i class="icon fas fa-check"></i> Lab created/updated successfully!</h5>
-                      {{msg_ok}}
+                      {{ msg_ok }}
                     </div>
                     {% endif %}
                     {% if msg_fail %}
                     <div class="alert alert-danger alert-dismissible">
                       <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
                       <h5><i class="icon fas fa-ban"></i> Fail to insert/update container lab!</h5>
-                      {{msg_fail}}
+                      {{ msg_fail }}
                     </div>
                     {% endif %}
                 </div>
                 <div class="col-sm-6">
                     <ol class="breadcrumb float-sm-right">
                         <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
-                        <li class="breadcrumb-item"><a href="{{url_for('home_blueprint.view_labs')}}">Labs</a></li>
+                        <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.view_labs') }}">Labs</a></li>
                         <li class="breadcrumb-item active">Create/Update CLab</li>
                     </ol>
                 </div>
@@ -106,17 +106,17 @@
                 <div class="card-body">
                   <div class="form-group">
                     <label>Lab title</label>
-                    <input name="clab_title" type="text" class="form-control" placeholder="Enter container lab title..." value="{{clab.title|default('', true)}}">
+                    <input name="clab_title" type="text" class="form-control" placeholder="Enter container lab title..." value="{{ clab.title|default('', true) }}">
                   </div>
                   <div class="form-group">
                     <label>Short Description</label>
-                    <input name="clab_desc" type="text" class="form-control" placeholder="Max 255 characters" value="{{clab.description|default('', true)}}">
+                    <input name="clab_desc" type="text" class="form-control" placeholder="Max 255 characters" value="{{ clab.description|default('', true) }}">
                   </div>
                   <div class="form-group">
                     <label>Lab categories</label>
                     <select name="clab_categories" class="form-control select2" multiple="multiple" data-placeholder="Select one or more categories" style="width: 100%;">
                       {% for cat_id in lab_categories %}
-                      <option value="{{cat_id}}" data-color="{{lab_categories[cat_id].color_cls}}" {{'selected' if lab_categories[cat_id] in clab.categories else ""}}>{{lab_categories[cat_id].category}}</option>
+                      <option value="{{ cat_id }}" data-color="{{ lab_categories[cat_id].color_cls }}" {{ 'selected' if lab_categories[cat_id] in clab.categories else "" }}>{{ lab_categories[cat_id].category }}</option>
                       {% endfor %}
                     </select>
                     <small class="form-text text-muted">Select one or more categories</small>
@@ -143,9 +143,9 @@
                       <select name="clab_allowed_groups" class="duallistbox" multiple="multiple">
                         {% for group in groups %}
                           {% if group in clab.allowed_groups %}
-                          <option value="{{group.id}}" selected>{{group.groupname}}</option>
+                          <option value="{{ group.id }}" selected>{{ group.groupname }}</option>
                           {% else %}
-                          <option value="{{group.id}}">{{group.groupname}}</option>
+                          <option value="{{ group.id }}">{{ group.groupname }}</option>
                           {% endif %}
                         {% endfor %}
                       </select>
@@ -183,7 +183,7 @@
               <div class="card-body pad">
                 <div class="mb-3">
                   <textarea name="clab_extended_desc" id="lab-editor" class="textarea" placeholder="Place some text here"
-                            style="width: 100%; height: 400px; font-size: 14px; line-height: 18px; border: 1px solid #dddddd; padding: 10px;">{{clab.extended_desc_str|default('', true)}}</textarea>
+                            style="width: 100%; height: 400px; font-size: 14px; line-height: 18px; border: 1px solid #dddddd; padding: 10px;">{{ clab.extended_desc_str|default('', true) }}</textarea>
                 </div>
                 <p class="text-sm mb-0">
                   Editor <a href="https://github.com/summernote/summernote">Documentation and license
@@ -210,7 +210,7 @@
                   <div class="col-md-12">
                     <div class="form-group">
                       <label>GIT repo URL (<span class="text-danger">Under development</span>):</label>
-                      <input name="clab_giturl" type="text" class="form-control" placeholder="Max 255 characters" value="{{clab.giturl|default('', true)}}" disabled>
+                      <input name="clab_giturl" type="text" class="form-control" placeholder="Max 255 characters" value="{{ clab.giturl|default('', true) }}" disabled>
                     </div>
 		  </div> <!-- end of col-md-6 -->
                 </div>
@@ -243,10 +243,10 @@
                   </div>
                 </div>
                 <!-- ./row -->
-		<div class="row {{'d-none' if not clab.manifest}}">
+		<div class="row {{ 'd-none' if not clab.manifest }}">
                   <div class="col-md-12">
                     <label>ContainerLab manifest</label>
-                    <textarea name="clab_yaml" id="clab_yaml" class="textarea" placeholder="Place some text here" rows="16">{{clab.manifest|default('', true)}}</textarea>
+                    <textarea name="clab_yaml" id="clab_yaml" class="textarea" placeholder="Place some text here" rows="16">{{ clab.manifest|default('', true) }}</textarea>
                   </div>
 		</div>
 		<div class="row">
@@ -264,13 +264,13 @@
                       </thead>
                       <tbody id="table-body-secrets">
                       {% for secret in clab.secret_names %}
-		      <tr id="row-secret-{{secret}}">
-                        <td><input class="form-control" type="text" name="secret-name" value="{{secret}}" readonly></td>
+		      <tr id="row-secret-{{ secret }}">
+                        <td><input class="form-control" type="text" name="secret-name" value="{{ secret }}" readonly></td>
                         <td><input class="form-control d-none" type="text" name="secret-server" value=""></td>
                         <td><input class="form-control d-none" type="text" name="secret-user" value=""></td>
 			<td>
                           <input class="form-control d-none" type="password" name="secret-pass" value="">
-			  <button type="button" class="btn btn-xs btn-outline-danger float-right" onclick="deleteSecretRow('{{secret}}')"><i class="fas fa-times"></i></button>
+			  <button type="button" class="btn btn-xs btn-outline-danger float-right" onclick="deleteSecretRow('{{ secret }}')"><i class="fas fa-times"></i></button>
                         </td>
                       </tr>
                       {% endfor %}
@@ -310,7 +310,7 @@
                 <button class="btn btn-outline-secondary" type="button" id="add-select-input-labguide">Add select question</button>
                 <button class="btn btn-outline-secondary" type="button" id="add-check-input-labguide">Add checkbox question</button>
                 <div class="mb-3">
-                  <textarea name="clab_guide" id="lab-edit-guide" class="textarea" placeholder="Place some text here" rows="16">{{clab.lab_guide_md_str|default('', true)}}</textarea>
+                  <textarea name="clab_guide" id="lab-edit-guide" class="textarea" placeholder="Place some text here" rows="16">{{ clab.lab_guide_md_str|default('', true) }}</textarea>
                 </div>
               </div>
             </div>
@@ -321,7 +321,7 @@
         <div class="row">
           <div class="col-md-12 mb-2">
             <button id="btnSubmit" type="button" class="btn btn-primary">
-              <span class="btn-text">{{"Create ContainerLab" if not clab.id else "Update ContainerLab"}}</span>
+              <span class="btn-text">{{ "Create ContainerLab" if not clab.id else "Update ContainerLab" }}</span>
               <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
             </button>
             <a href="{{ url_for('home_blueprint.view_labs', lab_id=clab.id) if clab.id else url_for('home_blueprint.view_labs') }}" class="btn btn-secondary mx-2" role="button" aria-pressed="true">Cancel</a>

--- a/apps/templates/pages/clabs_upsert.html
+++ b/apps/templates/pages/clabs_upsert.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Create ContainerLab {% endblock %}
+{% block title %} Create ContainerLab {% endblock title %}
 
 {% block body_class %} sidebar-mini {% endblock body_class %}
 

--- a/apps/templates/pages/clabs_upsert.html
+++ b/apps/templates/pages/clabs_upsert.html
@@ -8,19 +8,19 @@
 <!-- Google Font: Source Sans Pro -->
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
 <!-- Font Awesome -->
-<link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
 <!-- AdminLTE -->
-<link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 <!-- summernote -->
-<link rel="stylesheet" href="/static/assets/plugins/summernote/summernote-bs4.min.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/summernote/summernote-bs4.min.css') }}">
 <!-- Select2 -->
-<link rel="stylesheet" href="/static/assets/plugins/select2/css/select2.min.css">
-<link rel="stylesheet" href="/static/assets/plugins/select2-bootstrap4-theme/select2-bootstrap4.min.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/select2/css/select2.min.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/select2-bootstrap4-theme/select2-bootstrap4.min.css') }}">
 <!-- Bootstrap4 Duallistbox -->
-<link rel="stylesheet" href="/static/assets/plugins/bootstrap4-duallistbox/bootstrap-duallistbox.min.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/bootstrap4-duallistbox/bootstrap-duallistbox.min.css') }}">
 <!-- CodeMirror -->
-<link rel="stylesheet" href="/static/assets/plugins/codemirror/lib/codemirror.css">
-<link rel="stylesheet" href="/static/assets/plugins/codemirror/theme/abcdef.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/codemirror/lib/codemirror.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/codemirror/theme/abcdef.css') }}">
 <style>
 .dropzone {
     border: 2px dashed #adb5bd;
@@ -336,23 +336,23 @@
 
 {% block javascripts %}
 <!-- jQuery -->
-<script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
 <!-- Bootstrap 4 -->
-<script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 <!-- bs-custom-file-input -->
-<script src="/static/assets/plugins/bs-custom-file-input/bs-custom-file-input.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/bs-custom-file-input/bs-custom-file-input.min.js') }}"></script>
 <!-- Bootstrap4 Duallistbox -->
-<script src="/static/assets/plugins/bootstrap4-duallistbox/jquery.bootstrap-duallistbox.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/bootstrap4-duallistbox/jquery.bootstrap-duallistbox.min.js') }}"></script>
 <!-- AdminLTE -->
-<script src="/static/assets/js/adminlte.min.js"></script>
+<script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
 <!-- Summernote -->
-<script src="/static/assets/plugins/summernote/summernote-bs4.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/summernote/summernote-bs4.min.js') }}"></script>
 <!-- CodeMirror -->
-<script src="/static/assets/plugins/codemirror/lib/codemirror.js"></script>
-<script src="/static/assets/plugins/codemirror/mode/yaml/yaml.js"></script>
-<script src="/static/assets/plugins/codemirror/mode/markdown/markdown.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/codemirror/lib/codemirror.js') }}"></script>
+<script src="{{ url_for('static', filename='assets/plugins/codemirror/mode/yaml/yaml.js') }}"></script>
+<script src="{{ url_for('static', filename='assets/plugins/codemirror/mode/markdown/markdown.js') }}"></script>
 <!-- Select2 -->
-<script src="/static/assets/plugins/select2/js/select2.full.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/select2/js/select2.full.min.js') }}"></script>
 <script>
     function deleteSecretRow(secret) {
       const rowToDelete = document.getElementById(`row-secret-${secret}`);

--- a/apps/templates/pages/confirm.html
+++ b/apps/templates/pages/confirm.html
@@ -55,16 +55,13 @@
           </div>
           <div class="row">
             <div class="col-6">
-                <button type="submit" name="confirm" class="btn btn-primary btn-block">Verify code</button>    
+                <button type="submit" name="confirm" class="btn btn-primary btn-block">Verify code</button>
             </div>
             <div class="col-6">
                 <a href="{{ url_for('authentication_blueprint.resend_code') }}" class="btn btn-secondary btn-block">Resend code</a>
+            </div>
           </div>
         </form>
-
-        <br />
-
-
       </div>
       <!-- /.login-card-body -->
     </div>

--- a/apps/templates/pages/confirm.html
+++ b/apps/templates/pages/confirm.html
@@ -11,11 +11,11 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -74,8 +74,8 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/confirm.html
+++ b/apps/templates/pages/confirm.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base-fullscreen.html" %}
 
-{% block title %} Login {% endblock %}
+{% block title %} Login {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} login-page {% endblock body_class %}

--- a/apps/templates/pages/confirm.html
+++ b/apps/templates/pages/confirm.html
@@ -58,7 +58,7 @@
                 <button type="submit" name="confirm" class="btn btn-primary btn-block">Verify code</button>    
             </div>
             <div class="col-6">
-                <a href="{{ url_for('authentication_blueprint.resend_code')}}" class="btn btn-secondary btn-block">Resend code</a>
+                <a href="{{ url_for('authentication_blueprint.resend_code') }}" class="btn btn-secondary btn-block">Resend code</a>
           </div>
         </form>
 

--- a/apps/templates/pages/confirm_email.html
+++ b/apps/templates/pages/confirm_email.html
@@ -58,7 +58,7 @@
                 <button type="submit" name="confirm" class="btn btn-primary btn-block">Verify code</button>
             </div>
             <div class="col-6">
-                <a href="{{ url_for('authentication_blueprint.resend_email_code')}}" class="btn btn-secondary btn-block">Resend code</a>
+                <a href="{{ url_for('authentication_blueprint.resend_email_code') }}" class="btn btn-secondary btn-block">Resend code</a>
           </div>
         </form>
 

--- a/apps/templates/pages/confirm_email.html
+++ b/apps/templates/pages/confirm_email.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base-fullscreen.html" %}
 
-{% block title %} Confirm your e-mail {% endblock %}
+{% block title %} Confirm your e-mail {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} login-page {% endblock body_class %}

--- a/apps/templates/pages/confirm_email.html
+++ b/apps/templates/pages/confirm_email.html
@@ -11,11 +11,11 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -80,8 +80,8 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/confirm_email.html
+++ b/apps/templates/pages/confirm_email.html
@@ -59,6 +59,7 @@
             </div>
             <div class="col-6">
                 <a href="{{ url_for('authentication_blueprint.resend_email_code') }}" class="btn btn-secondary btn-block">Resend code</a>
+            </div>
           </div>
         </form>
 

--- a/apps/templates/pages/confirm_reset_password.html
+++ b/apps/templates/pages/confirm_reset_password.html
@@ -11,11 +11,11 @@
     <!-- Google Font: Source Sans Pro -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
     <!-- Font Awesome -->
-    <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
     <!-- icheck bootstrap -->
-    <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
     <!-- Theme style -->
-    <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
     
 {% endblock stylesheets %}
     
@@ -74,8 +74,8 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/confirm_reset_password.html
+++ b/apps/templates/pages/confirm_reset_password.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base-fullscreen.html" %}
 
-{% block title %} Login {% endblock %}
+{% block title %} Login {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} login-page {% endblock body_class %}

--- a/apps/templates/pages/contact.html
+++ b/apps/templates/pages/contact.html
@@ -11,9 +11,9 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -61,7 +61,7 @@
                       </ul>
                     </div>
                     <div class="col-5 text-center">
-                      <img src="/static/assets/img/user-avatar-1.png" alt="user-avatar" class="img-circle img-fluid">
+                      <img src="{{ url_for('static', filename='assets/img/user-avatar-1.png') }}" alt="user-avatar" class="img-circle img-fluid">
                     </div>
                   </div>
                 </div>
@@ -93,7 +93,7 @@
                       </ul>
                     </div>
                     <div class="col-5 text-center">
-                      <img src="/static/assets/img/user-avatar-2.png" alt="user-avatar" class="img-circle img-fluid">
+                      <img src="{{ url_for('static', filename='assets/img/user-avatar-2.png') }}" alt="user-avatar" class="img-circle img-fluid">
                     </div>
                   </div>
                 </div>
@@ -125,7 +125,7 @@
                       </ul>
                     </div>
                     <div class="col-5 text-center">
-                      <img src="/static/assets/img/user-avatar-3.png" alt="user-avatar" class="img-circle img-fluid">
+                      <img src="{{ url_for('static', filename='assets/img/user-avatar-3.png') }}" alt="user-avatar" class="img-circle img-fluid">
                     </div>
                   </div>
                 </div>
@@ -157,7 +157,7 @@
                       </ul>
                     </div>
                     <div class="col-5 text-center">
-                      <img src="/static/assets/img/user-avatar-4.png" alt="user-avatar" class="img-circle img-fluid">
+                      <img src="{{ url_for('static', filename='assets/img/user-avatar-4.png') }}" alt="user-avatar" class="img-circle img-fluid">
                     </div>
                   </div>
                 </div>
@@ -188,7 +188,7 @@
                       </ul>
                     </div>
                     <div class="col-5 text-center">
-                      <img src="/static/assets/img/user-avatar-1.png" alt="user-avatar" class="img-circle img-fluid">
+                      <img src="{{ url_for('static', filename='assets/img/user-avatar-1.png') }}" alt="user-avatar" class="img-circle img-fluid">
                     </div>
                   </div>
                 </div>
@@ -220,7 +220,7 @@
                       </ul>
                     </div>
                     <div class="col-5 text-center">
-                      <img src="/static/assets/img/user-avatar-2.png" alt="user-avatar" class="img-circle img-fluid">
+                      <img src="{{ url_for('static', filename='assets/img/user-avatar-2.png') }}" alt="user-avatar" class="img-circle img-fluid">
                     </div>
                   </div>
                 </div>
@@ -251,39 +251,7 @@
                       </ul>
                     </div>
                     <div class="col-5 text-center">
-                      <img src="/static/assets/img/user-avatar-3.png" alt="user-avatar" class="img-circle img-fluid">
-                    </div>
-                  </div>
-                </div>
-                <div class="card-footer">
-                  <div class="text-right">
-                    <a href="#" class="btn btn-sm bg-teal">
-                      <i class="fas fa-comments"></i>
-                    </a>
-                    <a href="#" class="btn btn-sm btn-primary">
-                      <i class="fas fa-user"></i> View Profile
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="col-12 col-sm-6 col-md-4 d-flex align-items-stretch">
-              <div class="card bg-light">
-                <div class="card-header text-muted border-bottom-0">
-                  Digital Strategist
-                </div>
-                <div class="card-body pt-0">
-                  <div class="row">
-                    <div class="col-7">
-                      <h2 class="lead"><b>Nicole Pearson</b></h2>
-                      <p class="text-muted text-sm"><b>About: </b> Web Designer / UX / Graphic Artist / Coffee Lover </p>
-                      <ul class="ml-4 mb-0 fa-ul text-muted">
-                        <li class="small"><span class="fa-li"><i class="fas fa-lg fa-building"></i></span> Address: Demo Street 123, Demo City 04312, NJ</li>
-                        <li class="small"><span class="fa-li"><i class="fas fa-lg fa-phone"></i></span> Phone #: + 800 - 12 12 23 52</li>
-                      </ul>
-                    </div>
-                    <div class="col-5 text-center">
-                      <img src="/static/assets/img/user-avatar-4.png" alt="user-avatar" class="img-circle img-fluid">
+                      <img src="{{ url_for('static', filename='assets/img/user-avatar-3.png') }}" alt="user-avatar" class="img-circle img-fluid">
                     </div>
                   </div>
                 </div>
@@ -315,7 +283,39 @@
                       </ul>
                     </div>
                     <div class="col-5 text-center">
-                      <img src="/static/assets/img/user-avatar-1.png" alt="user-avatar" class="img-circle img-fluid">
+                      <img src="{{ url_for('static', filename='assets/img/user-avatar-4.png') }}" alt="user-avatar" class="img-circle img-fluid">
+                    </div>
+                  </div>
+                </div>
+                <div class="card-footer">
+                  <div class="text-right">
+                    <a href="#" class="btn btn-sm bg-teal">
+                      <i class="fas fa-comments"></i>
+                    </a>
+                    <a href="#" class="btn btn-sm btn-primary">
+                      <i class="fas fa-user"></i> View Profile
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-sm-6 col-md-4 d-flex align-items-stretch">
+              <div class="card bg-light">
+                <div class="card-header text-muted border-bottom-0">
+                  Digital Strategist
+                </div>
+                <div class="card-body pt-0">
+                  <div class="row">
+                    <div class="col-7">
+                      <h2 class="lead"><b>Nicole Pearson</b></h2>
+                      <p class="text-muted text-sm"><b>About: </b> Web Designer / UX / Graphic Artist / Coffee Lover </p>
+                      <ul class="ml-4 mb-0 fa-ul text-muted">
+                        <li class="small"><span class="fa-li"><i class="fas fa-lg fa-building"></i></span> Address: Demo Street 123, Demo City 04312, NJ</li>
+                        <li class="small"><span class="fa-li"><i class="fas fa-lg fa-phone"></i></span> Phone #: + 800 - 12 12 23 52</li>
+                      </ul>
+                    </div>
+                    <div class="col-5 text-center">
+                      <img src="{{ url_for('static', filename='assets/img/user-avatar-1.png') }}" alt="user-avatar" class="img-circle img-fluid">
                     </div>
                   </div>
                 </div>
@@ -363,12 +363,12 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
   <!-- AdminLTE for demo purposes -->
-  <script src="/static/assets/js/demo.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/demo.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/contact.html
+++ b/apps/templates/pages/contact.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Contacts {% endblock %} 
+{% block title %} Contacts {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} sidebar-mini {% endblock body_class %}

--- a/apps/templates/pages/documentation.html
+++ b/apps/templates/pages/documentation.html
@@ -1,9 +1,9 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Tables Data {% endblock %} 
+{% block title %} Tables Data {% endblock title %}
 
 <!-- Element injected in the BODY element -->
-{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %} 
+{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
 
 <!-- Specific Page CSS goes HERE  -->
 {% block stylesheets %}

--- a/apps/templates/pages/documentation.html
+++ b/apps/templates/pages/documentation.html
@@ -11,12 +11,12 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- DataTables -->
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -941,18 +941,18 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- DataTables -->
-  <script src="/static/assets/plugins/datatables/jquery.dataTables.min.js"></script>
-  <script src="/static/assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/dataTables.responsive.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables/jquery.dataTables.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/dataTables.responsive.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
   <!-- AdminLTE for demo purposes -->
-  <script src="/static/assets/js/demo.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/demo.js') }}"></script>
   <!-- page script -->
   <script>
     $(function () {

--- a/apps/templates/pages/edit_user.html
+++ b/apps/templates/pages/edit_user.html
@@ -11,9 +11,9 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -162,19 +162,19 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- jquery-validation -->
-  <script src="/static/assets/plugins/jquery-validation/jquery.validate.min.js"></script>
-  <script src="/static/assets/plugins/jquery-validation/additional-methods.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery-validation/jquery.validate.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery-validation/additional-methods.min.js') }}"></script>
   <!-- InputMask -->
-  <script src="/static/assets/plugins/moment/moment.min.js"></script>
-  <script src="/static/assets/plugins/inputmask/jquery.inputmask.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/moment/moment.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/inputmask/jquery.inputmask.min.js') }}"></script>
   <!-- Tempusdominus Bootstrap 4 -->
-  <script src="/static/assets/plugins/tempusdominus-bootstrap-4/js/tempusdominus-bootstrap-4.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/tempusdominus-bootstrap-4/js/tempusdominus-bootstrap-4.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
   <!-- Page script -->
   <script>
     $(function () {

--- a/apps/templates/pages/edit_user.html
+++ b/apps/templates/pages/edit_user.html
@@ -45,7 +45,7 @@
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
               <li class="breadcrumb-item"><a href="/">Home</a></li>
-              <li class="breadcrumb-item"><a href="/users">Users</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.view_users') }}">Users</a></li>
               <li class="breadcrumb-item active">{{ user.name }}</li>
             </ol>
           </div>
@@ -62,7 +62,7 @@
           </div>
           <!-- /.card-header -->
           <div class="card-body">
-          <form id="userForm" method="POST">
+          <form id="userForm" method="post">
             <h5>User information</h5>
             <div class="row">
               <div class="col-md-6">

--- a/apps/templates/pages/edit_user.html
+++ b/apps/templates/pages/edit_user.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Profile - {{ user.name }} {% endblock %} 
+{% block title %} Profile - {{ user.name }} {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} sidebar-mini {% endblock body_class %}
@@ -17,7 +17,7 @@
 
 {% endblock stylesheets %}
 
-{% block content %}    
+{% block content %}
 
   <!-- Content Wrapper. Contains page content -->
   <div class="content-wrapper">

--- a/apps/templates/pages/edit_user.html
+++ b/apps/templates/pages/edit_user.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Profile - {{user.name}} {% endblock %} 
+{% block title %} Profile - {{ user.name }} {% endblock %} 
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} sidebar-mini {% endblock body_class %}
@@ -31,14 +31,14 @@
             <div class="alert alert-success alert-dismissible">
               <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
               <h5><i class="icon fas fa-check"></i> User updated successfully!</h5>
-              {{msg_ok}}
+              {{ msg_ok }}
             </div>
             {% endif %}
             {% if msg_fail %}
             <div class="alert alert-danger alert-dismissible">
               <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
               <h5><i class="icon fas fa-ban"></i> Fail to update user!</h5>
-              {{msg_fail}}
+              {{ msg_fail }}
             </div>
             {% endif %}
           </div>
@@ -46,7 +46,7 @@
             <ol class="breadcrumb float-sm-right">
               <li class="breadcrumb-item"><a href="/">Home</a></li>
               <li class="breadcrumb-item"><a href="/users">Users</a></li>
-              <li class="breadcrumb-item active">{{user.name}}</li>
+              <li class="breadcrumb-item active">{{ user.name }}</li>
             </ol>
           </div>
         </div>
@@ -58,7 +58,7 @@
       <div class="container-fluid">
         <div class="card card-default">
           <div class="card-header">
-            <h3 class="card-title">User - {{user.uid}}</h3>
+            <h3 class="card-title">User - {{ user.uid }}</h3>
           </div>
           <!-- /.card-header -->
           <div class="card-body">
@@ -68,22 +68,22 @@
               <div class="col-md-6">
                 <div class="form-group">
                   <label>Username</label>
-                  <input name="username" type="text" class="form-control is-valid" value="{{user.username}}" {{'disabled' if user.id != current_user.id and current_user.category != 'admin' else ''}}/>
+                  <input name="username" type="text" class="form-control is-valid" value="{{ user.username }}" {{ 'disabled' if user.id != current_user.id and current_user.category != 'admin' else '' }}/>
                 </div>
                 <!-- /.form-group -->
                 <div class="form-group">
                   <label>E-mail</label>
-                  <input name="email" type="text" class="form-control" value="{{user.email|default('', true)}}" {{'disabled' if user.id != current_user.id and current_user.category != 'admin' else ''}}/>
+                  <input name="email" type="text" class="form-control" value="{{ user.email|default('', true) }}" {{ 'disabled' if user.id != current_user.id and current_user.category != 'admin' else '' }}/>
                 </div>
                 <!-- /.form-group -->
                 <div class="form-group">
                   <label>First Name</label>
-                  <input name="given_name" type="text" class="form-control" value="{{user.given_name|default('', true)}}" {{'disabled' if user.id != current_user.id and current_user.category != 'admin' else ''}}/>
+                  <input name="given_name" type="text" class="form-control" value="{{ user.given_name|default('', true) }}" {{ 'disabled' if user.id != current_user.id and current_user.category != 'admin' else '' }}/>
                 </div>
                 <!-- /.form-group -->
                 <div class="form-group">
                   <label>Last Name</label>
-                  <input name="family_name" type="text" class="form-control" value="{{user.family_name|default('', true)}}" {{'disabled' if user.id != current_user.id and current_user.category != 'admin' else ''}}/>
+                  <input name="family_name" type="text" class="form-control" value="{{ user.family_name|default('', true) }}" {{ 'disabled' if user.id != current_user.id and current_user.category != 'admin' else '' }}/>
                 </div>
                 <!-- /.form-group -->
                 {% if current_user.id == user.id or current_user.category == 'admin' %}
@@ -97,14 +97,14 @@
                   <label>User category</label>
                   {% if current_user.category == "admin" %}
                   <select name="user_category" class="form-control">
-                    <option {{'selected' if user.category == 'user' else ''}}>user</option>
-                    <option {{'selected' if user.category == 'student' else ''}}>student</option>
-                    <option {{'selected' if user.category == 'labcreator' else ''}} value="labcreator">lab creator</option>
-                    <option {{'selected' if user.category == 'teacher' else ''}}>teacher</option>
-                    <option {{'selected' if user.category == 'admin' else ''}}>admin</option>
+                    <option {{ 'selected' if user.category == 'user' else '' }}>user</option>
+                    <option {{ 'selected' if user.category == 'student' else '' }}>student</option>
+                    <option {{ 'selected' if user.category == 'labcreator' else '' }} value="labcreator">lab creator</option>
+                    <option {{ 'selected' if user.category == 'teacher' else '' }}>teacher</option>
+                    <option {{ 'selected' if user.category == 'admin' else '' }}>admin</option>
                   </select>
 		  {% else %}
-                  <input type="text" class="form-control" disabled="disabled" value="{{current_user.category}}"/>
+                  <input type="text" class="form-control" disabled="disabled" value="{{ current_user.category }}"/>
 		  {% endif %}
                 </div>
               </div>
@@ -112,14 +112,14 @@
                 <!-- /.form-group -->
                 <div class="form-group">
                   <label>Issuer</label>
-                  <input type="text" class="form-control" value="{{user.issuer|default('LOCAL', true)}}" disabled/>
+                  <input type="text" class="form-control" value="{{ user.issuer|default('LOCAL', true) }}" disabled/>
                 </div>
                 <!-- /.form-group -->
                 <div class="form-group">
                   <label>Member of groups:</label>
                   <select name="member_of_groups" multiple class="form-control" disabled>
                     {% for group in user.member_of_groups %}
-		    <option>{{group.groupname}}</option>
+		    <option>{{ group.groupname }}</option>
                     {% endfor %}
                   </select>
                 </div>
@@ -127,7 +127,7 @@
                   <label>Assistant of groups:</label>
                   <select name="assistant_of_groups" multiple class="form-control" disabled>
                     {% for group in user.assistant_of_groups %}
-		    <option>{{group.groupname}}</option>
+		    <option>{{ group.groupname }}</option>
                     {% endfor %}
                   </select>
                 </div>
@@ -135,7 +135,7 @@
                   <label>Owner of groups:</label>
                   <select name="owner_of_groups" multiple class="form-control" disabled>
                     {% for group in user.owner_of_groups %}
-		    <option>{{group.groupname}}</option>
+		    <option>{{ group.groupname }}</option>
                     {% endfor %}
                   </select>
                 </div>
@@ -144,7 +144,7 @@
 
             <div class="row">
               <button class="btn btn-primary" type="submit">Save</button>
-              <a href="{{url_for(return_path|default('home_blueprint.index', true))}}" class="btn btn-secondary mx-2" role="button" aria-pressed="true">Cancel</a>
+              <a href="{{ url_for(return_path|default('home_blueprint.index', true)) }}" class="btn btn-secondary mx-2" role="button" aria-pressed="true">Cancel</a>
             </div>
             <!-- /.row -->
           </form>

--- a/apps/templates/pages/email_required.html
+++ b/apps/templates/pages/email_required.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base-fullscreen.html" %}
 
-{% block title %} Confirm your e-mail {% endblock %}
+{% block title %} Confirm your e-mail {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} register-page {% endblock body_class %}

--- a/apps/templates/pages/email_required.html
+++ b/apps/templates/pages/email_required.html
@@ -11,11 +11,11 @@
 <!-- Google Font: Source Sans Pro -->
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
 <!-- Font Awesome -->
-<link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
 <!-- icheck bootstrap -->
-<link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
 <!-- Theme style -->
-<link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -72,8 +72,8 @@
 {% block javascripts %}
 
 <!-- jQuery -->
-<script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
 <!-- Bootstrap 4 -->
-<script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/error.html
+++ b/apps/templates/pages/error.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} {{title|default("Error", true)}} {% endblock %} 
+{% block title %} {{ title|default("Error", true) }} {% endblock %} 
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} sidebar-mini {% endblock body_class %}
@@ -25,12 +25,12 @@
       <div class="container-fluid">
         <div class="row mb-2">
           <div class="col-sm-6">
-            <h1>{{title|default("Error", true)}}</h1>
+            <h1>{{ title|default("Error", true) }}</h1>
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
               <li class="breadcrumb-item"><a href="#">Home</a></li>
-              <li class="breadcrumb-item active">{{title|default("Error", true)}}</li>
+              <li class="breadcrumb-item active">{{ title|default("Error", true) }}</li>
             </ol>
           </div>
         </div>
@@ -42,16 +42,16 @@
       <div class="error-page">
         <h2 class="headline text-danger"><i class="fas fa-exclamation-triangle text-danger"></i></h2>
         <div class="error-content">
-          <h3> Oops! {{title|default("Error.", true)}}</h3>
+          <h3> Oops! {{ title|default("Error.", true) }}</h3>
           <p>
-            {{msg|default("Failed to run task.", true)}}
+            {{ msg|default("Failed to run task.", true) }}
           </p>
         </div>
         {% if additional_actions %}
         <div class="error-content pt-5">
           {% for action in additional_actions %}
-          <a href="{{action['href']}}" type="button" class="btn {{action['btn-class']}} btn-lg mr-2">
-            <i class="fas {{action['icon']}}"></i>  {{action['text']}}
+          <a href="{{ action['href'] }}" type="button" class="btn {{ action['btn-class'] }} btn-lg mr-2">
+            <i class="fas {{ action['icon'] }}"></i>  {{ action['text'] }}
           </a>
           {% endfor %}
         </div>

--- a/apps/templates/pages/error.html
+++ b/apps/templates/pages/error.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} {{ title|default("Error", true) }} {% endblock %} 
+{% block title %} {{ title|default("Error", true) }} {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} sidebar-mini {% endblock body_class %}
@@ -17,7 +17,7 @@
 
 {% endblock stylesheets %}
 
-{% block content %}    
+{% block content %}
 
   <div class="content-wrapper">
     <!-- Content Header (Page header) -->

--- a/apps/templates/pages/error.html
+++ b/apps/templates/pages/error.html
@@ -11,9 +11,9 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -68,10 +68,10 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/feedback_view.html
+++ b/apps/templates/pages/feedback_view.html
@@ -70,13 +70,13 @@
                       {% if current_user.category == "admin" %}
                       <div class="float-right">
                         {% if feedback.is_hidden %}
-                        <form action="{{ url_for('home_blueprint.hide_feedback') }}" method="POST" class="d-inline">
+                        <form action="{{ url_for('home_blueprint.hide_feedback') }}" method="post" class="d-inline">
                           <input type="hidden" name="feedback_id" value="{{ feedback.id }}">
                           <input type="hidden" name="action" value="unhide">
                           <button type="submit" class="btn btn-info btn-sm">Unhide</button>
                         </form>
                         {% else %}
-                        <form action="{{ url_for('home_blueprint.hide_feedback') }}" method="POST" class="d-inline">
+                        <form action="{{ url_for('home_blueprint.hide_feedback') }}" method="post" class="d-inline">
                           <input type="hidden" name="feedback_id" value="{{ feedback.id }}">
                           <input type="hidden" name="action" value="hide">
                           <button type="submit" class="btn btn-warning btn-sm">Hide</button>

--- a/apps/templates/pages/feedback_view.html
+++ b/apps/templates/pages/feedback_view.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Home {% endblock %}
+{% block title %} Home {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}

--- a/apps/templates/pages/feedback_view.html
+++ b/apps/templates/pages/feedback_view.html
@@ -11,13 +11,13 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome Icons -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- overlayScrollbars -->
-  <link rel="stylesheet" href="/static/assets/plugins/overlayScrollbars/css/OverlayScrollbars.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
   <!-- Leaflet -->
-  <link rel="stylesheet" href="/static/assets/plugins/leaflet/leaflet.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/leaflet/leaflet.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -105,9 +105,9 @@
 <!-- Specific Page JS goes HERE  -->
 {% block javascripts %}
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- Page Script -->
   <script>
     $(function () {

--- a/apps/templates/pages/finished_lab_infos.html
+++ b/apps/templates/pages/finished_lab_infos.html
@@ -8,11 +8,11 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
   <style>
     .success-icon {
       font-size: 5rem;
@@ -129,16 +129,16 @@
 {% block javascripts %}
   <!-- REQUIRED SCRIPTS -->
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
 
   <!-- Bootstrap -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 
   <!-- overlayScrollbars -->
-  <script src="/static/assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
 
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.js') }}"></script>
 
   <script>
     $(document).ready(function() {

--- a/apps/templates/pages/finished_lab_infos.html
+++ b/apps/templates/pages/finished_lab_infos.html
@@ -59,7 +59,7 @@
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="{{url_for('home_blueprint.index')}}">Home</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
               <li class="breadcrumb-item"><a href="#">Labs</a></li>
               <li class="breadcrumb-item active">Lab Completed</li>
             </ol>
@@ -89,7 +89,7 @@
                 </p>
 
                 <div class="success-actions">
-                  <a href="{{url_for('home_blueprint.view_labs', lab_id=lab_id)}}" type="button" class="btn btn-primary btn-lg mr-2" id="retry-lab">
+                  <a href="{{ url_for('home_blueprint.view_labs', lab_id=lab_id) }}" type="button" class="btn btn-primary btn-lg mr-2" id="retry-lab">
                     <i class="fas fa-redo"></i> Execute Again
                   </a>
                   <!-- Future feature: View Answers -->
@@ -99,7 +99,7 @@
                 </div>
 
                 <div class="mt-4">
-                  <a href="{{url_for('home_blueprint.index')}}" class="text-muted">
+                  <a href="{{ url_for('home_blueprint.index') }}" class="text-muted">
                     <i class="fas fa-arrow-left mr-1"></i> Back to Home
                   </a>
                 </div>
@@ -161,7 +161,7 @@
       // Button to execute again
       $('#retry-lab').click(function() {
         // Redirect to the laboratory page
-        window.location.href = '/labs/execute/{{lab_id}}';
+        window.location.href = '/labs/execute/{{ lab_id }}';
       });
 
 

--- a/apps/templates/pages/finished_lab_infos.html
+++ b/apps/templates/pages/finished_lab_infos.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Lab Completed {% endblock %}
+{% block title %} Lab Completed {% endblock title %}
 
 {% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
 

--- a/apps/templates/pages/finished_labs.html
+++ b/apps/templates/pages/finished_labs.html
@@ -1,9 +1,9 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Finished Labs {% endblock %} 
+{% block title %} Finished Labs {% endblock title %}
 
 <!-- Element injected in the BODY element -->
-{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %} 
+{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
 
 <!-- Specific Page CSS goes HERE  -->
 {% block stylesheets %}
@@ -23,7 +23,7 @@
   </style>
 {% endblock stylesheets %}
 
-{% block content %}  
+{% block content %}
 
   <!-- Content Wrapper. Contains page content -->
   <div class="content-wrapper">

--- a/apps/templates/pages/finished_labs.html
+++ b/apps/templates/pages/finished_labs.html
@@ -11,14 +11,14 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- DataTables -->
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
   <style type="text/css">
   </style>
 {% endblock stylesheets %}
@@ -145,16 +145,16 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- DataTables -->
-  <script src="/static/assets/plugins/datatables/jquery.dataTables.min.js"></script>
-  <script src="/static/assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/dataTables.responsive.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables/jquery.dataTables.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/dataTables.responsive.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
   <!-- Page Script -->
   <script>
     $(function () {
@@ -256,6 +256,6 @@
     })
   </script>
   <!-- AdminLTE for demo purposes -->
-  <script src="/static/assets/js/demo.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/demo.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/finished_labs.html
+++ b/apps/templates/pages/finished_labs.html
@@ -36,7 +36,7 @@
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="/index">Home</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
               <li class="breadcrumb-item active">Finished Labs</li>
             </ol>
           </div>

--- a/apps/templates/pages/finished_labs.html
+++ b/apps/templates/pages/finished_labs.html
@@ -62,9 +62,9 @@
                       <div class="col-md-8">
                         <select name="filter_group" class="form-control" onchange="this.form.submit()">
                           <option value="">My own labs</option>
-                          <option value="all" {{'selected' if filter_group == 'all' else ''}}>All labs</option>
+                          <option value="all" {{ 'selected' if filter_group == 'all' else '' }}>All labs</option>
                           {% for group_id in groups %}
-                          <option value="{{group_id}}" {{'selected' if filter_group == group_id else ''}}>{{groups[group_id].groupname}}</option>
+                          <option value="{{ group_id }}" {{ 'selected' if filter_group == group_id else '' }}>{{ groups[group_id].groupname }}</option>
                           {% endfor %}
                         </select>
 	              </div>
@@ -95,18 +95,18 @@
                 </thead>
                 <tbody>
             	{% for lab in labs %}
-                <tr id="{{lab['lab_instance_id']}}">
+                <tr id="{{ lab['lab_instance_id'] }}">
                   <td>
                     <div class="icheck-primary">
-                      <input type="checkbox" value="" id="checkbox-{{lab['lab_instance_id']}}">
-                      <label for="checkbox-{{lab['lab_instance_id']}}"></label>
+                      <input type="checkbox" value="" id="checkbox-{{ lab['lab_instance_id'] }}">
+                      <label for="checkbox-{{ lab['lab_instance_id'] }}"></label>
                     </div>
                   </td>
-                  <td>{{lab['user']}}</td>
-                  <td>{{lab['title']}}</td>
-                  <td>{{lab['created']}}</td>
-                  <td>{{lab['finished']}}</td>
-                  <td>{{lab['finish_reason']}}</td>
+                  <td>{{ lab['user'] }}</td>
+                  <td>{{ lab['title'] }}</td>
+                  <td>{{ lab['created'] }}</td>
+                  <td>{{ lab['finished'] }}</td>
+                  <td>{{ lab['finish_reason'] }}</td>
                 </tr>
                 {% endfor %}
                 </tbody>

--- a/apps/templates/pages/gallery.html
+++ b/apps/templates/pages/gallery.html
@@ -1,9 +1,9 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Gallery {% endblock %} 
+{% block title %} Gallery {% endblock title %}
 
 <!-- Element injected in the BODY element -->
-{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %} 
+{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
 
 <!-- Specific Page CSS goes HERE  -->
 {% block stylesheets %}

--- a/apps/templates/pages/gallery.html
+++ b/apps/templates/pages/gallery.html
@@ -11,11 +11,11 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- Ekko Lightbox -->
-  <link rel="stylesheet" href="/static/assets/plugins/ekko-lightbox/ekko-lightbox.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/ekko-lightbox/ekko-lightbox.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -224,19 +224,19 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- jQuery UI -->
-  <script src="/static/assets/plugins/jquery-ui/jquery-ui.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery-ui/jquery-ui.min.js') }}"></script>
   <!-- Ekko Lightbox -->
-  <script src="/static/assets/plugins/ekko-lightbox/ekko-lightbox.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/ekko-lightbox/ekko-lightbox.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
   <!-- AdminLTE for demo purposes -->
-  <script src="/static/assets/js/demo.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/demo.js') }}"></script>
   <!-- Filterizr-->
-  <script src="/static/assets/plugins/filterizr/jquery.filterizr.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/filterizr/jquery.filterizr.min.js') }}"></script>
   <!-- Page specific script -->
   <script>
     $(function () {

--- a/apps/templates/pages/gallery.html
+++ b/apps/templates/pages/gallery.html
@@ -52,22 +52,22 @@
               <div class="card-body">
                 <div>
                   <div class="btn-group w-100 mb-2">
-                    <a class="btn btn-info active" href="javascript:void(0)" data-filter="all"> All items </a>
-                    <a class="btn btn-info" href="javascript:void(0)" data-filter="1"> Category 1 (WHITE) </a>
-                    <a class="btn btn-info" href="javascript:void(0)" data-filter="2"> Category 2 (BLACK) </a>
-                    <a class="btn btn-info" href="javascript:void(0)" data-filter="3"> Category 3 (COLORED) </a>
-                    <a class="btn btn-info" href="javascript:void(0)" data-filter="4"> Category 4 (COLORED, BLACK) </a>
+                    <a class="btn btn-info active" href="#" data-filter="all"> All items </a>
+                    <a class="btn btn-info" href="#" data-filter="1"> Category 1 (WHITE) </a>
+                    <a class="btn btn-info" href="#" data-filter="2"> Category 2 (BLACK) </a>
+                    <a class="btn btn-info" href="#" data-filter="3"> Category 3 (COLORED) </a>
+                    <a class="btn btn-info" href="#" data-filter="4"> Category 4 (COLORED, BLACK) </a>
                   </div>
                   <div class="mb-2">
-                    <a class="btn btn-secondary" href="javascript:void(0)" data-shuffle> Shuffle items </a>
+                    <a class="btn btn-secondary" href="#" data-shuffle> Shuffle items </a>
                     <div class="float-right">
                       <select class="custom-select" style="width: auto;" data-sortOrder>
                         <option value="index"> Sort by Position </option>
                         <option value="sortData"> Sort by Custom Data </option>
                       </select>
                       <div class="btn-group">
-                        <a class="btn btn-default" href="javascript:void(0)" data-sortAsc> Ascending </a>
-                        <a class="btn btn-default" href="javascript:void(0)" data-sortDesc> Descending </a>
+                        <a class="btn btn-default" href="#" data-sortAsc> Ascending </a>
+                        <a class="btn btn-default" href="#" data-sortDesc> Descending </a>
                       </div>
                     </div>
                   </div>

--- a/apps/templates/pages/groups_edit.html
+++ b/apps/templates/pages/groups_edit.html
@@ -11,16 +11,16 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- daterange picker -->
-  <link rel="stylesheet" href="/static/assets/plugins/daterangepicker/daterangepicker.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/daterangepicker/daterangepicker.css') }}">
   <!-- Select2 -->
-  <link rel="stylesheet" href="/static/assets/plugins/select2/css/select2.min.css">
-  <link rel="stylesheet" href="/static/assets/plugins/select2-bootstrap4-theme/select2-bootstrap4.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/select2/css/select2.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/select2-bootstrap4-theme/select2-bootstrap4.min.css') }}">
   <!-- Bootstrap4 Duallistbox -->
-  <link rel="stylesheet" href="/static/assets/plugins/bootstrap4-duallistbox/bootstrap-duallistbox.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/bootstrap4-duallistbox/bootstrap-duallistbox.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -220,22 +220,22 @@ user2@ufxpto.edu.br"
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- Bootstrap4 Duallistbox -->
-  <script src="/static/assets/plugins/bootstrap4-duallistbox/jquery.bootstrap-duallistbox.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap4-duallistbox/jquery.bootstrap-duallistbox.min.js') }}"></script>
   <!-- Select2 -->
-  <script src="/static/assets/plugins/select2/js/select2.full.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/select2/js/select2.full.min.js') }}"></script>
   <!-- InputMask -->
-  <script src="/static/assets/plugins/moment/moment.min.js"></script>
-  <script src="/static/assets/plugins/inputmask/jquery.inputmask.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/moment/moment.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/inputmask/jquery.inputmask.min.js') }}"></script>
   <!-- date-range-picker -->
-  <script src="/static/assets/plugins/daterangepicker/daterangepicker.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/daterangepicker/daterangepicker.js') }}"></script>
   <!-- Tempusdominus Bootstrap 4 -->
-  <script src="/static/assets/plugins/tempusdominus-bootstrap-4/js/tempusdominus-bootstrap-4.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/tempusdominus-bootstrap-4/js/tempusdominus-bootstrap-4.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
   <!-- Page script -->
   <script>
     $(function () {

--- a/apps/templates/pages/groups_edit.html
+++ b/apps/templates/pages/groups_edit.html
@@ -135,11 +135,11 @@ user2@ufxpto.edu.br"
                         <select name="group_members" class="duallistbox" multiple="multiple">
 	                {% set members_dict = group.members_dict %}
 	                {% for user_id in users %}
-		        {%   set selected = "" %}
-		        {%   if user_id in members_dict %}
-		        {%     set selected = "selected" %}
-		        {%   endif %}
-		          <option {{selected}} value={{user_id}}>{{users[user_id]}}</option>
+		        {% set selected = "" %}
+		        {% if user_id in members_dict %}
+		        {% set selected = "selected" %}
+		        {% endif %}
+		          <option {{ selected }} value={{ user_id }}>{{ users[user_id] }}</option>
 		        {% endfor %}
                         </select>
                       </div>
@@ -157,11 +157,11 @@ user2@ufxpto.edu.br"
                         <select name="group_assistants" class="duallistbox" multiple="multiple">
 	                {% set assistants_dict = group.assistants_dict %}
 	                {% for user_id in users %}
-		        {%   set selected = "" %}
-		        {%   if user_id in assistants_dict %}
-		        {%     set selected = "selected" %}
-		        {%   endif %}
-		          <option {{selected}} value={{user_id}}>{{users[user_id]}}</option>
+		        {% set selected = "" %}
+		        {% if user_id in assistants_dict %}
+		        {% set selected = "selected" %}
+		        {% endif %}
+		          <option {{ selected }} value={{ user_id }}>{{ users[user_id] }}</option>
 		        {% endfor %}
                         </select>
                       </div>
@@ -179,17 +179,17 @@ user2@ufxpto.edu.br"
                         <select name="group_owners" class="duallistbox" multiple="multiple">
 	                {% set owners_dict = group.owners_dict %}
 	                {% for user_id in users %}
-		        {%   set selected = "" %}
-		        {%   if action_name == "Create" %}
-		        {%     if (current_user.category == "admin" or current_user.category == "teacher") and current_user.id == user_id %}
-		        {%       set selected = "selected" %}
-		        {%     endif %}
-		        {%   else %}
-		        {%     if user_id in owners_dict %}
-		        {%       set selected = "selected" %}
-		        {%     endif %}
-		        {%   endif %}
-		          <option {{selected}} value={{user_id}}>{{users[user_id]}}</option>
+		        {% set selected = "" %}
+		        {% if action_name == "Create" %}
+		        {% if (current_user.category == "admin" or current_user.category == "teacher") and current_user.id == user_id %}
+		        {% set selected = "selected" %}
+		        {% endif %}
+		        {% else %}
+		        {% if user_id in owners_dict %}
+		        {% set selected = "selected" %}
+		        {% endif %}
+		        {% endif %}
+		          <option {{ selected }} value={{ user_id }}>{{ users[user_id] }}</option>
 		        {% endfor %}
                         </select>
                       </div>
@@ -201,7 +201,7 @@ user2@ufxpto.edu.br"
               </div> <!-- /.row -->
 
               <div class="row">
-		<button class="btn btn-primary" type="submit">{{action_name}}</button>
+		<button class="btn btn-primary" type="submit">{{ action_name }}</button>
                 <a href="{{ url_for('home_blueprint.list_groups') }}" class="btn btn-secondary mx-2" role="button" aria-pressed="true">Cancel</a>
               </div>
               <!-- /.row -->

--- a/apps/templates/pages/groups_edit.html
+++ b/apps/templates/pages/groups_edit.html
@@ -69,7 +69,7 @@
           </div>
           <!-- /.card-header -->
           <div class="card-body">
-            <form method="POST" action="">
+            <form method="post" action="">
               <div class="row">
                 <div class="col-md-6">
                   <div class="card card-primary">

--- a/apps/templates/pages/groups_edit.html
+++ b/apps/templates/pages/groups_edit.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Edit Group - {{ group.groupname }} {% endblock %} 
+{% block title %} Edit Group - {{ group.groupname }} {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} sidebar-mini {% endblock body_class %}
@@ -24,7 +24,7 @@
 
 {% endblock stylesheets %}
 
-{% block content %}    
+{% block content %}
 
   <!-- Content Wrapper. Contains page content -->
   <div class="content-wrapper">

--- a/apps/templates/pages/groups_list.html
+++ b/apps/templates/pages/groups_list.html
@@ -8,14 +8,14 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- DataTables -->
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 {% endblock stylesheets %}
 
 {% block content %}
@@ -168,22 +168,22 @@
 {% block javascripts %}
   <!-- REQUIRED SCRIPTS -->
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   
   <!-- Bootstrap -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 
   <!-- DataTables -->
-  <script src="/static/assets/plugins/datatables/jquery.dataTables.min.js"></script>
-  <script src="/static/assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/dataTables.responsive.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables/jquery.dataTables.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/dataTables.responsive.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js') }}"></script>
   
   <!-- overlayScrollbars -->
-  <script src="/static/assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
   
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.js') }}"></script>
 
   <!-- Custom Script for Delete Functionality -->
   <script>

--- a/apps/templates/pages/groups_list.html
+++ b/apps/templates/pages/groups_list.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Groups {% endblock %}
+{% block title %} Groups {% endblock title %}
 
 {% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
 

--- a/apps/templates/pages/groups_list.html
+++ b/apps/templates/pages/groups_list.html
@@ -79,7 +79,7 @@
                 </thead>
                 <tbody>
                 {% for group in groups %}
-                <tr id="{{group.id}}">
+                <tr id="{{ group.id }}">
                   <td>{{ group.groupname }}</td>
                   <td>{{ group.organization|default("", true) }}</td>
                   <td class="text-right">
@@ -92,7 +92,7 @@
                       <a href="{{ url_for('home_blueprint.edit_group', group_id=group.id) }}" class="btn btn-outline-dark" role="button" aria-pressed="true">
                         <i class="fas fa-edit"></i> Edit/View
                       </a>
-		      <button type="button" title="Delete group" class="btn btn-outline-danger button-delete-group" data-toggle="modal" data-target="#modal-delete-group" data-id="{{group.id}}">
+		      <button type="button" title="Delete group" class="btn btn-outline-danger button-delete-group" data-toggle="modal" data-target="#modal-delete-group" data-id="{{ group.id }}">
                         <i class="fas fa-trash"></i> Delete
                       </button>
                     {% endif %}

--- a/apps/templates/pages/groups_list.html
+++ b/apps/templates/pages/groups_list.html
@@ -44,7 +44,7 @@
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="/index">Home</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
               <li class="breadcrumb-item active">Groups</li>
             </ol>
           </div>

--- a/apps/templates/pages/index.html
+++ b/apps/templates/pages/index.html
@@ -55,7 +55,7 @@
               <div class="info-box-content">
                 <span class="info-box-text">Finished Labs</span>
                 <span class="info-box-number">
-                  {{stats['lab_instances']}}
+                  {{ stats['lab_instances'] }}
                 </span>
               </div>
               <!-- /.info-box-content -->
@@ -69,7 +69,7 @@
 
               <div class="info-box-content">
                 <span class="info-box-text">Registered Labs</span>
-                <span class="info-box-number">{{stats['registered_labs']|length}}</span>
+                <span class="info-box-number">{{ stats['registered_labs']|length }}</span>
               </div>
               <!-- /.info-box-content -->
             </div>
@@ -87,7 +87,7 @@
 
               <div class="info-box-content">
                 <span class="info-box-text">Users</span>
-                <span class="info-box-number">{{stats['users']}}</span>
+                <span class="info-box-number">{{ stats['users'] }}</span>
               </div>
               <!-- /.info-box-content -->
             </div>
@@ -96,11 +96,11 @@
           <!-- /.col -->
           <div class="col-12 col-sm-6 col-md-3">
             <div class="info-box mb-3">
-              <button id="thumbsUpButtonMain" type="button" class="info-box-icon {{"bg-success" if stats['has_liked'] else "bg-secondary"}} elevation-1 icobutton icobutton--thumbs-up" data-toggle="modal" data-target="#modal-feedback"><i class="fas fa-thumbs-up"></i></button>
+              <button id="thumbsUpButtonMain" type="button" class="info-box-icon {{ "bg-success" if stats['has_liked'] else "bg-secondary" }} elevation-1 icobutton icobutton--thumbs-up" data-toggle="modal" data-target="#modal-feedback"><i class="fas fa-thumbs-up"></i></button>
 
               <div class="info-box-content">
                 <span class="info-box-text">Likes</span>
-                <span class="info-box-number" id="user-likes">{{stats['likes']}}</span>
+                <span class="info-box-number" id="user-likes">{{ stats['likes'] }}</span>
               </div>
               <!-- /.info-box-content -->
             </div>
@@ -117,7 +117,7 @@
             <!-- MAP & BOX PANE -->
             <div class="card">
               <div class="card-header">
-                <h3 class="card-title">{{testbed_infos.title}}</h3>
+                <h3 class="card-title">{{ testbed_infos.title }}</h3>
               </div>
               <!-- /.card-header -->
               <div class="card-body p-0">
@@ -143,7 +143,7 @@
 
                       <div class="info-box-content">
                         <span class="info-box-text">Available CPUs</span>
-                        <span class="info-box-number">{{stats['cpu_capacity']}}</span>
+                        <span class="info-box-number">{{ stats['cpu_capacity'] }}</span>
                       </div>
                       <!-- /.info-box-content -->
                     </div>
@@ -153,7 +153,7 @@
 
                       <div class="info-box-content">
                         <span class="info-box-text">Available Memory</span>
-                        <span class="info-box-number">{{stats['memory_capacity']}}</span>
+                        <span class="info-box-number">{{ stats['memory_capacity'] }}</span>
                       </div>
                       <!-- /.info-box-content -->
                     </div>
@@ -163,7 +163,7 @@
 
                       <div class="info-box-content">
                         <span class="info-box-text">Storage capacity</span>
-                        <span class="info-box-number">{{stats['storage_capacity']}}</span>
+                        <span class="info-box-number">{{ stats['storage_capacity'] }}</span>
                       </div>
                       <!-- /.info-box-content -->
                     </div>
@@ -173,7 +173,7 @@
 
                       <div class="info-box-content">
                         <span class="info-box-text">Pods</span>
-                        <span class="info-box-number">{{stats['total_pods']}}</span>
+                        <span class="info-box-number">{{ stats['total_pods'] }}</span>
                       </div>
                       <!-- /.info-box-content -->
                     </div>
@@ -183,7 +183,7 @@
 
                       <div class="info-box-content">
                         <span class="info-box-text">Nodes</span>
-                        <span class="info-box-number">{{stats['total_nodes']}}</span>
+                        <span class="info-box-number">{{ stats['total_nodes'] }}</span>
                       </div>
                       <!-- /.info-box-content -->
                     </div>
@@ -315,7 +315,7 @@
             <div class="card-header d-flex justify-content-between align-items-center">
               <h3 class="card-title mb-0">Users Feedback</h3>
               <div class="ml-auto">
-                <a href="#" id="view-add-feedback" class="btn btn-sm btn-outline-primary mr-2" data-toggle="modal" data-target="#modal-feedback">{{ "View" if user_feedback else "Add"}} Feedback</a>
+                <a href="#" id="view-add-feedback" class="btn btn-sm btn-outline-primary mr-2" data-toggle="modal" data-target="#modal-feedback">{{ "View" if user_feedback else "Add" }} Feedback</a>
                 <a href="{{ url_for('home_blueprint.feedback_view') }}" class="btn btn-sm btn-outline-secondary">See All</a>
               </div>
             </div>
@@ -334,10 +334,10 @@
                       </button>
                     </div>
                     <div class="modal-body">
-                      <div class="form-group {{"d-none" if stats['has_liked'] else ""}}">
+                      <div class="form-group {{ "d-none" if stats['has_liked'] else "" }}">
                         <label for="thumbsUp">Enjoying the platform?</label>
                         <div class="info-box mb-3">
-                          <button id="thumbsUpButton" type="button" class="info-box-icon {{"bg-success" if stats['has_liked'] else "bg-secondary"}} elevation-1 icobutton icobutton--thumbs-up"><i class="fas fa-thumbs-up"></i></button>
+                          <button id="thumbsUpButton" type="button" class="info-box-icon {{ "bg-success" if stats['has_liked'] else "bg-secondary" }} elevation-1 icobutton icobutton--thumbs-up"><i class="fas fa-thumbs-up"></i></button>
                         </div>
                       </div>
                       <div class="form-group">
@@ -393,14 +393,14 @@
                       <img src="/static/assets/img/default-150x150.png" alt="Lab Image" class="img-size-50">
                     </div>
                     <div class="product-info">
-                      <a href="/labs/view/{{lab.id}}" class="product-title">
-                        {{lab.title}}
+                      <a href="/labs/view/{{ lab.id }}" class="product-title">
+                        {{ lab.title }}
 			{% for category in lab.categories %}
-			<span class="badge badge-{{category.color_cls}} float-right ml-1">{{category.category}}</span>
+			<span class="badge badge-{{ category.color_cls }} float-right ml-1">{{ category.category }}</span>
 			{% endfor %}
 		      </a>
                       <span class="product-description">
-                        {{lab.description|default('No short description provided. Click to see more details', true)}}
+                        {{ lab.description|default('No short description provided. Click to see more details', true) }}
                       </span>
                     </div>
                    </li>
@@ -474,7 +474,7 @@
   <!-- Leaflet -->
   <script src="/static/assets/plugins/leaflet/leaflet.js"></script>
   {% if config.MAP_GEOJSON_JS %}
-  <script src="/static/assets/plugins/leaflet/geojson/{{config.MAP_GEOJSON_JS}}"></script>
+  <script src="/static/assets/plugins/leaflet/geojson/{{ config.MAP_GEOJSON_JS }}"></script>
   {% endif %}
   <!-- ChartJS -->
   <script src="/static/assets/plugins/chart.js/Chart.min.js"></script>
@@ -510,7 +510,7 @@
           this.options = extend({}, this.options);
           extend(this.options, options);
 
-          this.checked = {{"true" if stats['has_liked'] else "false"}};
+          this.checked = {{ "true" if stats['has_liked'] else "false" }};
           this.timeline = new mojs.Timeline();
 
           for (var i = 0, len = this.options.tweens.length; i < len; ++i) {
@@ -620,11 +620,11 @@
       // ------ PIE CHART ------
       var pieChartCanvas = $('#pieChart').get(0).getContext('2d')
       var pieData = {
-        labels: {{stats.lab_categories.category_names|safe}},
+        labels: {{ stats.lab_categories.category_names|safe }},
         datasets: [
           {
-            data: {{stats.lab_categories.usage_counts|safe}},
-            backgroundColor: {{stats.lab_categories.category_colors|safe}},
+            data: {{ stats.lab_categories.usage_counts|safe }},
+            backgroundColor: {{ stats.lab_categories.category_colors|safe }},
             borderColor: '#eeeeeeff'
           }
         ]
@@ -640,7 +640,7 @@
         options: pieOptions
       })
       const pieChartLegend = document.getElementById('pie-chart-legend');
-      const categories = {{stats.lab_categories.name_cls|safe}};
+      const categories = {{ stats.lab_categories.name_cls|safe }};
       Object.keys(categories).forEach(name => {
           pieChartLegend.innerHTML += `<li><i class="fa fa-circle fa-border text-${categories[name]}"></i> ${name}</li>`;
       });
@@ -655,10 +655,10 @@
         }
       };
       const salesChartCanvas = $('#salesChart').get(0).getContext('2d');
-      const labsData = {{stats.lab_usage.labs|safe}};
-      const answersData = {{stats.lab_usage.answers|safe}};
+      const labsData = {{ stats.lab_usage.labs|safe }};
+      const answersData = {{ stats.lab_usage.answers|safe }};
       const salesChartData = {
-        labels: {{stats.lab_usage.months|safe}},
+        labels: {{ stats.lab_usage.months|safe }},
         datasets: [
           {
              label: 'Lab Instances',
@@ -708,9 +708,9 @@
       $('#current-month-completed-labs').text(labsData.at(-1));
       $('#current-month-answers-questions').text(answersData.at(-1));
       $('#current-month-completed-challenges').text(answersData.at(-1));
-      $('#completed-labs-last-six-months').text({{stats.lab_usage.total_labs}});
-      $('#answered-questions-last-six-months').text({{stats.lab_usage.total_answers}});
-      $('#solved-challenges-last-six-months').text({{stats.lab_usage.total_answers}});
+      $('#completed-labs-last-six-months').text({{ stats.lab_usage.total_labs }});
+      $('#answered-questions-last-six-months').text({{ stats.lab_usage.total_answers }});
+      $('#solved-challenges-last-six-months').text({{ stats.lab_usage.total_answers }});
       updateGrowthAmount('completed-labs-growth', labsData.at(-1) - labsData.at(-2));
       updateGrowthAmount('completed-challenges-growth', answersData.at(-1) - answersData.at(-2));
       updateGrowthAmount('answered-questions-growth', answersData.at(-1) - answersData.at(-2));
@@ -734,7 +734,7 @@
         const commentInput = document.getElementById("comment");
         const submitButton = document.getElementById("submit-star");
 
-        let selectedRating = {{user_feedback.stars|default(0, true)}};
+        let selectedRating = {{ user_feedback.stars|default(0, true) }};
         let hasRated = false;
 
         fetch('api/feedback', {
@@ -763,7 +763,7 @@
         });
 
         // ------------------------ STARS ------------------------
-        highlightStars({{user_feedback.stars|default(0, true)}});
+        highlightStars({{ user_feedback.stars|default(0, true) }});
         stars.forEach(star => {
             star.addEventListener("mouseover", function () {
                 const index = parseInt(this.getAttribute("data-index"));

--- a/apps/templates/pages/index.html
+++ b/apps/templates/pages/index.html
@@ -11,14 +11,14 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome Icons -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- overlayScrollbars -->
-  <link rel="stylesheet" href="/static/assets/plugins/overlayScrollbars/css/OverlayScrollbars.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
   <!-- Leaflet -->
-  <link rel="stylesheet" href="/static/assets/plugins/leaflet/leaflet.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/leaflet/leaflet.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
-  <link rel="stylesheet" href="/static/assets/css/custom.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/custom.css') }}">
 {% endblock stylesheets %}
 
 {% block content %}
@@ -388,7 +388,7 @@
 		  {% if loop.index <= 5 %}
                   <li class="item">
                     <div class="product-img">
-                      <img src="/static/assets/img/default-150x150.png" alt="Lab Image" class="img-size-50">
+                      <img src="{{ url_for('static', filename='assets/img/default-150x150.png') }}" alt="Lab Image" class="img-size-50">
                     </div>
                     <div class="product-info">
                       <a href="{{ url_for('home_blueprint.view_labs', lab_id=lab.id) }}" class="product-title">
@@ -460,27 +460,27 @@
 
   <!-- REQUIRED SCRIPTS -->
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- overlayScrollbars -->
-  <script src="/static/assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.js') }}"></script>
 
   <!-- PAGE PLUGINS -->
   <!-- Leaflet -->
-  <script src="/static/assets/plugins/leaflet/leaflet.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/leaflet/leaflet.js') }}"></script>
   {% if config.MAP_GEOJSON_JS %}
-  <script src="/static/assets/plugins/leaflet/geojson/{{ config.MAP_GEOJSON_JS }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/leaflet/geojson/{{ config.MAP_GEOJSON_JS }}') }}"></script>
   {% endif %}
   <!-- ChartJS -->
-  <script src="/static/assets/plugins/chart.js/Chart.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/chart.js/Chart.min.js') }}"></script>
   <!-- Motion JS -->
-  <script src="/static/assets/plugins/mojs/mojs.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/mojs/mojs.js') }}"></script>
 
   <!-- PAGE SCRIPTS -->
-  <script src="/static/assets/js/pages/dashboard2.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/pages/dashboard2.js') }}"></script>
   <script type="text/javascript">
     function isIOSSafari() {
         var userAgent;

--- a/apps/templates/pages/index.html
+++ b/apps/templates/pages/index.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Home {% endblock %}
+{% block title %} Home {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}

--- a/apps/templates/pages/index.html
+++ b/apps/templates/pages/index.html
@@ -369,8 +369,6 @@
           <!-- /.card -->
         </div>
         <!-- /.Right col -->
-          </div>
-          <!-- /.col -->
         </div>
         <!-- /.row -->
 
@@ -393,7 +391,7 @@
                       <img src="/static/assets/img/default-150x150.png" alt="Lab Image" class="img-size-50">
                     </div>
                     <div class="product-info">
-                      <a href="/labs/view/{{ lab.id }}" class="product-title">
+                      <a href="{{ url_for('home_blueprint.view_labs', lab_id=lab.id) }}" class="product-title">
                         {{ lab.title }}
 			{% for category in lab.categories %}
 			<span class="badge badge-{{ category.color_cls }} float-right ml-1">{{ category.category }}</span>
@@ -410,7 +408,7 @@
               </div>
               <!-- /.card-body -->
               <div class="card-footer text-center">
-                <a href="/labs/view" class="uppercase">View All Labs</a>
+                <a href="{{ url_for('home_blueprint.view_labs') }}" class="uppercase">View All Labs</a>
               </div>
               <!-- /.card-footer -->
             </div>

--- a/apps/templates/pages/k8s_dep_list.html
+++ b/apps/templates/pages/k8s_dep_list.html
@@ -75,15 +75,15 @@
                 </thead>
                 <tbody>
                 {% for item in deployments %}
-                <tr id="{{item['uid']}}">
+                <tr id="{{ item['uid'] }}">
                   <td>
                     <div class="icheck-primary">
-                      <input type="checkbox" value="" id="checkbox-{{item['uid']}}">
-                      <label for="checkbox-{{item['uid']}}"></label>
+                      <input type="checkbox" value="" id="checkbox-{{ item['uid'] }}">
+                      <label for="checkbox-{{ item['uid'] }}"></label>
                     </div>
                   </td>
                   <td>{{ item['name'] }}</td>
-                  <td>{{ item['containers_ready']}}/{{item['containers_total']}}</td>
+                  <td>{{ item['containers_ready'] }}/{{ item['containers_total'] }}</td>
                   <td>{{ item['age'] }}</td>
                   <td>{{ item['containers'] }}</td>
                   <td>

--- a/apps/templates/pages/k8s_dep_list.html
+++ b/apps/templates/pages/k8s_dep_list.html
@@ -11,14 +11,14 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- DataTables -->
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 {% endblock stylesheets %}
 
 {% block content %}
@@ -196,16 +196,16 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- DataTables -->
-  <script src="/static/assets/plugins/datatables/jquery.dataTables.min.js"></script>
-  <script src="/static/assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/dataTables.responsive.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables/jquery.dataTables.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/dataTables.responsive.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
   <!-- Page Script -->
   <script>
     $(function () {
@@ -353,6 +353,6 @@
     })
   </script>
   <!-- AdminLTE for demo purposes -->
-  <script src="/static/assets/js/demo.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/demo.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/k8s_dep_list.html
+++ b/apps/templates/pages/k8s_dep_list.html
@@ -34,7 +34,7 @@
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="/index">Home</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
               <li class="breadcrumb-item">Kubernetes</li>
               <li class="breadcrumb-item active">Deployments</li>
             </ol>

--- a/apps/templates/pages/k8s_dep_list.html
+++ b/apps/templates/pages/k8s_dep_list.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Kubernetes Deployments {% endblock %}
+{% block title %} Kubernetes Deployments {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}

--- a/apps/templates/pages/k8s_pod_list.html
+++ b/apps/templates/pages/k8s_pod_list.html
@@ -77,15 +77,15 @@
                 </thead>
                 <tbody>
                 {% for item in pods %}
-                <tr id="{{item['uid']}}">
+                <tr id="{{ item['uid'] }}">
                   <td>
                     <div class="icheck-primary">
-                      <input type="checkbox" value="" id="checkbox-{{item['uid']}}">
-                      <label for="checkbox-{{item['uid']}}"></label>
+                      <input type="checkbox" value="" id="checkbox-{{ item['uid'] }}">
+                      <label for="checkbox-{{ item['uid'] }}"></label>
                     </div>
                   </td>
                   <td>{{ item['name'] }}</td>
-                  <td>{{ item['containers_ready']}}/{{item['containers_total']}}</td>
+                  <td>{{ item['containers_ready'] }}/{{ item['containers_total'] }}</td>
                   <td>{{ item['phase'] }}</td>
                   <td>{{ item['age'] }}</td>
                   <td>{{ item['pod_ip'] }}</td>

--- a/apps/templates/pages/k8s_pod_list.html
+++ b/apps/templates/pages/k8s_pod_list.html
@@ -11,14 +11,14 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- DataTables -->
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 {% endblock stylesheets %}
 
 {% block content %}
@@ -200,16 +200,16 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- DataTables -->
-  <script src="/static/assets/plugins/datatables/jquery.dataTables.min.js"></script>
-  <script src="/static/assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/dataTables.responsive.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables/jquery.dataTables.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/dataTables.responsive.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
   <!-- Page Script -->
   <script>
     $(function () {
@@ -359,6 +359,6 @@
     })
   </script>
   <!-- AdminLTE for demo purposes -->
-  <script src="/static/assets/js/demo.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/demo.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/k8s_pod_list.html
+++ b/apps/templates/pages/k8s_pod_list.html
@@ -34,7 +34,7 @@
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="/index">Home</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
               <li class="breadcrumb-item">Kubernetes</li>
               <li class="breadcrumb-item active">Pods</li>
             </ol>

--- a/apps/templates/pages/k8s_pod_list.html
+++ b/apps/templates/pages/k8s_pod_list.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Kubernetes Pods {% endblock %}
+{% block title %} Kubernetes Pods {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}

--- a/apps/templates/pages/k8s_srv_list.html
+++ b/apps/templates/pages/k8s_srv_list.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Kubernetes Services {% endblock %}
+{% block title %} Kubernetes Services {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}

--- a/apps/templates/pages/k8s_srv_list.html
+++ b/apps/templates/pages/k8s_srv_list.html
@@ -11,14 +11,14 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- DataTables -->
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 {% endblock stylesheets %}
 
 {% block content %}
@@ -190,16 +190,16 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- DataTables -->
-  <script src="/static/assets/plugins/datatables/jquery.dataTables.min.js"></script>
-  <script src="/static/assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/dataTables.responsive.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables/jquery.dataTables.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/dataTables.responsive.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
   <!-- Page Script -->
   <script>
     $(function () {
@@ -347,6 +347,6 @@
     })
   </script>
   <!-- AdminLTE for demo purposes -->
-  <script src="/static/assets/js/demo.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/demo.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/k8s_srv_list.html
+++ b/apps/templates/pages/k8s_srv_list.html
@@ -72,11 +72,11 @@
                 </thead>
                 <tbody>
                 {% for item in services %}
-                <tr id="{{item['uid']}}">
+                <tr id="{{ item['uid'] }}">
                   <td>
                     <div class="icheck-primary">
-                      <input type="checkbox" value="" id="checkbox-{{item['uid']}}">
-                      <label for="checkbox-{{item['uid']}}"></label>
+                      <input type="checkbox" value="" id="checkbox-{{ item['uid'] }}">
+                      <label for="checkbox-{{ item['uid'] }}"></label>
                     </div>
                   </td>
                   <td>{{ item['name'] }}</td>

--- a/apps/templates/pages/k8s_srv_list.html
+++ b/apps/templates/pages/k8s_srv_list.html
@@ -34,7 +34,7 @@
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="/index">Home</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
               <li class="breadcrumb-item">Kubernetes</li>
               <li class="breadcrumb-item active">Services</li>
             </ol>

--- a/apps/templates/pages/lab_answers_list.html
+++ b/apps/templates/pages/lab_answers_list.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Lab Answers {% endblock %}
+{% block title %} Lab Answers {% endblock title %}
 
 {% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
 

--- a/apps/templates/pages/lab_answers_list.html
+++ b/apps/templates/pages/lab_answers_list.html
@@ -44,7 +44,7 @@
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="/index">Home</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
 	      <li class="breadcrumb-item"><a href="#">Labs</a></li>
               <li class="breadcrumb-item active">Lab Answers</li>
             </ol>

--- a/apps/templates/pages/lab_answers_list.html
+++ b/apps/templates/pages/lab_answers_list.html
@@ -69,7 +69,7 @@
                           <option value="">All Labs</option>
                           <option disabled>--</option>
 			{% for lab_id in labs %}
-			  <option value="{{lab_id}}" {{'selected' if lab_id == filter_lab else ''}}>{{labs[lab_id].title}}</option>
+			  <option value="{{ lab_id }}" {{ 'selected' if lab_id == filter_lab else '' }}>{{ labs[lab_id].title }}</option>
 			{% endfor %}
                       </select>
                     </div>
@@ -79,14 +79,14 @@
                           <option value="">All Groups</option>
                           <option disabled>--</option>
 			{% for group_id in groups %}
-			  <option value="{{group_id}}" {{'selected' if group_id == filter_group else ''}}>{{groups[group_id].groupname}}</option>
+			  <option value="{{ group_id }}" {{ 'selected' if group_id == filter_group else '' }}>{{ groups[group_id].groupname }}</option>
 			{% endfor %}
                       </select>
                     </div>
                     <div class="form-group row">
                       <div class="custom-control custom-switch">
                         <input type="checkbox" class="custom-control-input" id="customSwitch1" name="check_answer_sheet">
-			<label class="custom-control-label" for="customSwitch1">Check answers with Lab Answer Sheet</label> (see more information in <a href="{{url_for('home_blueprint.add_answer_sheet')}}">Lab Answer Sheet</a>)
+			<label class="custom-control-label" for="customSwitch1">Check answers with Lab Answer Sheet</label> (see more information in <a href="{{ url_for('home_blueprint.add_answer_sheet') }}">Lab Answer Sheet</a>)
                       </div>
                     </div>
                     <div class="form-group row">
@@ -117,13 +117,13 @@
                 </thead>
                 <tbody>
                 {% for lab_answer in lab_answers %}
-                <tr id="{{lab_answer['id']}}">
+                <tr id="{{ lab_answer['id'] }}">
                   <td>{{ lab_answer['lab_title'] }}</td>
                   <td>{{ lab_answer['user'] }}</td>
                   <td>{{ lab_answer['score'] }}</td>
                   <td>{{ lab_answer['answers_text'] }}</td>
                   <td class="text-right">
-		    <button type="button" title="Show answer" class="btn btn-outline-dark button-show-answer" data-toggle="modal" data-target="#modal-show-answer" data-answers="<p>Lab answers for user <b>{{ lab_answer['user'] }}</b></p>{{lab_answer['answers']}}" data-answerid="{{lab_answer['id']}}" data-labid="{{lab_answer['lab_id']}}">
+		    <button type="button" title="Show answer" class="btn btn-outline-dark button-show-answer" data-toggle="modal" data-target="#modal-show-answer" data-answers="<p>Lab answers for user <b>{{ lab_answer['user'] }}</b></p>{{ lab_answer['answers'] }}" data-answerid="{{ lab_answer['id'] }}" data-labid="{{ lab_answer['lab_id'] }}">
                       <i class="fas fa-eye"></i> View Answers
                     </button>
                   </td>

--- a/apps/templates/pages/lab_answers_list.html
+++ b/apps/templates/pages/lab_answers_list.html
@@ -8,14 +8,14 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- DataTables -->
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
-  <link rel="stylesheet" type="text/css" href="/static/assets/plugins/datatables/css/datatables.min.css"/>
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css') }}">
+  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='assets/plugins/datatables/css/datatables.min.css') }}"/>
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 {% endblock stylesheets %}
 
 {% block content %}
@@ -179,22 +179,22 @@
 {% block javascripts %}
   <!-- REQUIRED SCRIPTS -->
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
 
   <!-- Bootstrap -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 
   <!-- DataTables -->
-  <script src="/static/assets/plugins/datatables/jquery.dataTables.min.js"></script>
-  <script src="/static/assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
-  <script src="/static/assets/plugins/datatables/datatables.min.js"></script>
-  <script src="/static/assets/plugins/datatables/dataTables.buttons.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables/jquery.dataTables.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables/datatables.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables/dataTables.buttons.min.js') }}"></script>
 
   <!-- overlayScrollbars -->
-  <script src="/static/assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
 
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.js') }}"></script>
 
   <!-- Custom Script for Delete Functionality -->
   <script>

--- a/apps/templates/pages/lab_answers_sheet.html
+++ b/apps/templates/pages/lab_answers_sheet.html
@@ -8,14 +8,14 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- DataTables -->
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 {% endblock stylesheets %}
 
 {% block content %}
@@ -135,22 +135,22 @@
 {% block javascripts %}
   <!-- REQUIRED SCRIPTS -->
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
 
   <!-- Bootstrap -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 
   <!-- DataTables -->
-  <script src="/static/assets/plugins/datatables/jquery.dataTables.min.js"></script>
-  <script src="/static/assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/dataTables.responsive.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables/jquery.dataTables.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/dataTables.responsive.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js') }}"></script>
 
   <!-- overlayScrollbars -->
-  <script src="/static/assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
 
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.js') }}"></script>
 
   <!-- Custom Script for Delete Functionality -->
   <script>

--- a/apps/templates/pages/lab_answers_sheet.html
+++ b/apps/templates/pages/lab_answers_sheet.html
@@ -44,9 +44,9 @@
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="{{url_for('home_blueprint.index')}}">Home</a></li>
-	      <li class="breadcrumb-item"><a href="{{url_for('home_blueprint.view_labs')}}">Labs</a></li>
-	      <li class="breadcrumb-item"><a href="{{url_for('home_blueprint.list_lab_answers')}}">Labs Answers</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
+	      <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.view_labs') }}">Labs</a></li>
+	      <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.list_lab_answers') }}">Labs Answers</a></li>
               <li class="breadcrumb-item active">Lab Answers Sheet</li>
             </ol>
           </div>
@@ -72,7 +72,7 @@
                       <select name="lab_id" class="form-control" onchange="this.form.submit()">
                           <option value="">--</option>
 			{% for labid in labs %}
-			  <option value="{{labid}}" {{'selected' if labid == lab_id else ''}}>{{labs[labid].title}}</option>
+			  <option value="{{ labid }}" {{ 'selected' if labid == lab_id else '' }}>{{ labs[labid].title }}</option>
 			{% endfor %}
                       </select>
                     </div>
@@ -101,8 +101,8 @@
                   <tbody id="table-body-answers">
                   {% for question in answers %}
                   <tr>
-                    <td><input class="form-control" type="text" name="question" value="{{question}}"></td>
-                    <td><input class="form-control" type="text" name="answer" value="{{answers[question]}}"></td>
+                    <td><input class="form-control" type="text" name="question" value="{{ question }}"></td>
+                    <td><input class="form-control" type="text" name="answer" value="{{ answers[question] }}"></td>
                   </tr>
                   {% endfor %}
 	          <tr id="copy-answer-row">

--- a/apps/templates/pages/lab_answers_sheet.html
+++ b/apps/templates/pages/lab_answers_sheet.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Lab Answers Sheet {% endblock %}
+{% block title %} Lab Answers Sheet {% endblock title %}
 
 {% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
 

--- a/apps/templates/pages/lab_categories_edit.html
+++ b/apps/templates/pages/lab_categories_edit.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Edit Lab Category - {{ category.category }} {% endblock %}
+{% block title %} Edit Lab Category - {{ category.category }} {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} sidebar-mini {% endblock body_class %}

--- a/apps/templates/pages/lab_categories_edit.html
+++ b/apps/templates/pages/lab_categories_edit.html
@@ -62,7 +62,7 @@
           </div>
           <!-- /.card-header -->
           <div class="card-body">
-            <form method="POST" action="">
+            <form method="post" action="">
               <div class="row">
                 <div class="col-md-6">
                   <div class="form-group">

--- a/apps/templates/pages/lab_categories_edit.html
+++ b/apps/templates/pages/lab_categories_edit.html
@@ -11,9 +11,9 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -103,10 +103,10 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/lab_categories_list.html
+++ b/apps/templates/pages/lab_categories_list.html
@@ -44,7 +44,7 @@
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="/index">Home</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
               <li class="breadcrumb-item active">Lab Categories</li>
             </ol>
           </div>

--- a/apps/templates/pages/lab_categories_list.html
+++ b/apps/templates/pages/lab_categories_list.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Lab Categories {% endblock %}
+{% block title %} Lab Categories {% endblock title %}
 
 {% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
 

--- a/apps/templates/pages/lab_categories_list.html
+++ b/apps/templates/pages/lab_categories_list.html
@@ -8,14 +8,14 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- DataTables -->
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 {% endblock stylesheets %}
 
 {% block content %}
@@ -137,22 +137,22 @@
 {% block javascripts %}
   <!-- REQUIRED SCRIPTS -->
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
 
   <!-- Bootstrap -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 
   <!-- DataTables -->
-  <script src="/static/assets/plugins/datatables/jquery.dataTables.min.js"></script>
-  <script src="/static/assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/dataTables.responsive.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables/jquery.dataTables.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/dataTables.responsive.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js') }}"></script>
 
   <!-- overlayScrollbars -->
-  <script src="/static/assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
 
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.js') }}"></script>
 
   <!-- Custom Script for Delete Functionality -->
   <script>

--- a/apps/templates/pages/lab_instance_view.html
+++ b/apps/templates/pages/lab_instance_view.html
@@ -1,9 +1,9 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} View Lab Instance {% endblock %} 
+{% block title %} View Lab Instance {% endblock title %}
 
 <!-- Element injected in the BODY element -->
-{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %} 
+{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
 
 <!-- Specific Page CSS goes HERE  -->
 {% block stylesheets %}
@@ -72,7 +72,7 @@ word-break: break-all;
   </style>
 {% endblock stylesheets %}
 
-{% block content %}  
+{% block content %}
 
   <!-- Content Wrapper. Contains page content -->
   <div class="content-wrapper">

--- a/apps/templates/pages/lab_instance_view.html
+++ b/apps/templates/pages/lab_instance_view.html
@@ -85,7 +85,7 @@ word-break: break-all;
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="/index">Home</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
               <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.running_labs') }}">Running Labs</a></li>
               <li class="breadcrumb-item active">View Lab</li>
             </ol>

--- a/apps/templates/pages/lab_instance_view.html
+++ b/apps/templates/pages/lab_instance_view.html
@@ -11,15 +11,15 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- DataTables -->
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
-  <link rel="stylesheet" href="/static/assets/css/alert.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/alert.css') }}">
   <style type="text/css">
 pre { background-color: #ced4da; 
   position: relative;
@@ -259,17 +259,17 @@ word-break: break-all;
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- DataTables -->
-  <script src="/static/assets/plugins/datatables/jquery.dataTables.min.js"></script>
-  <script src="/static/assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/dataTables.responsive.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js"></script>
-  <script src="/static/assets/plugins/clipboard.js/clipboard.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables/jquery.dataTables.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/dataTables.responsive.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/clipboard.js/clipboard.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
   <!-- Page Script -->
   <script>
     $(function () {
@@ -494,6 +494,6 @@ word-break: break-all;
     }
   </script>
   <!-- AdminLTE for demo purposes -->
-  <script src="/static/assets/js/demo.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/demo.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/lab_instance_view.html
+++ b/apps/templates/pages/lab_instance_view.html
@@ -86,7 +86,7 @@ word-break: break-all;
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
               <li class="breadcrumb-item"><a href="/index">Home</a></li>
-              <li class="breadcrumb-item"><a href="{{url_for('home_blueprint.running_labs')}}">Running Labs</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.running_labs') }}">Running Labs</a></li>
               <li class="breadcrumb-item active">View Lab</li>
             </ol>
           </div>
@@ -100,9 +100,9 @@ word-break: break-all;
         <div class="col-md-12">
           <div class="card card-dark">
             <div class="card-header" id="lab-header">
-              <h3 class="card-title text single-line">Lab title: {{lab['title']}} / Lab owner: {{lab['user']}}</h3>
+              <h3 class="card-title text single-line">Lab title: {{ lab['title'] }} / Lab owner: {{ lab['user'] }}</h3>
 	      <div class="card-tools">
-                <span id="lab-expiration" class="pr-3" data-expires-at="{{lab['expires_at']|default('', true)}}">Expires at: {{lab['expires_at']|default('Never', true)}}</span>
+                <span id="lab-expiration" class="pr-3" data-expires-at="{{ lab['expires_at']|default('', true) }}">Expires at: {{ lab['expires_at']|default('Never', true) }}</span>
                   <button type="button" class="btn btn-tool" data-card-widget="collapse" title="Collapse">
                     <i class="fas fa-minus"></i>
                   </button>
@@ -132,35 +132,35 @@ word-break: break-all;
                   <tbody>
                   {% for resource in lab['resources'] %}
                   <tr>
-                    <td>{{resource['display_name']}}</td>
-                    <td>{{resource['ready']}}</td>
-                    <td>{{resource['node_name']}}</td>
-                    <td>{{resource['pod_ip']}}</td>
-                    <td>{{resource['age']}}</td>
+                    <td>{{ resource['display_name'] }}</td>
+                    <td>{{ resource['ready'] }}</td>
+                    <td>{{ resource['node_name'] }}</td>
+                    <td>{{ resource['pod_ip'] }}</td>
+                    <td>{{ resource['age'] }}</td>
                     <td>
                       <div class="d-flex flex-nowrap">
                         {% for link in resource['links'] %}
-                        {%   if resource['kind'] == 'service' %}
-                        {%     set link_icon = 'globe' %}
-                        {%     set link_name = link[0] %}
-                        {%     set link_href = link[1] %}
-                        {%   else %}
-                        {%     set link_icon = 'desktop' %}
-                        {%     set link_name = link %}
-                        {%     set link_href = url_for('home_blueprint.xterm', lab_id=lab['lab_instance_id'], kind=resource['kind'], pod=resource['name'], container=link)  %}
-                        {%   endif %}
-                        <a class="btn btn-outline-dark mr-1 btn-terminal" href="{{link_href}}" target="_blank" role="button"><i class="fas fa-{{link_icon}}"></i> {{link_name}}</a>
+                        {% if resource['kind'] == 'service' %}
+                        {% set link_icon = 'globe' %}
+                        {% set link_name = link[0] %}
+                        {% set link_href = link[1] %}
+                        {% else %}
+                        {% set link_icon = 'desktop' %}
+                        {% set link_name = link %}
+                        {% set link_href = url_for('home_blueprint.xterm', lab_id=lab['lab_instance_id'], kind=resource['kind'], pod=resource['name'], container=link) %}
+                        {% endif %}
+                        <a class="btn btn-outline-dark mr-1 btn-terminal" href="{{ link_href }}" target="_blank" role="button"><i class="fas fa-{{ link_icon }}"></i> {{ link_name }}</a>
                         {% endfor %}
                         {% if lab['is_clab'] and 'clabernetes/topologyNode' in resource['labels'] %}
-                        {%   set link_href = url_for('home_blueprint.xterm', lab_id=lab['lab_instance_id'], kind='clab', pod=resource['name'], container=resource['display_name'])  %}
-                        <a class="btn btn-outline-dark mr-1 btn-terminal" href="{{link_href}}" target="_blank" role="button"><i class="fas fa-server"></i> {{resource['display_name']}} (ssh)</a>
+                        {% set link_href = url_for('home_blueprint.xterm', lab_id=lab['lab_instance_id'], kind='clab', pod=resource['name'], container=resource['display_name']) %}
+                        <a class="btn btn-outline-dark mr-1 btn-terminal" href="{{ link_href }}" target="_blank" role="button"><i class="fas fa-server"></i> {{ resource['display_name'] }} (ssh)</a>
                         {% endif %}
                       </div>
                     </td>
                     <td>
                       <div class="d-flex flex-nowrap">
                         {% for service in resource['services'] %}
-                        <a class="btn btn-outline-dark mr-1 btn-service" href="{{service[1]}}" target="_blank" role="button"><i class="fas fa-globe"></i> {{service[0]}}</a>
+                        <a class="btn btn-outline-dark mr-1 btn-service" href="{{ service[1] }}" target="_blank" role="button"><i class="fas fa-globe"></i> {{ service[0] }}</a>
                         {% endfor %}
                       </div>
                     </td>
@@ -231,7 +231,7 @@ word-break: break-all;
             </div>
             <!-- /.card-header -->
             <div class="card-body" id="lab-guide">
-                {{lab_guide|safe}}
+                {{ lab_guide|safe }}
             </div>
             <!-- /.card-body -->
             <div class="card-footer">
@@ -358,17 +358,17 @@ word-break: break-all;
         $("#delete-lab").html('<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Finishing... ');
         $("#delete-lab").prop('disabled', true);
         var request = $.ajax({
-          url:  "/api/lab/{{lab['lab_instance_id']}}",
+          url:  "/api/lab/{{ lab['lab_instance_id'] }}",
           type: "DELETE",
           dataType: "json",
           contentType: "application/json",
         });
         request.done(function(data) {
-          location.href = "{{url_for('home_blueprint.view_finished_lab_infos', lab_id=lab['lab_id'])}}";
+          location.href = "{{ url_for('home_blueprint.view_finished_lab_infos', lab_id=lab['lab_id']) }}";
         });
         request.fail(function(xhr) {
           sessionStorage.setItem('msgFail', xhr.responseText);
-          location.href = "{{url_for('home_blueprint.running_labs')}}";
+          location.href = "{{ url_for('home_blueprint.running_labs') }}";
         });
       });
       function saveAnswers(showToast = true) {
@@ -388,7 +388,7 @@ word-break: break-all;
           return;
         }
         var request = $.ajax({
-          url:  "/api/lab_answers/{{lab['lab_instance_id']}}",
+          url:  "/api/lab_answers/{{ lab['lab_instance_id'] }}",
           type: "POST",
           data: JSON.stringify(answers),
           dataType: "json",
@@ -428,7 +428,7 @@ word-break: break-all;
       // load answers
       $(window).on("load", function () {
         var request = $.ajax({
-          url:  "/api/lab_answers/{{lab['lab_instance_id']}}",
+          url:  "/api/lab_answers/{{ lab['lab_instance_id'] }}",
           type: "GET",
         });
         request.done(function(data) {
@@ -467,7 +467,7 @@ word-break: break-all;
     // Extends lab expiration
     function extendLabExpiration(hours) {
       var request = $.ajax({
-        url:  "/api/lab/{{lab['lab_instance_id']}}/extend",
+        url:  "/api/lab/{{ lab['lab_instance_id'] }}/extend",
         type: "POST",
         dataType: "json",
         contentType: "application/json",

--- a/apps/templates/pages/labs_edit.html
+++ b/apps/templates/pages/labs_edit.html
@@ -11,19 +11,19 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
   <!-- summernote -->
-  <link rel="stylesheet" href="/static/assets/plugins/summernote/summernote-bs4.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/summernote/summernote-bs4.min.css') }}">
   <!-- Select2 -->
-  <link rel="stylesheet" href="/static/assets/plugins/select2/css/select2.min.css">
-  <link rel="stylesheet" href="/static/assets/plugins/select2-bootstrap4-theme/select2-bootstrap4.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/select2/css/select2.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/select2-bootstrap4-theme/select2-bootstrap4.min.css') }}">
   <!-- Bootstrap4 Duallistbox -->
-  <link rel="stylesheet" href="/static/assets/plugins/bootstrap4-duallistbox/bootstrap-duallistbox.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/bootstrap4-duallistbox/bootstrap-duallistbox.min.css') }}">
   <!-- CodeMirror -->
-  <link rel="stylesheet" href="/static/assets/plugins/codemirror/lib/codemirror.css">
-  <link rel="stylesheet" href="/static/assets/plugins/codemirror/theme/abcdef.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/codemirror/lib/codemirror.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/codemirror/theme/abcdef.css') }}">
   <style>
 .input-group > .select2-container--default {
     width: auto;
@@ -515,29 +515,29 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- bs-custom-file-input -->
-  <script src="/static/assets/plugins/bs-custom-file-input/bs-custom-file-input.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bs-custom-file-input/bs-custom-file-input.min.js') }}"></script>
   <!-- Bootstrap4 Duallistbox -->
-  <script src="/static/assets/plugins/bootstrap4-duallistbox/jquery.bootstrap-duallistbox.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap4-duallistbox/jquery.bootstrap-duallistbox.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
   <!-- Shared Labs delete/restore actions -->
-  <script src="/static/assets/js/pages/labs_actions.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/pages/labs_actions.js') }}"></script>
   <!-- AdminLTE for demo purposes -->
-  <script src="/static/assets/js/demo.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/demo.js') }}"></script>
   <!-- Summernote -->
-  <script src="/static/assets/plugins/summernote/summernote-bs4.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/summernote/summernote-bs4.min.js') }}"></script>
   <!-- CodeMirror -->
-  <script src="/static/assets/plugins/codemirror/lib/codemirror.js"></script>
-  <script src="/static/assets/plugins/codemirror/mode/yaml/yaml.js"></script>
-  <script src="/static/assets/plugins/codemirror/mode/markdown/markdown.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/codemirror/lib/codemirror.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/codemirror/mode/yaml/yaml.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/codemirror/mode/markdown/markdown.js') }}"></script>
   <!-- Marked -->
-  <script src="/static/assets/plugins/marked/marked.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/marked/marked.min.js') }}"></script>
   <!-- Select2 -->
-  <script src="/static/assets/plugins/select2/js/select2.full.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/select2/js/select2.full.min.js') }}"></script>
   <script>
     $(function () {
       $('#lab-editor').summernote({

--- a/apps/templates/pages/labs_edit.html
+++ b/apps/templates/pages/labs_edit.html
@@ -1,9 +1,9 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Create/Update Lab {% endblock %} 
+{% block title %} Create/Update Lab {% endblock title %}
 
 <!-- Element injected in the BODY element -->
-{% block body_class %} sidebar-mini {% endblock body_class %} 
+{% block body_class %} sidebar-mini {% endblock body_class %}
 
 <!-- Specific Page CSS goes HERE  -->
 {% block stylesheets %}
@@ -43,7 +43,7 @@
 
 {% endblock stylesheets %}
 
-{% block content %}    
+{% block content %}
 
   <div class="content-wrapper">
     <!-- Content Header (Page header) -->

--- a/apps/templates/pages/labs_edit.html
+++ b/apps/templates/pages/labs_edit.html
@@ -80,7 +80,7 @@
 
     <!-- Main content -->
     <section class="content">
-      <form method="POST" enctype="multipart/form-data" action="{{ url_for('home_blueprint.edit_lab', lab_id=lab.id|default('new', true)) }}">
+      <form method="post" enctype="multipart/form-data" action="{{ url_for('home_blueprint.edit_lab', lab_id=lab.id|default('new', true)) }}">
       <input type="hidden" name="pending_upload_filenames" id="pending-upload-filenames" value="[]">
       <input type="hidden" name="pending_upload_orignames" id="pending-upload-orignames" value="[]">
       <div class="container-fluid">

--- a/apps/templates/pages/labs_edit.html
+++ b/apps/templates/pages/labs_edit.html
@@ -56,21 +56,21 @@
             <div class="alert alert-success alert-dismissible">
               <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
               <h5><i class="icon fas fa-check"></i> Lab created/updated successfully!</h5>
-              {{msg_ok}}
+              {{ msg_ok }}
             </div>
             {% endif %}
             {% if msg_fail %}
             <div class="alert alert-danger alert-dismissible">
               <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
               <h5><i class="icon fas fa-ban"></i> Fail to create/update lab!</h5>
-              {{msg_fail}}
+              {{ msg_fail }}
             </div>
             {% endif %}
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="{{url_for('home_blueprint.index')}}">Home</a></li>
-              <li class="breadcrumb-item"><a href="{{url_for('home_blueprint.view_labs')}}">Labs</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.view_labs') }}">Labs</a></li>
               <li class="breadcrumb-item active">Create/Update Lab</li>
             </ol>
           </div>
@@ -80,7 +80,7 @@
 
     <!-- Main content -->
     <section class="content">
-      <form method="POST" enctype="multipart/form-data" action="{{url_for('home_blueprint.edit_lab', lab_id=lab.id|default('new', true))}}">
+      <form method="POST" enctype="multipart/form-data" action="{{ url_for('home_blueprint.edit_lab', lab_id=lab.id|default('new', true)) }}">
       <input type="hidden" name="pending_upload_filenames" id="pending-upload-filenames" value="[]">
       <input type="hidden" name="pending_upload_orignames" id="pending-upload-orignames" value="[]">
       <div class="container-fluid">
@@ -97,17 +97,17 @@
                 <div class="card-body">
                   <div class="form-group">
                     <label>Lab title</label>
-                    <input name="lab_title" type="text" class="form-control" placeholder="Enter lab title..." value="{{lab.title|default('', true)}}">
+                    <input name="lab_title" type="text" class="form-control" placeholder="Enter lab title..." value="{{ lab.title|default('', true) }}">
                   </div>
                   <div class="form-group">
                     <label>Short Description</label>
-                    <input name="lab_description" type="text" class="form-control" placeholder="Max 255 characters" value="{{lab.description|default('', true)}}">
+                    <input name="lab_description" type="text" class="form-control" placeholder="Max 255 characters" value="{{ lab.description|default('', true) }}">
                   </div>
                   <div class="form-group">
                     <label>Lab categories</label>
                     <select name="lab_categories" class="form-control select2" multiple="multiple" data-placeholder="Select one or more categories" style="width: 100%;">
                       {% for cat_id in lab_categories %}
-                      <option value="{{cat_id}}" data-color="{{lab_categories[cat_id].color_cls}}" {{'selected' if lab_categories[cat_id] in lab.categories else ""}}>{{lab_categories[cat_id].category}}</option>
+                      <option value="{{ cat_id }}" data-color="{{ lab_categories[cat_id].color_cls }}" {{ 'selected' if lab_categories[cat_id] in lab.categories else "" }}>{{ lab_categories[cat_id].category }}</option>
                       {% endfor %}
                     </select>
                     <small class="form-text text-muted">Select one or more categories</small>
@@ -134,9 +134,9 @@
                       <select name="lab_allowed_groups" class="duallistbox" multiple="multiple">
                         {% for group in groups %}
                           {% if group in allowed_groups %}
-                          <option value="{{group.id}}" selected>{{group.groupname}}</option>
+                          <option value="{{ group.id }}" selected>{{ group.groupname }}</option>
                           {% else %}
-                          <option value="{{group.id}}">{{group.groupname}}</option>
+                          <option value="{{ group.id }}">{{ group.groupname }}</option>
                           {% endif %}
                         {% endfor %}
                       </select>
@@ -145,7 +145,7 @@
                     <!--
                     <div class="form-group">
                       <label>Lab goals (one per line)</label>
-                      <textarea name="lab_goals" class="form-control" rows="5" placeholder="One goal per line" value="{{lab.goals|default('', true)}}"></textarea>
+                      <textarea name="lab_goals" class="form-control" rows="5" placeholder="One goal per line" value="{{ lab.goals|default('', true) }}"></textarea>
                     </div>
                     -->
                     <!-- /.form-group -->
@@ -181,7 +181,7 @@
               <div class="card-body pad">
                 <div class="mb-3">
                   <textarea name="lab_extended_desc" id="lab-editor" class="textarea" placeholder="Place some text here"
-                            style="width: 100%; height: 400px; font-size: 14px; line-height: 18px; border: 1px solid #dddddd; padding: 10px;">{{lab.extended_desc_str|default('', true)}}</textarea>
+                            style="width: 100%; height: 400px; font-size: 14px; line-height: 18px; border: 1px solid #dddddd; padding: 10px;">{{ lab.extended_desc_str|default('', true) }}</textarea>
                 </div>
                 <p class="text-sm mb-0">
                   Editor <a href="https://github.com/summernote/summernote">Documentation and license
@@ -221,7 +221,7 @@
 		              </div> <!-- end of col-md-6 -->
                 </div>
                 <div class="mb-3">
-                  <textarea name="lab_manifest" id="lab-edit-manifest" class="textarea" placeholder="Place some text here" rows="16">{{lab.manifest|default('', true)}}</textarea>
+                  <textarea name="lab_manifest" id="lab-edit-manifest" class="textarea" placeholder="Place some text here" rows="16">{{ lab.manifest|default('', true) }}</textarea>
                 </div>
                 <p class="text-sm mb-0">
                   Read <a href="#">more information</a> about the Kubernetes manifest.
@@ -264,7 +264,7 @@
                         <button class="btn btn-outline-secondary" type="button" id="upload-file-labguide-btn"><i class="fas fa-paperclip"></i> Paste, drop, or click to add files</button>
                         <input type="file" id="labguide-file-input" style="display: none;">
                         <div class="mb-3">
-                          <textarea name="lab_guide" id="lab-edit-guide" class="textarea" placeholder="Place some text here" rows="16">{{lab.lab_guide_md_str|default('', true)}}</textarea>
+                          <textarea name="lab_guide" id="lab-edit-guide" class="textarea" placeholder="Place some text here" rows="16">{{ lab.lab_guide_md_str|default('', true) }}</textarea>
                         </div>
                         <div id="lab-uploads-panel" class="mt-3">
                           <h6><i class="fas fa-paperclip"></i> Attached files</h6>

--- a/apps/templates/pages/labs_view.html
+++ b/apps/templates/pages/labs_view.html
@@ -1,9 +1,9 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} View Labs {% endblock %} 
+{% block title %} View Labs {% endblock title %}
 
 <!-- Element injected in the BODY element -->
-{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %} 
+{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
 
 <!-- Specific Page CSS goes HERE  -->
 {% block stylesheets %}
@@ -22,7 +22,7 @@
 
 {% endblock stylesheets %}
 
-{% block content %}  
+{% block content %}
 
   <div class="content-wrapper">
     <!-- Content Header (Page header) -->

--- a/apps/templates/pages/labs_view.html
+++ b/apps/templates/pages/labs_view.html
@@ -34,8 +34,8 @@
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="{{url_for('home_blueprint.index')}}">Home</a></li>
-              <li class="breadcrumb-item"><a href="{{url_for('home_blueprint.view_labs')}}">Labs</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.view_labs') }}">Labs</a></li>
               <li class="breadcrumb-item active">View Labs</li>
             </ol>
           </div>
@@ -70,8 +70,8 @@
             <div class="col-12">
               <h5><i class="fas fa-tags"></i> Filter by Category:</h5>
               {% for cat_id in lab_categories %}
-              <button class="btn btn-{{lab_categories[cat_id].color_cls}} mx-2 filter-button{% if loop.first %} active-underline{% endif %}" data-filter="category-{{cat_id}}">
-                {{lab_categories[cat_id].category}}
+              <button class="btn btn-{{ lab_categories[cat_id].color_cls }} mx-2 filter-button{% if loop.first %} active-underline{% endif %}" data-filter="category-{{ cat_id }}">
+                {{ lab_categories[cat_id].category }}
               </button>
               {% endfor %}
             </div>
@@ -109,11 +109,11 @@
           {% for cat in lab.categories %}
             {% set _ = category_classes.append("category-" ~ cat.id) %}
           {% endfor %}
-          <div class="{{card_size}}">
-            <div class="card {% if lab.is_deleted %}card-danger{% else %}card-dark{% endif %} filter {{category_classes|join(' ')}} {% if is_completed %}lab-completed{% else %}lab-not-completed{% endif %} mh-100">
+          <div class="{{ card_size }}">
+            <div class="card {% if lab.is_deleted %}card-danger{% else %}card-dark{% endif %} filter {{ category_classes|join(' ') }} {% if is_completed %}lab-completed{% else %}lab-not-completed{% endif %} mh-100">
               <div class="card-header">
                 <h2 class="card-title">
-                  {{lab.title}}
+                  {{ lab.title }}
                   {% if lab.is_deleted %}<span class="badge badge-light ml-2"><i class="fas fa-trash"></i> Deleted</span>{% endif %}
                 </h2>
                 <div class="card-tools">
@@ -125,11 +125,11 @@
                   </button>
                 </div>
               </div>
-              <div class="card-body {{card_body}}">
+              <div class="card-body {{ card_body }}">
                 {% if lab.categories|length > 0 %}
                 <div class="float-left w-100 pb-2">
                   {% for category in lab.categories %}
-                    <span class="badge badge-{{category.color_cls}} mr-1">{{category.category}}</span>
+                    <span class="badge badge-{{ category.color_cls }} mr-1">{{ category.category }}</span>
                   {% endfor %}
                   {% if is_completed %}
                     <span class="badge badge-success mr-1"><i class="fas fa-check"></i> Completed</span>
@@ -140,31 +140,31 @@
                   <span class="badge badge-success mr-1"><i class="fas fa-check"></i> Completed</span>
                 </div>
                 {% endif %}
-                {{lab.extended_desc_str|safe}}
+                {{ lab.extended_desc_str|safe }}
               </div>
               <!-- /.card-body -->
               <div class="card-footer mt-auto">
                 {% if is_running %}
-                {%   set route = 'home_blueprint.view_lab_instance' %}
-                {%   set lab_id = user_labs_status[lab.id]["running_id"] %}
-                {%   set link_text = 'Resume Lab' %}
+                {% set route = 'home_blueprint.view_lab_instance' %}
+                {% set lab_id = user_labs_status[lab.id]["running_id"] %}
+                {% set link_text = 'Resume Lab' %}
                 {% else %}
-                {%   set route = 'home_blueprint.run_lab' %}
-                {%   set lab_id = lab.id %}
-                {%   set link_text = 'Start Lab' %}
+                {% set route = 'home_blueprint.run_lab' %}
+                {% set lab_id = lab.id %}
+                {% set link_text = 'Start Lab' %}
                 {% endif %}
-                <a class="btn btn-outline-dark mx-2" href="{{url_for('home_blueprint.view_labs', lab_id=lab.id)}}" role="button"><i class="fas fa-eye"></i> View Lab</a>
+                <a class="btn btn-outline-dark mx-2" href="{{ url_for('home_blueprint.view_labs', lab_id=lab.id) }}" role="button"><i class="fas fa-eye"></i> View Lab</a>
                 {% if not lab.is_deleted %}
-                <a class="btn btn-outline-dark mx-2" href="{{url_for(route, lab_id=lab_id)}}" role="button"><i class="far fa-play-circle"></i> {{link_text}}</a>
+                <a class="btn btn-outline-dark mx-2" href="{{ url_for(route, lab_id=lab_id) }}" role="button"><i class="far fa-play-circle"></i> {{ link_text }}</a>
                 {% endif %}
-                {% if current_user.category == "admin" or current_user.category == "teacher" or (current_user.category == "labcreator" and lab.updated_by == current_user.id)%}
-		<a class="btn btn-outline-dark mx-2" href="{{url_for('home_blueprint.edit_lab', lab_id=lab.id) if not config.get("ENABLE_CLABS") or not lab.is_clab else url_for('clabs_blueprint.upsert', clab_id=lab.id)}}" role="button"><i class="fas fa-edit"></i> Update {{"Lab" if not config.get("ENABLE_CLABS") or not lab.is_clab else "ContainerLab"}}</a>
+                {% if current_user.category == "admin" or current_user.category == "teacher" or (current_user.category == "labcreator" and lab.updated_by == current_user.id) %}
+		<a class="btn btn-outline-dark mx-2" href="{{ url_for('home_blueprint.edit_lab', lab_id=lab.id) if not config.get("ENABLE_CLABS") or not lab.is_clab else url_for('clabs_blueprint.upsert', clab_id=lab.id) }}" role="button"><i class="fas fa-edit"></i> Update {{ "Lab" if not config.get("ENABLE_CLABS") or not lab.is_clab else "ContainerLab" }}</a>
                 {% if lab.is_deleted %}
                 {% if current_user.category == "admin" %}
-                <button type="button" class="btn btn-outline-success mx-2 button-restore-lab" data-toggle="modal" data-target="#modal-restore-lab" data-id="{{lab.id}}"><i class="fas fa-trash-restore"></i> Restore Lab</button>
+                <button type="button" class="btn btn-outline-success mx-2 button-restore-lab" data-toggle="modal" data-target="#modal-restore-lab" data-id="{{ lab.id }}"><i class="fas fa-trash-restore"></i> Restore Lab</button>
                 {% endif %}
                 {% elif current_user.category == "admin" or lab.updated_by == current_user.id %}
-                <button type="button" class="btn btn-outline-danger mx-2 button-delete-lab" data-toggle="modal" data-target="#modal-delete-lab" data-id="{{lab.id}}" data-name="{{lab.title}}"><i class="fas fa-trash"></i> Delete Lab</button>
+                <button type="button" class="btn btn-outline-danger mx-2 button-delete-lab" data-toggle="modal" data-target="#modal-delete-lab" data-id="{{ lab.id }}" data-name="{{ lab.title }}"><i class="fas fa-trash"></i> Delete Lab</button>
                 {% endif %}
                 {% endif %}
               </div>

--- a/apps/templates/pages/labs_view.html
+++ b/apps/templates/pages/labs_view.html
@@ -11,11 +11,11 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome Icons -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- overlayScrollbars -->
-  <link rel="stylesheet" href="/static/assets/plugins/overlayScrollbars/css/OverlayScrollbars.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
   <style type="text/css">
   .card-h-250 {max-height: 250px;}
   </style>
@@ -232,15 +232,15 @@
 
   <!-- REQUIRED SCRIPTS -->
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- overlayScrollbars -->
-  <script src="/static/assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.js') }}"></script>
   <!-- Shared Labs delete/restore actions -->
-  <script src="/static/assets/js/pages/labs_actions.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/pages/labs_actions.js') }}"></script>
   <script>
     $(function () {
       $(".filter-button").click(function(){

--- a/apps/templates/pages/labs_view.html
+++ b/apps/templates/pages/labs_view.html
@@ -43,7 +43,7 @@
         <div class="filter-section">
           <div class="row mb-3">
             <div class="col-12">
-              <form method="GET" action="{{ url_for('home_blueprint.view_labs') }}" class="form-inline">
+              <form method="get" action="{{ url_for('home_blueprint.view_labs') }}" class="form-inline">
                 <label class="mr-2"><i class="fas fa-users"></i> Filter by Group:</label>
                 <select name="filter_group" class="form-control mr-2">
                   <option value="">All Groups</option>

--- a/apps/templates/pages/login.html
+++ b/apps/templates/pages/login.html
@@ -83,10 +83,6 @@
              </div>
           </div>
         </form>
-
-        <br />
-
-
       </div>
       <!-- /.login-card-body -->
     </div>

--- a/apps/templates/pages/login.html
+++ b/apps/templates/pages/login.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base-fullscreen.html" %}
 
-{% block title %} Login {% endblock %}
+{% block title %} Login {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} login-page {% endblock body_class %}

--- a/apps/templates/pages/login.html
+++ b/apps/templates/pages/login.html
@@ -11,11 +11,11 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -95,8 +95,8 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/my_support_thread_view.html
+++ b/apps/templates/pages/my_support_thread_view.html
@@ -6,8 +6,8 @@
 
 {% block stylesheets %}
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
   <style>
     .direct-chat-text { white-space: pre-wrap; word-wrap: break-word; }
     .support-system-msg { text-align: center; color: #8a939b; font-size: .8rem; margin: 10px 0; }
@@ -89,9 +89,9 @@
 {% endblock content %}
 
 {% block javascripts %}
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
-  <script src="/static/assets/js/adminlte.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.js') }}"></script>
   <script>
     (function () {
       var THREAD_ID = {{ thread.id }};

--- a/apps/templates/pages/my_support_thread_view.html
+++ b/apps/templates/pages/my_support_thread_view.html
@@ -24,7 +24,7 @@
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="/index">Home</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
               <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.list_my_support_threads') }}">My Support</a></li>
               <li class="breadcrumb-item active">Case #{{ thread.id }}</li>
             </ol>

--- a/apps/templates/pages/my_support_thread_view.html
+++ b/apps/templates/pages/my_support_thread_view.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} My Support Case {% endblock %}
+{% block title %} My Support Case {% endblock title %}
 
 {% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
 

--- a/apps/templates/pages/my_support_threads.html
+++ b/apps/templates/pages/my_support_threads.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} My Support {% endblock %}
+{% block title %} My Support {% endblock title %}
 
 {% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
 

--- a/apps/templates/pages/my_support_threads.html
+++ b/apps/templates/pages/my_support_threads.html
@@ -22,7 +22,7 @@
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="/index">Home</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
               <li class="breadcrumb-item active">My Support</li>
             </ol>
           </div>

--- a/apps/templates/pages/my_support_threads.html
+++ b/apps/templates/pages/my_support_threads.html
@@ -6,10 +6,10 @@
 
 {% block stylesheets %}
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css">
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 {% endblock stylesheets %}
 
 {% block content %}
@@ -82,14 +82,14 @@
 {% endblock content %}
 
 {% block javascripts %}
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
-  <script src="/static/assets/plugins/datatables/jquery.dataTables.min.js"></script>
-  <script src="/static/assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/dataTables.responsive.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js"></script>
-  <script src="/static/assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js"></script>
-  <script src="/static/assets/js/adminlte.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables/jquery.dataTables.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/dataTables.responsive.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.js') }}"></script>
   <script>
     $(function () {
       $("#tableMyThreads").DataTable({

--- a/apps/templates/pages/page-403.html
+++ b/apps/templates/pages/page-403.html
@@ -11,11 +11,11 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -138,8 +138,8 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/page-403.html
+++ b/apps/templates/pages/page-403.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base-fullscreen.html" %}
 
-{% block title %} Error 403 {% endblock %} 
+{% block title %} Error 403 {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} login-page {% endblock body_class %}

--- a/apps/templates/pages/page-403.html
+++ b/apps/templates/pages/page-403.html
@@ -126,7 +126,7 @@
       insufficient privileges or security restrictions on this server.
     </p>
     <div class="d-flex justify-content-center gap-3 flex-wrap mt-3">
-      <a href="javascript:history.back()" class="btn btn-secondary">Go Back</a>
+      <a href="{{ url_for('home_blueprint.index') }}" class="btn btn-secondary" onclick="history.back(); return false;">Go Back</a>
     </div>
   </div>
 

--- a/apps/templates/pages/page-404.html
+++ b/apps/templates/pages/page-404.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base-fullscreen.html" %}
 
-{% block title %} Error 404 {% endblock %} 
+{% block title %} Error 404 {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} login-page {% endblock body_class %}

--- a/apps/templates/pages/page-404.html
+++ b/apps/templates/pages/page-404.html
@@ -78,7 +78,7 @@
         </p>
         <div class="d-flex justify-content-center flex-wrap mt-3">
             <a href="{{ url_for('authentication_blueprint.login') }}" class="btn btn-primary m-2">Return to Home</a>
-            <a href="javascript:history.back()" class="btn btn-secondary m-2">Go Back</a>
+            <a href="{{ url_for('home_blueprint.index') }}" class="btn btn-secondary m-2" onclick="history.back(); return false;">Go Back</a>
         </div>
     </div>
 

--- a/apps/templates/pages/page-404.html
+++ b/apps/templates/pages/page-404.html
@@ -11,11 +11,11 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -90,8 +90,8 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/page-404.html
+++ b/apps/templates/pages/page-404.html
@@ -77,7 +77,7 @@
             or is temporarily unavailable. Please check the URL for any mistakes.
         </p>
         <div class="d-flex justify-content-center flex-wrap mt-3">
-            <a href="{{ url_for('authentication_blueprint.login')}}" class="btn btn-primary m-2">Return to Home</a>
+            <a href="{{ url_for('authentication_blueprint.login') }}" class="btn btn-primary m-2">Return to Home</a>
             <a href="javascript:history.back()" class="btn btn-secondary m-2">Go Back</a>
         </div>
     </div>

--- a/apps/templates/pages/page-500.html
+++ b/apps/templates/pages/page-500.html
@@ -125,7 +125,7 @@
             Our team has been notified and is working to resolve the issue as quickly as possible.
         </p>
         <div class="d-flex justify-content-center gap-3 flex-wrap mt-3">
-            <a href="{{ url_for('authentication_blueprint.login')}}" class="btn btn-primary m-2">Return to Home</a>
+            <a href="{{ url_for('authentication_blueprint.login') }}" class="btn btn-primary m-2">Return to Home</a>
             <a href="mailto:support@hackinsdn.com" class="btn btn-secondary m-2">Contact Support</a>
         </div>
     </div>

--- a/apps/templates/pages/page-500.html
+++ b/apps/templates/pages/page-500.html
@@ -11,11 +11,11 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -138,8 +138,8 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/page-500.html
+++ b/apps/templates/pages/page-500.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base-fullscreen.html" %}
 
-{% block title %} Error 500 {% endblock %} 
+{% block title %} Error 500 {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} login-page {% endblock body_class %}

--- a/apps/templates/pages/register.html
+++ b/apps/templates/pages/register.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base-fullscreen.html" %}
 
-{% block title %} Register {% endblock %}
+{% block title %} Register {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} register-page {% endblock body_class %}

--- a/apps/templates/pages/register.html
+++ b/apps/templates/pages/register.html
@@ -11,11 +11,11 @@
 <!-- Google Font: Source Sans Pro -->
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
 <!-- Font Awesome -->
-<link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
 <!-- icheck bootstrap -->
-<link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
 <!-- Theme style -->
-<link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -106,12 +106,12 @@
 {% block javascripts %}
 
 <!-- jQuery -->
-<script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
 <!-- jquery-validation -->
-<script src="/static/assets/plugins/jquery-validation/jquery.validate.min.js"></script>
-<script src="/static/assets/plugins/jquery-validation/additional-methods.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/jquery-validation/jquery.validate.min.js') }}"></script>
+<script src="{{ url_for('static', filename='assets/plugins/jquery-validation/additional-methods.min.js') }}"></script>
 <!-- Bootstrap 4 -->
-<script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+<script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 <!-- Page script -->
 <script>
   $(function () {

--- a/apps/templates/pages/reset_password.html
+++ b/apps/templates/pages/reset_password.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base-fullscreen.html" %}
 
-{% block title %} Login {% endblock %}
+{% block title %} Login {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} login-page {% endblock body_class %}

--- a/apps/templates/pages/reset_password.html
+++ b/apps/templates/pages/reset_password.html
@@ -11,11 +11,11 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -80,8 +80,8 @@
   </script>
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/run_lab.html
+++ b/apps/templates/pages/run_lab.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Forms Advanced {% endblock %} 
+{% block title %} Forms Advanced {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} sidebar-mini {% endblock body_class %}
@@ -20,7 +20,7 @@
 
 {% endblock stylesheets %}
 
-{% block content %}    
+{% block content %}
 
   <!-- Content Wrapper. Contains page content -->
   <div class="content-wrapper">

--- a/apps/templates/pages/run_lab.html
+++ b/apps/templates/pages/run_lab.html
@@ -11,12 +11,12 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- Select2 -->
-  <link rel="stylesheet" href="/static/assets/plugins/select2/css/select2.min.css">
-  <link rel="stylesheet" href="/static/assets/plugins/select2-bootstrap4-theme/select2-bootstrap4.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/select2/css/select2.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/select2-bootstrap4-theme/select2-bootstrap4.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -152,18 +152,18 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- Select2 -->
-  <script src="/static/assets/plugins/select2/js/select2.full.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/select2/js/select2.full.min.js') }}"></script>
   <!-- InputMask -->
-  <script src="/static/assets/plugins/moment/moment.min.js"></script>
-  <script src="/static/assets/plugins/inputmask/jquery.inputmask.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/moment/moment.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/inputmask/jquery.inputmask.min.js') }}"></script>
   <!-- Tempusdominus Bootstrap 4 -->
-  <script src="/static/assets/plugins/tempusdominus-bootstrap-4/js/tempusdominus-bootstrap-4.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/tempusdominus-bootstrap-4/js/tempusdominus-bootstrap-4.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
   <!-- Page script -->
   <script>
     $(function () {

--- a/apps/templates/pages/run_lab.html
+++ b/apps/templates/pages/run_lab.html
@@ -59,7 +59,7 @@
           </div>
           <!-- /.card-header -->
           <div class="card-body">
-          <form method="POST">
+          <form method="post">
             <h5>Overall information</h5>
             <div class="row">
               <div class="col-md-6">

--- a/apps/templates/pages/run_lab.html
+++ b/apps/templates/pages/run_lab.html
@@ -34,7 +34,7 @@
             <div class="alert alert-danger alert-dismissible">
               <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
               <h5><i class="icon fas fa-ban"></i> Fail to execute the lab!</h5>
-              {{msg_fail}}
+              {{ msg_fail }}
             </div>
             {% endif %}
           </div>
@@ -55,7 +55,7 @@
         <!-- SELECT2 EXAMPLE -->
         <div class="card card-default">
           <div class="card-header">
-            <h3 class="card-title">Lab -- {{lab.title}}</h3>
+            <h3 class="card-title">Lab -- {{ lab.title }}</h3>
           </div>
           <!-- /.card-header -->
           <div class="card-body">
@@ -65,12 +65,12 @@
               <div class="col-md-6">
                 <div class="form-group">
                   <label>Lab title</label>
-                  <input type="text" class="form-control" disabled="disabled" value="{{lab.title}}"/>
+                  <input type="text" class="form-control" disabled="disabled" value="{{ lab.title }}"/>
                 </div>
                 <!-- /.form-group -->
                 <div class="form-group">
                   <label>User label</label>
-                  <input type="text" class="form-control" disabled="disabled" value="{{current_user.email}}"/>
+                  <input type="text" class="form-control" disabled="disabled" value="{{ current_user.email }}"/>
                 </div>
                 <!-- /.form-group -->
               </div>
@@ -78,7 +78,7 @@
               <div class="col-md-6">
                 <div class="form-group">
                   <label>Lab category</label>
-                  <input type="text" class="form-control" disabled="disabled" value="{{lab.category}}"/>
+                  <input type="text" class="form-control" disabled="disabled" value="{{ lab.category }}"/>
                 </div>
                 <!-- /.form-group -->
                 <!--
@@ -110,7 +110,7 @@
                   <label>Lab Duration/Expiration</label>
                   <select name="lab_expiration" class="form-control" required>
                     {% for exp_sec in lab_expirations %}
-                    <option value="{{exp_sec}}">{{lab_expirations[exp_sec]}}</option>
+                    <option value="{{ exp_sec }}">{{ lab_expirations[exp_sec] }}</option>
                     {% endfor %}
                   </select>
 	          <!--

--- a/apps/templates/pages/run_lab_status.html
+++ b/apps/templates/pages/run_lab_status.html
@@ -11,11 +11,11 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- pace-progress -->
-  <link rel="stylesheet" href="/static/assets/plugins/pace-progress/themes/black/pace-theme-flat-top.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/pace-progress/themes/black/pace-theme-flat-top.css') }}">
   <!-- adminlte-->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -92,15 +92,15 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
     <!-- pace-progress -->
-  <script src="/static/assets/plugins/pace-progress/pace.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/pace-progress/pace.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
   <!-- AdminLTE for demo purposes -->
-  <script src="/static/assets/js/demo.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/demo.js') }}"></script>
   <!-- Page script -->
   <script>
     $(function () {

--- a/apps/templates/pages/run_lab_status.html
+++ b/apps/templates/pages/run_lab_status.html
@@ -65,11 +65,11 @@
                       <div id="loading" class="overlay"><i class="fas fa-3x fa-sync-alt fa-spin"></i><div class="text-bold pt-2">Loading...</div></div>
                       <ul>
                         {% for resource in resources %}
-                        <li><span id="{{resource['kind'] + '__' + resource['name']}}" class="badge badge-secondary status-badge">Unknown</span> {{resource['kind']}}/{{resource['name']}}</li>
+                        <li><span id="{{ resource['kind'] + '__' + resource['name'] }}" class="badge badge-secondary status-badge">Unknown</span> {{ resource['kind'] }}/{{ resource['name'] }}</li>
                         {% endfor %}
                       </ul>
                       <p id="statusText"></p>
-                      <a style="display: none;" id="labLink" class="btn btn-outline-success" href="{{url_for('home_blueprint.view_lab_instance', lab_id=lab_instance_id)}}">Start using the Lab resources and Lab guide!</a>
+                      <a style="display: none;" id="labLink" class="btn btn-outline-success" href="{{ url_for('home_blueprint.view_lab_instance', lab_id=lab_instance_id) }}">Start using the Lab resources and Lab guide!</a>
                     </div>
                   </div>
                 </div>
@@ -106,7 +106,7 @@
     $(function () {
       var checkStatus = function() {
         var request = $.ajax({
-          url: "/api/lab/status/{{lab_instance_id}}",
+          url: "/api/lab/status/{{ lab_instance_id }}",
           type: "GET",
           dataType: "json",
           contentType: "application/json",

--- a/apps/templates/pages/run_lab_status.html
+++ b/apps/templates/pages/run_lab_status.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Run Lab - Status {% endblock %} 
+{% block title %} Run Lab - Status {% endblock title %}
 
 <!-- Element injected in the BODY element -->
 {% block body_class %} sidebar-mini pace-primary {% endblock body_class %}
@@ -19,7 +19,7 @@
 
 {% endblock stylesheets %}
 
-{% block content %}  
+{% block content %}
 
   <div class="content-wrapper">
     <!-- Content Header (Page header) -->

--- a/apps/templates/pages/running.html
+++ b/apps/templates/pages/running.html
@@ -1,9 +1,9 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Running Labs {% endblock %} 
+{% block title %} Running Labs {% endblock title %}
 
 <!-- Element injected in the BODY element -->
-{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %} 
+{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
 
 <!-- Specific Page CSS goes HERE  -->
 {% block stylesheets %}
@@ -23,7 +23,7 @@
   </style>
 {% endblock stylesheets %}
 
-{% block content %}  
+{% block content %}
 
   <!-- Content Wrapper. Contains page content -->
   <div class="content-wrapper">

--- a/apps/templates/pages/running.html
+++ b/apps/templates/pages/running.html
@@ -11,14 +11,14 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- DataTables -->
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
   <style type="text/css">
   </style>
 {% endblock stylesheets %}
@@ -175,16 +175,16 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- DataTables -->
-  <script src="/static/assets/plugins/datatables/jquery.dataTables.min.js"></script>
-  <script src="/static/assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/dataTables.responsive.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables/jquery.dataTables.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/dataTables.responsive.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
   <!-- Page Script -->
   <script>
     $(function () {
@@ -315,6 +315,6 @@
     })
   </script>
   <!-- AdminLTE for demo purposes -->
-  <script src="/static/assets/js/demo.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/demo.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/running.html
+++ b/apps/templates/pages/running.html
@@ -69,9 +69,9 @@
                       <div class="col-md-8">
                         <select name="filter_group" class="form-control" onchange="this.form.submit()">
                           <option value="">My own labs</option>
-                          <option value="all" {{'selected' if filter_group == 'all' else ''}}>All labs</option>
+                          <option value="all" {{ 'selected' if filter_group == 'all' else '' }}>All labs</option>
                           {% for group_id in groups %}
-                          <option value="{{group_id}}" {{'selected' if filter_group == group_id else ''}}>{{groups[group_id].groupname}}</option>
+                          <option value="{{ group_id }}" {{ 'selected' if filter_group == group_id else '' }}>{{ groups[group_id].groupname }}</option>
                           {% endfor %}
                         </select>
 	              </div>
@@ -101,18 +101,18 @@
                 </thead>
                 <tbody>
             	{% for lab in labs %}
-                <tr id="{{lab['lab_instance_id']}}">
+                <tr id="{{ lab['lab_instance_id'] }}">
                   <td>
                     <div class="icheck-primary">
-                      <input type="checkbox" value="" id="checkbox-{{lab['lab_instance_id']}}" class="checkbox-labs">
-                      <label for="checkbox-{{lab['lab_instance_id']}}"></label>
+                      <input type="checkbox" value="" id="checkbox-{{ lab['lab_instance_id'] }}" class="checkbox-labs">
+                      <label for="checkbox-{{ lab['lab_instance_id'] }}"></label>
                     </div>
                   </td>
             	  <td>{{ lab['user'] }}</td>
-                  <td>{{lab['title']}}</td>
-                  <td>{{lab['created']}}</td>
+                  <td>{{ lab['title'] }}</td>
+                  <td>{{ lab['created'] }}</td>
                   <td>
-                    <a class="btn btn-default" href="{{url_for('home_blueprint.view_lab_instance', lab_id=lab['lab_instance_id'])}}"><i class="fas fa-eye"></i> View</a>
+                    <a class="btn btn-default" href="{{ url_for('home_blueprint.view_lab_instance', lab_id=lab['lab_instance_id']) }}"><i class="fas fa-eye"></i> View</a>
                   </td>
                 </tr>
                 {% endfor %}

--- a/apps/templates/pages/running.html
+++ b/apps/templates/pages/running.html
@@ -36,7 +36,7 @@
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="/index">Home</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
               <li class="breadcrumb-item active">Running Labs</li>
             </ol>
           </div>

--- a/apps/templates/pages/support_thread_view.html
+++ b/apps/templates/pages/support_thread_view.html
@@ -26,7 +26,7 @@
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="/index">Home</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
               <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.list_support_threads') }}">Support</a></li>
               <li class="breadcrumb-item active">Thread #{{ thread.id }}</li>
             </ol>

--- a/apps/templates/pages/support_thread_view.html
+++ b/apps/templates/pages/support_thread_view.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Support Chat {% endblock %}
+{% block title %} Support Chat {% endblock title %}
 
 {% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
 

--- a/apps/templates/pages/support_thread_view.html
+++ b/apps/templates/pages/support_thread_view.html
@@ -6,8 +6,8 @@
 
 {% block stylesheets %}
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
   <style>
     /* Preserve line breaks in multi-line messages */
     .direct-chat-text { white-space: pre-wrap; word-wrap: break-word; }
@@ -111,9 +111,9 @@
 {% endblock content %}
 
 {% block javascripts %}
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
-  <script src="/static/assets/js/adminlte.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.js') }}"></script>
   <script>
     (function () {
       var THREAD_ID = {{ thread.id }};

--- a/apps/templates/pages/support_threads.html
+++ b/apps/templates/pages/support_threads.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Support {% endblock %}
+{% block title %} Support {% endblock title %}
 
 {% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
 

--- a/apps/templates/pages/support_threads.html
+++ b/apps/templates/pages/support_threads.html
@@ -26,7 +26,7 @@
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="/index">Home</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
               <li class="breadcrumb-item active">Support</li>
             </ol>
           </div>

--- a/apps/templates/pages/support_threads.html
+++ b/apps/templates/pages/support_threads.html
@@ -8,12 +8,12 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- DataTables -->
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 {% endblock stylesheets %}
 
 {% block content %}
@@ -100,14 +100,14 @@
 {% endblock content %}
 
 {% block javascripts %}
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
-  <script src="/static/assets/plugins/datatables/jquery.dataTables.min.js"></script>
-  <script src="/static/assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/dataTables.responsive.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js"></script>
-  <script src="/static/assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js"></script>
-  <script src="/static/assets/js/adminlte.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables/jquery.dataTables.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/dataTables.responsive.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.js') }}"></script>
   <script>
     $(function () {
       $("#tableSupportThreads").DataTable({

--- a/apps/templates/pages/users.html
+++ b/apps/templates/pages/users.html
@@ -1,9 +1,9 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Users {% endblock %} 
+{% block title %} Users {% endblock title %}
 
 <!-- Element injected in the BODY element -->
-{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %} 
+{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
 
 <!-- Specific Page CSS goes HERE  -->
 {% block stylesheets %}
@@ -21,7 +21,7 @@
   <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
 {% endblock stylesheets %}
 
-{% block content %}  
+{% block content %}
 
   <!-- Content Wrapper. Contains page content -->
   <div class="content-wrapper">

--- a/apps/templates/pages/users.html
+++ b/apps/templates/pages/users.html
@@ -48,7 +48,7 @@
         <div class="col-md-12">
           <div class="card">
             <div class="card-header">
-              <h3 class="card-title">Current users ({{'All' if current_user.category == "admin" else 'Unauthorized'}} users)</h3>
+              <h3 class="card-title">Current users ({{ 'All' if current_user.category == "admin" else 'Unauthorized' }} users)</h3>
               <div class="float-right">
                 <button type="button" title="Select all users" class="btn btn-default btn-sm checkbox-toggle"><i class="far fa-square"></i></button>
                 <button type="button" title="Delete selected users" class="btn btn-default btn-sm" data-toggle="modal" data-target="#modal-default">
@@ -78,11 +78,11 @@
                 </thead>
                 <tbody>
             	{% for user in users %}
-                <tr id="{{user.id}}">
+                <tr id="{{ user.id }}">
                   <td>
                     <div class="icheck-primary">
-                      <input type="checkbox" value="" id="checkbox-{{user.id}}" class="checkbox-user">
-                      <label for="checkbox-{{user.id}}"></label>
+                      <input type="checkbox" value="" id="checkbox-{{ user.id }}" class="checkbox-user">
+                      <label for="checkbox-{{ user.id }}"></label>
                     </div>
                   </td>
             	  <td>{{ user.username }}</td>
@@ -92,7 +92,7 @@
                   <td>{{ user.issuer|default('LOCAL', true) }}</td>
                   <td>{{ user.last_login.strftime('%Y-%m-%d %H:%M') if user.last_login else '--' }}</td>
                   <td>{{ user.created_at.strftime('%Y-%m-%d %H:%M') if user.created_at else '--' }}</td>
-                  <td><a href="{{url_for('home_blueprint.edit_user', user_id=user.id)}}" class="btn btn-outline-dark" role="button" aria-pressed="true"><i class="fa fa-pen"></i> Edit</a></td>
+                  <td><a href="{{ url_for('home_blueprint.edit_user', user_id=user.id) }}" class="btn btn-outline-dark" role="button" aria-pressed="true"><i class="fa fa-pen"></i> Edit</a></td>
                 </tr>
                 {% endfor %}
                 </tbody>

--- a/apps/templates/pages/users.html
+++ b/apps/templates/pages/users.html
@@ -34,7 +34,7 @@
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">
-              <li class="breadcrumb-item"><a href="/index">Home</a></li>
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
               <li class="breadcrumb-item active">Users</li>
             </ol>
           </div>

--- a/apps/templates/pages/users.html
+++ b/apps/templates/pages/users.html
@@ -11,14 +11,14 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- DataTables -->
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
-  <link rel="stylesheet" href="/static/assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css') }}">
   <!-- icheck bootstrap -->
-  <link rel="stylesheet" href="/static/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 {% endblock stylesheets %}
 
 {% block content %}
@@ -178,16 +178,16 @@
 {% block javascripts %}
 
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap 4 -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- DataTables -->
-  <script src="/static/assets/plugins/datatables/jquery.dataTables.min.js"></script>
-  <script src="/static/assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/dataTables.responsive.min.js"></script>
-  <script src="/static/assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables/jquery.dataTables.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/dataTables.responsive.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
   <!-- Page Script -->
   <script>
     $(function () {
@@ -366,6 +366,6 @@
     })
   </script>
   <!-- AdminLTE for demo purposes -->
-  <script src="/static/assets/js/demo.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/demo.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/waiting_approval.html
+++ b/apps/templates/pages/waiting_approval.html
@@ -1,9 +1,9 @@
 {% extends "layouts/base.html" %}
 
-{% block title %} Home {% endblock %} 
+{% block title %} Home {% endblock title %}
 
 <!-- Element injected in the BODY element -->
-{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %} 
+{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
 
 <!-- Specific Page CSS goes HERE  -->
 {% block stylesheets %}
@@ -21,7 +21,7 @@
 
 {% endblock stylesheets %}
 
-{% block content %}  
+{% block content %}
 
   <div class="content-wrapper">
     <!-- Content Header (Page header) -->

--- a/apps/templates/pages/waiting_approval.html
+++ b/apps/templates/pages/waiting_approval.html
@@ -11,13 +11,13 @@
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
   <!-- Font Awesome Icons -->
-  <link rel="stylesheet" href="/static/assets/plugins/fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
   <!-- overlayScrollbars -->
-  <link rel="stylesheet" href="/static/assets/plugins/overlayScrollbars/css/OverlayScrollbars.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
   <!-- Leaflet -->
-  <link rel="stylesheet" href="/static/assets/plugins/leaflet/leaflet.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/leaflet/leaflet.css') }}">
   <!-- Theme style -->
-  <link rel="stylesheet" href="/static/assets/css/adminlte.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
 
 {% endblock stylesheets %}
 
@@ -83,12 +83,12 @@
 
   <!-- REQUIRED SCRIPTS -->
   <!-- jQuery -->
-  <script src="/static/assets/plugins/jquery/jquery.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
   <!-- Bootstrap -->
-  <script src="/static/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
   <!-- overlayScrollbars -->
-  <script src="/static/assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
   <!-- AdminLTE App -->
-  <script src="/static/assets/js/adminlte.js"></script>
+  <script src="{{ url_for('static', filename='assets/js/adminlte.js') }}"></script>
 
 {% endblock javascripts %}

--- a/apps/templates/pages/xterm.html
+++ b/apps/templates/pages/xterm.html
@@ -6,7 +6,7 @@
     <meta name="description" content="Interactive terminal session for HackInSDN lab environments.">
     <meta name="keywords" content="terminal, xterm, cybersecurity, networking, labs, HackInSDN">
     <title>{{ container }} - xterm</title>
-    <link rel="icon" href="/static/assets/favicon.ico">
+    <link rel="icon" href="{{ url_for('static', filename='assets/favicon.ico') }}">
     <style>
 html {
   font-family: arial;
@@ -42,11 +42,11 @@ body {
   }
 }
     </style>
-    <link rel="stylesheet" href="/static/assets/plugins/xterm/xterm/css/xterm.css"/>
+    <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/xterm/xterm/css/xterm.css') }}"/>
   </head>
   <body>
     <div style="display: flex;">
-      <a href="https://hackinsdn.ufba.br" target="_blank" style="font-size: 1.4em; text-decoration: none; color:black"><img alt="hackinsdn" style="height: 50px" src="/static/assets/img/hackinsdn-horizontal.png" /></a>
+      <a href="https://hackinsdn.ufba.br" target="_blank" style="font-size: 1.4em; text-decoration: none; color:black"><img alt="hackinsdn" style="height: 50px" src="{{ url_for('static', filename='assets/img/hackinsdn-horizontal.png') }}" /></a>
         <span style="font-size: small; display: flex; flex-wrap: wrap; gap: .1em; justify-content: flex-end; margin: auto 0 auto auto;">
           status:
           <span style="font-size: small" id="status">connecting...</span>
@@ -77,10 +77,10 @@ body {
     </script>
     {% endif %}
     <!-- xterm -->
-    <script src="/static/assets/plugins/xterm/xterm/lib/xterm.js"></script>
-    <script src="/static/assets/plugins/xterm/addon-fit/lib/addon-fit.js"></script>
-    <script src="/static/assets/plugins/xterm/addon-web-links/lib/addon-web-links.js"></script>
-    <script src="/static/assets/plugins/xterm/addon-search/lib/addon-search.js"></script>
+    <script src="{{ url_for('static', filename='assets/plugins/xterm/xterm/lib/xterm.js') }}"></script>
+    <script src="{{ url_for('static', filename='assets/plugins/xterm/addon-fit/lib/addon-fit.js') }}"></script>
+    <script src="{{ url_for('static', filename='assets/plugins/xterm/addon-web-links/lib/addon-web-links.js') }}"></script>
+    <script src="{{ url_for('static', filename='assets/plugins/xterm/addon-search/lib/addon-search.js') }}"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.min.js"></script>
 
     <script>

--- a/apps/templates/pages/xterm.html
+++ b/apps/templates/pages/xterm.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0" />
-    <title>{{container}} - xterm</title>
+    <title>{{ container }} - xterm</title>
     <link rel="icon" href="/static/assets/favicon.ico">
     <style>
 html {
@@ -67,11 +67,11 @@ body {
 
     <!-- Analytics measurements -->
     {% if config.ANALYTICS_JSFILE %}
-    <script async src="{{config.ANALYTICS_JSFILE}}"></script>
+    <script async src="{{ config.ANALYTICS_JSFILE }}"></script>
     {% endif %}
     {% if config.ANALYTICS_SCRIPT %}
     <script>
-    {{config.ANALYTICS_SCRIPT|safe}}
+    {{ config.ANALYTICS_SCRIPT|safe }}
     </script>
     {% endif %}
     <!-- xterm -->
@@ -148,7 +148,7 @@ body {
       fit.fit();
       term.resize(15, 50);
       fit.fit();
-      term.writeln("Welcome to {{host}}");
+      term.writeln("Welcome to {{ host }}");
       term.writeln('')
       term.writeln("You can copy with ctrl+shift+c or ctrl+shift+x");
       term.writeln("You can paste with ctrl+shift+v");
@@ -167,13 +167,13 @@ body {
           data = String.fromCharCode(27, data.codePointAt(0));
           shouldClear = true;
         }
-        socket.emit("pty-input", { input: data, host: "{{host}}" });
+        socket.emit("pty-input", { input: data, host: "{{ host }}" });
         if (shouldClear) {
           clearVirtualKeyboard();
         }
       });
 
-      const socket = io.connect("/pty?host={{host}}");
+      const socket = io.connect("/pty?host={{ host }}");
       const status = document.getElementById("status");
 
       socket.on("pty-output", function (data) {
@@ -209,7 +209,7 @@ body {
         }
         fit.fit();
         const dims = { cols: term.cols, rows: term.rows };
-        socket.emit("resize", { dims: dims, host: "{{host}}" });
+        socket.emit("resize", { dims: dims, host: "{{ host }}" });
       }
 
       function debounce(func, wait_ms) {
@@ -271,7 +271,7 @@ body {
       function handleVirtualKeyboard(evt) {
         evt.preventDefault();
         if (evt.target.id in specialKeyMap) {
-          socket.emit("pty-input", { input: specialKeyMap[evt.target.id], host: "{{host}}" });
+          socket.emit("pty-input", { input: specialKeyMap[evt.target.id], host: "{{ host }}" });
           clearVirtualKeyboard();
         } else if (evt.target.id === "ctrl") {
           ctrlButton.style.backgroundColor = "lightblue";
@@ -301,7 +301,7 @@ body {
       }
 
       window.onbeforeunload = function () {
-        socket.emit('disconnect', {'host': "{{host}}"});
+        socket.emit('disconnect', {'host': "{{ host }}"});
       }
     </script>
   </body>

--- a/apps/templates/pages/xterm.html
+++ b/apps/templates/pages/xterm.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0" />
+    <meta name="description" content="Interactive terminal session for HackInSDN lab environments.">
+    <meta name="keywords" content="terminal, xterm, cybersecurity, networking, labs, HackInSDN">
     <title>{{ container }} - xterm</title>
     <link rel="icon" href="/static/assets/favicon.ico">
     <style>

--- a/apps/templates/pages/xterm.html
+++ b/apps/templates/pages/xterm.html
@@ -44,7 +44,7 @@ body {
   </head>
   <body>
     <div style="display: flex;">
-      <a href="https://hackinsdn.ufba.br" target="_blank" style="font-size: 1.4em; text-decoration: none; color:black"><img style="height: 50px" src="/static/assets/img/hackinsdn-horizontal.png" /></a>
+      <a href="https://hackinsdn.ufba.br" target="_blank" style="font-size: 1.4em; text-decoration: none; color:black"><img alt="hackinsdn" style="height: 50px" src="/static/assets/img/hackinsdn-horizontal.png" /></a>
         <span style="font-size: small; display: flex; flex-wrap: wrap; gap: .1em; justify-content: flex-end; margin: auto 0 auto auto;">
           status:
           <span style="font-size: small" id="status">connecting...</span>


### PR DESCRIPTION
## What changed

Cleans up all actionable djlint findings in `apps/templates` and adds a CI workflow to keep them from coming back.

### Template fixes, by rule
- **T001** – wrapped all `{{var}}` variables in single whitespace: `{{ var }}` (246 occurrences)
- **T002** – double quotes in `{% include %}` tags in the base layout
- **T003** – named every `{% endblock %}` with its block name (43 files)
- **T032** – removed extra whitespace padding inside `{% ... %}` tags
- **H019** – replaced `href="javascript:history.back()"` on the 403/404 pages with a real `url_for` fallback URL plus an `onclick` handler (degrades gracefully without JS)
- **H025** – fixed real HTML structure bugs: a missing `</div>` in `confirm.html` and `confirm_email.html` (unclosed `.row` inside the form) and an extra stray `</div>` in `index.html`
- **H029** – lowercased `method="POST"/"GET"` form attributes
- **H030/H031** – added `meta description`/`keywords` to both layouts and `xterm.html`; also fixed a missing space in the `og:image` tag and made its URL absolute via `config.BASE_URL` (OpenGraph scrapers require absolute URLs)
- **J004** – converted all 432 hardcoded `/static/...` href/src URLs to `{{ url_for('static', filename=...) }}`
- **J018** – converted hardcoded internal links (`/index`, `/profile`, `/users`, `/labs/view`) to `url_for()` with endpoints verified against the route decorators

### CI
New `.github/workflows/lint.yml` runs djlint on PRs and pushes to main, installing the version pinned in `requirements-dev.txt`:

```
djlint --profile=jinja --ignore=H023,D004,H006,H021 --exclude="apps/templates/mail/" apps/templates/
```

## Reviewer notes
- `apps/templates/mail/` is deliberately excluded from linting: HTML emails require inline styles (email clients strip `<style>` blocks), and meta description/keywords are meaningless in email — those findings are false positives there.
- Ignored rules are the style-level ones assessed as needing design decisions or being low-value: H023 (entity refs), D004, H006 (img width/height), H021 (inline styles).
- The bulk of the diff is mechanical whitespace/`url_for` rewrites; every change was verified by re-running djlint (0 errors with the CI command) and parsing all 53 templates with Jinja2 (0 errors). The H025 fixes change real HTML structure but match what browsers were already auto-correcting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)