### PR TITLE
refactor: rename duplicate lab to fork lab

### DIFF
--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -572,15 +572,15 @@ def edit_lab(lab_id):
     else:
         return render_template("pages/labs_edit.html", lab=lab, lab_categories=lab_categories, msg_fail=msg, segment="/labs/edit", groups=groups, allowed_groups=lab.allowed_groups, lab_uploads=lab_uploads)
 
-@blueprint.route('/labs/duplicate/<lab_id>', methods=["GET"])
+@blueprint.route('/labs/fork/<lab_id>', methods=["GET"])
 @login_required
 @check_user_category(["admin", "teacher", "labcreator"])
-def duplicate_lab(lab_id):
+def fork_lab(lab_id):
     source = db.session.get(Labs, lab_id)
     if not source or source.is_deleted:
         return render_template("pages/labs_edit.html", lab=None, segment="/labs/edit", msg_fail="Lab not found")
     if current_user.category == "labcreator" and source.updated_by != current_user.id:
-        # labcreators may duplicate any lab they can view (same predicate as
+        # labcreators may fork any lab they can view (same predicate as
         # view_labs): shared with one of their groups or their own
         source_group_ids = {group.id for group in source.allowed_groups}
         if not source_group_ids.intersection(current_user.all_group_ids):
@@ -593,15 +593,15 @@ def duplicate_lab(lab_id):
     groups = Groups.query.filter_by(is_deleted=False).all()
 
     # Labs.title is String(255): truncate the source title so the suffix fits
-    new_title = f"{source.title} -- Copy"
+    new_title = f"{source.title} -- Fork"
     if len(new_title) > 255:
-        new_title = source.title[:247] + " -- Copy"
+        new_title = source.title[:247] + " -- Fork"
 
     lab_guide_md = source.lab_guide_md_str if source.lab_guide_md else ""
     extended_desc = source.extended_desc_str if source.extended_desc else ""
 
     # guide attachments are shared with the source lab (same filenames and
-    # URLs): nothing is written to disk on this GET, so an abandoned duplicate
+    # URLs): nothing is written to disk on this GET, so an abandoned fork
     # leaves no orphan files behind. Deletion is reference-counted in
     # delete_lab_upload, so removing the attachment from one lab does not
     # break the other.
@@ -623,8 +623,8 @@ def duplicate_lab(lab_id):
         lab_guide_md_str=lab_guide_md,
     )
 
-    duplicate_lab_log = HomeLogging(ipaddr=get_remote_addr(), action="duplicate_lab", success=True, lab_id=source.id, user_id=current_user.id)
-    db.session.add(duplicate_lab_log)
+    fork_lab_log = HomeLogging(ipaddr=get_remote_addr(), action="fork_lab", success=True, lab_id=source.id, user_id=current_user.id)
+    db.session.add(fork_lab_log)
     db.session.commit()
 
     return render_template(
@@ -636,7 +636,7 @@ def duplicate_lab(lab_id):
         segment="/labs/edit",
         lab_uploads=lab_uploads,
         pending_uploads=lab_uploads,
-        duplicated_from=source.title,
+        forked_from=source.title,
     )
 
 @blueprint.route('/users')
@@ -1434,7 +1434,7 @@ def delete_lab_upload(lab_id, filename):
     md["uploads"] = uploads
     lab_md.md = md
 
-    # lab duplication shares attachment files instead of copying them, so the
+    # lab forking shares attachment files instead of copying them, so the
     # same filename may be referenced by other labs: only remove the file from
     # disk when this lab held the last reference
     # substring matching for LabMetadata._md.contains(filename) is correct

--- a/apps/templates/pages/labs_edit.html
+++ b/apps/templates/pages/labs_edit.html
@@ -66,11 +66,11 @@
               {{ msg_fail }}
             </div>
             {% endif %}
-            {% if duplicated_from %}
+            {% if forked_from %}
             <div class="alert alert-info alert-dismissible">
               <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-              <h5><i class="icon fas fa-copy"></i> Duplicating Lab</h5>
-              You are duplicating "{{ duplicated_from }}". Nothing is saved until you press Submit.
+              <h5><i class="icon fas fa-code-branch"></i> Forking Lab</h5>
+              You are forking "{{ forked_from }}". Nothing is saved until you press Submit.
             </div>
             {% endif %}
           </div>
@@ -453,7 +453,7 @@
             <button type="submit" class="btn btn-primary">Submit</button>
             <a href="{{ url_for('home_blueprint.view_labs', lab_id=lab.id) if lab.id else url_for('home_blueprint.view_labs') }}" class="btn btn-secondary mx-2" role="button" aria-pressed="true">Cancel</a>
             {% if lab and lab.id and not lab.is_deleted %}
-            <a href="{{ url_for('home_blueprint.duplicate_lab', lab_id=lab.id) }}" class="btn btn-info" role="button"><i class="fas fa-copy"></i> Duplicate</a>
+            <a href="{{ url_for('home_blueprint.fork_lab', lab_id=lab.id) }}" class="btn btn-info" role="button"><i class="fas fa-code-branch"></i> Fork</a>
             {% endif %}
             {% if lab and lab.id %}
               {% if lab.is_deleted %}

--- a/apps/templates/pages/labs_view.html
+++ b/apps/templates/pages/labs_view.html
@@ -158,7 +158,7 @@
                 <a class="btn btn-outline-dark mx-1 card-action-btn" href="{{ url_for(route, lab_id=lab_id) }}" role="button" title="{{ link_text }}" aria-label="{{ link_text }}"><i class="far fa-play-circle"></i></a>
                 {% endif %}
                 {% if not lab.is_deleted and current_user.category in ["admin", "teacher", "labcreator"] and (not config.get("ENABLE_CLABS") or not lab.is_clab) %}
-                <a class="btn btn-outline-dark mx-1 card-action-btn" href="{{ url_for('home_blueprint.duplicate_lab', lab_id=lab.id) }}" role="button" title="Duplicate" aria-label="Duplicate"><i class="fas fa-copy"></i></a>
+                <a class="btn btn-outline-dark mx-1 card-action-btn" href="{{ url_for('home_blueprint.fork_lab', lab_id=lab.id) }}" role="button" title="Fork" aria-label="Fork"><i class="fas fa-code-branch"></i></a>
                 {% endif %}
                 {% if current_user.category == "admin" or current_user.category == "teacher" or (current_user.category == "labcreator" and lab.updated_by == current_user.id) %}
 		<a class="btn btn-outline-dark mx-1 card-action-btn" href="{{ url_for('home_blueprint.edit_lab', lab_id=lab.id) if not config.get("ENABLE_CLABS") or not lab.is_clab else url_for('clabs_blueprint.upsert', clab_id=lab.id) }}" role="button" title="Update" aria-label="Update"><i class="fas fa-edit"></i></a>

--- a/doc/fork-lab.md
+++ b/doc/fork-lab.md
@@ -1,28 +1,28 @@
-# Duplicate (Fork) a Lab
+# Fork a Lab
 
-This document describes the "Duplicate Lab" feature: how it behaves for
+This document describes the "Fork Lab" feature: how it behaves for
 users, which permission rules apply, and how it is implemented.
 
 ## Overview
 
-Duplicating a Lab opens the regular Lab creation page with every field
+Forking a Lab opens the regular Lab creation page with every field
 pre-filled from an existing Lab, so the user can tweak and submit it as a
-brand new Lab. The pre-filled title receives a ` -- Copy` suffix (e.g.
-`Intro to SDN` becomes `Intro to SDN -- Copy`). Nothing is persisted until
+brand new Lab. The pre-filled title receives a ` -- Fork` suffix (e.g.
+`Intro to SDN` becomes `Intro to SDN -- Fork`). Nothing is persisted until
 the user presses **Submit** — abandoning the page leaves the catalog
 unchanged.
 
 ## Where the action is available
 
 - **Labs list page** (`/labs/view`): each Lab card footer shows a
-  **Duplicate** button (copy icon) next to Update, for admins, teachers and
+  **Fork** button (code-branch icon) next to Update, for admins, teachers and
   labcreators. The button is hidden for deleted labs and for ContainerLabs
   (see Limitations).
-- **Lab edit page** (`/labs/edit/<lab_id>`): a **Duplicate** button next to
+- **Lab edit page** (`/labs/edit/<lab_id>`): a **Fork** button next to
   Submit/Cancel, shown when editing an existing, non-deleted Lab.
 
 As part of this change the Labs list card buttons became icon-only so the
-action row fits on one line: the label (View, Start/Resume, Duplicate,
+action row fits on one line: the label (View, Start/Resume, Fork,
 Update, Restore, Delete) is shown as a tooltip on hover and kept as an
 `aria-label` for screen readers. When a single Lab is displayed
 (`/labs/view/<id>`) the card has room, so a small script appends the label
@@ -31,10 +31,10 @@ modals keep the full wording.
 
 ## Permissions
 
-The route is `GET /labs/duplicate/<lab_id>` and is restricted to the
+The route is `GET /labs/fork/<lab_id>` and is restricted to the
 `admin`, `teacher` and `labcreator` categories:
 
-| Role | May duplicate |
+| Role | May fork |
 | --- | --- |
 | admin | any non-deleted Lab |
 | teacher | any non-deleted Lab (mirrors their unrestricted edit access) |
@@ -48,7 +48,7 @@ found" page used elsewhere, so the route does not leak Lab existence.
 
 ## What gets copied
 
-- Title (with the ` -- Copy` suffix, truncated so it fits the 255-character
+- Title (with the ` -- Fork` suffix, truncated so it fits the 255-character
   column limit)
 - Short description
 - Categories
@@ -59,7 +59,7 @@ found" page used elsewhere, so the route does not leak Lab existence.
 - Goals
 - Lab Guide attachments — shared with the source lab, see below
 
-The audit log (`HomeLogging`) records a `duplicate_lab` action with the
+The audit log (`HomeLogging`) records a `fork_lab` action with the
 *source* Lab id when the form is opened; saving the copy goes through the
 normal create flow and is logged as `edit_lab` like any other new Lab.
 
@@ -68,7 +68,7 @@ normal create flow and is logged as `edit_lab` like any other new Lab.
 The feature reuses the existing create/edit machinery instead of adding a
 separate save path:
 
-- `duplicate_lab` (in `apps/home/routes.py`) loads the source Lab and
+- `fork_lab` (in `apps/home/routes.py`) loads the source Lab and
   renders the existing `pages/labs_edit.html` template in **"new lab"
   mode**: the pre-filled object has `id=None`, so the form posts to
   `/labs/edit/new` and the standard `edit_lab` POST handler creates the new
@@ -79,13 +79,13 @@ separate save path:
   accidentally persist a half-built Lab on autoflush; a namespace object
   renders identically in the template with zero session side effects.
 - An informational alert on the form tells the user which Lab is being
-  duplicated and that nothing is saved until Submit.
+  forked and that nothing is saved until Submit.
 
 ### Guide attachments (uploads)
 
 Lab Guide attachments are tracked in `LabMetadata.md["uploads"]` and stored
-under `UPLOAD_DIR`. The duplicate **shares** the source's files instead of
-copying them — the duplicate GET writes nothing to disk, so abandoning the
+under `UPLOAD_DIR`. The fork **shares** the source's files instead of
+copying them — the fork GET writes nothing to disk, so abandoning the
 form leaves no orphan files behind:
 
 1. The source's uploads list is handed to the form as *pending uploads* —
@@ -98,7 +98,7 @@ form leaves no orphan files behind:
    **reference-counted**: the entry is always removed from the requesting
    Lab's uploads list, but the file is only removed from disk when no other
    Lab's metadata still references that filename. This holds for arbitrary
-   duplicate chains — the last Lab holding a reference deletes the file.
+   fork chains — the last Lab holding a reference deletes the file.
    The check is a substring match on the metadata JSON, which is precise
    because uploaded filenames are unique `uuid4().hex` values.
 
@@ -117,23 +117,23 @@ untracked shared URLs.)
 ## Limitations / future work
 
 - **ContainerLabs**: clabs are edited through the dedicated
-  `clabs` upsert page, and duplicating one also requires copying the
+  `clabs` upsert page, and forking one also requires copying the
   topology stored in `LabMetadata.md` and issuing a new `short_uuid`. The
-  Duplicate button is therefore hidden for clab cards (when `ENABLE_CLABS`
-  is on); clab duplication is left for a follow-up.
-- Answer sheets, schedules and statistics are not copied — the duplicate is
+  Fork button is therefore hidden for clab cards (when `ENABLE_CLABS`
+  is on); clab forking is left for a follow-up.
+- Answer sheets, schedules and statistics are not copied — the fork is
   a fresh Lab with no usage history.
 - Uploading a file while creating a brand-new Lab and then abandoning the
   form still orphans that file (pre-existing behavior, unrelated to
-  duplication). A follow-up sweeper could delete `UPLOAD_DIR` files older
+  forking). A follow-up sweeper could delete `UPLOAD_DIR` files older
   than N days that no Lab metadata or content references.
 
 ## Tests
 
-`tests/test_labs.py::TestDuplicate` covers: role gating (student denied),
-unknown/deleted source rejection, form prefill with `-- Copy` title and all
+`tests/test_labs.py::TestFork` covers: role gating (student denied),
+unknown/deleted source rejection, form prefill with `-- Fork` title and all
 source values, the guarantee that the GET persists nothing to the database
 and writes nothing to disk, submitting the prefilled form as a new Lab,
 title truncation, labcreator scope (own, group-shared, unshared-denied),
 attachment sharing on save, reference-counted attachment deletion, and
-Duplicate button visibility on the list page.
+Fork button visibility on the list page.

--- a/tests/test_labs.py
+++ b/tests/test_labs.py
@@ -15,11 +15,11 @@ Admins can undelete via POST /api/labs/<id>/restore, reveal soft-deleted labs
 in the catalog with ?show_deleted=1, and open a deleted lab in the editor to
 restore it (all covered by TestRestore).
 
-GET /labs/duplicate/<id> (TestDuplicate) prefills the "new lab" form with a
-copy of an existing lab ("<title> -- Copy") without persisting anything or
+GET /labs/fork/<id> (TestFork) prefills the "new lab" form with a
+copy of an existing lab ("<title> -- Fork") without persisting anything or
 writing to disk; admin/teacher may fork any non-deleted lab, labcreator any
 lab they can view (group-shared or own). Guide attachments are shared
-between source and duplicate, with reference-counted deletion in
+between source and fork, with reference-counted deletion in
 DELETE /labs/<id>/uploads/<filename>.
 
 Runs entirely against a throwaway temporary SQLite database created in a temp
@@ -530,60 +530,60 @@ class TestRestore:
         logout(client)
 
 
-# --- duplicate (fork) -----------------------------------------------------
-class TestDuplicate:
-    def test_student_cannot_duplicate_lab(self, client, ids):
-        lab_id = _make_lab(ids, "Dup Student Denied")
+# --- fork a lab ------------------------------------------------------------
+class TestFork:
+    def test_student_cannot_fork_lab(self, client, ids):
+        lab_id = _make_lab(ids, "Fork Student Denied")
         logout(client)
         login(client, "lbstudent", "stud123")
-        resp = client.get(f"/labs/duplicate/{lab_id}")
+        resp = client.get(f"/labs/fork/{lab_id}")
         assert b"Unauthorized request" in resp.data
         logout(client)
 
-    def test_duplicate_missing_lab_is_rejected(self, client, ids):
+    def test_fork_missing_lab_is_rejected(self, client, ids):
         login(client, "lbadmin", "admin123")
-        resp = client.get("/labs/duplicate/does-not-exist")
+        resp = client.get("/labs/fork/does-not-exist")
         assert b"Lab not found" in resp.data
 
-    def test_duplicate_deleted_lab_is_rejected(self, client, ids):
-        lab_id = _make_lab(ids, "Dup Deleted Source")
+    def test_fork_deleted_lab_is_rejected(self, client, ids):
+        lab_id = _make_lab(ids, "Fork Deleted Source")
         db.session.get(Labs, lab_id).is_deleted = True
         db.session.commit()
-        resp = client.get(f"/labs/duplicate/{lab_id}")
+        resp = client.get(f"/labs/fork/{lab_id}")
         assert b"Lab not found" in resp.data
 
-    def test_admin_duplicate_prefills_form_without_saving(self, client, ids):
-        lab = Labs(title="Dup Source Lab", description="dup short desc")
-        lab.set_extended_desc("dup extended desc")
-        lab.set_lab_guide_md("# dup guide")
-        lab.manifest = "apiVersion: v1 # dup manifest"
+    def test_admin_fork_prefills_form_without_saving(self, client, ids):
+        lab = Labs(title="Fork Source Lab", description="fork short desc")
+        lab.set_extended_desc("fork extended desc")
+        lab.set_lab_guide_md("# fork guide")
+        lab.manifest = "apiVersion: v1 # fork manifest"
         db.session.add(lab)
         lab.categories.append(db.session.get(LabCategories, ids["category_id"]))
         lab.allowed_groups.append(db.session.get(Groups, ids["student_group_id"]))
         db.session.commit()
 
         labs_before = Labs.query.count()
-        resp = client.get(f"/labs/duplicate/{lab.id}")
+        resp = client.get(f"/labs/fork/{lab.id}")
         assert resp.status_code == 200
-        assert b"Dup Source Lab -- Copy" in resp.data
-        assert b"dup short desc" in resp.data
-        assert b"dup extended desc" in resp.data
-        assert b"# dup guide" in resp.data
-        assert b"apiVersion: v1 # dup manifest" in resp.data
+        assert b"Fork Source Lab -- Fork" in resp.data
+        assert b"fork short desc" in resp.data
+        assert b"fork extended desc" in resp.data
+        assert b"# fork guide" in resp.data
+        assert b"apiVersion: v1 # fork manifest" in resp.data
         # renders in "new lab" mode: form posts to /labs/edit/new
         assert b'action="/labs/edit/new"' in resp.data
-        # a duplicate GET must never persist a new lab nor touch the source
+        # a fork GET must never persist a new lab nor touch the source
         assert Labs.query.count() == labs_before
-        source = Labs.query.filter_by(title="Dup Source Lab").first()
+        source = Labs.query.filter_by(title="Fork Source Lab").first()
         assert source is not None
-        assert Labs.query.filter_by(title="Dup Source Lab -- Copy").first() is None
+        assert Labs.query.filter_by(title="Fork Source Lab -- Fork").first() is None
 
-    def test_submitting_duplicate_creates_new_lab(self, client, ids):
-        source = Labs.query.filter_by(title="Dup Source Lab").first()
+    def test_submitting_fork_creates_new_lab(self, client, ids):
+        source = Labs.query.filter_by(title="Fork Source Lab").first()
         resp = client.post(
             "/labs/edit/new",
             data=lab_form(
-                lab_title="Dup Source Lab -- Copy",
+                lab_title="Fork Source Lab -- Fork",
                 lab_description=source.description,
                 lab_guide=source.lab_guide_md_str,
                 lab_manifest=source.manifest,
@@ -593,58 +593,58 @@ class TestDuplicate:
         )
         assert resp.status_code == 200
 
-        copy = Labs.query.filter_by(title="Dup Source Lab -- Copy").first()
+        copy = Labs.query.filter_by(title="Fork Source Lab -- Fork").first()
         assert copy is not None
         assert copy.id != source.id
         assert copy.manifest == source.manifest
         # the source keeps its own title/values
-        assert db.session.get(Labs, source.id).title == "Dup Source Lab"
+        assert db.session.get(Labs, source.id).title == "Fork Source Lab"
 
-    def test_duplicate_truncates_long_title(self, client, ids):
+    def test_fork_truncates_long_title(self, client, ids):
         lab_id = _make_lab(ids, "T" * 255)
-        resp = client.get(f"/labs/duplicate/{lab_id}")
-        assert ("T" * 247 + " -- Copy").encode() in resp.data
+        resp = client.get(f"/labs/fork/{lab_id}")
+        assert ("T" * 247 + " -- Fork").encode() in resp.data
         logout(client)
 
-    def test_labcreator_can_duplicate_own_lab(self, client, ids):
-        lab_id = _make_lab(ids, "Dup Creator Own Lab", updated_by=ids["labcreator_id"])
+    def test_labcreator_can_fork_own_lab(self, client, ids):
+        lab_id = _make_lab(ids, "Fork Creator Own Lab", updated_by=ids["labcreator_id"])
         login(client, "lblabcreator", "lc123")
-        resp = client.get(f"/labs/duplicate/{lab_id}")
+        resp = client.get(f"/labs/fork/{lab_id}")
         assert resp.status_code == 200
-        assert b"Dup Creator Own Lab -- Copy" in resp.data
+        assert b"Fork Creator Own Lab -- Fork" in resp.data
 
-    def test_labcreator_can_duplicate_group_shared_lab(self, client, ids):
+    def test_labcreator_can_fork_group_shared_lab(self, client, ids):
         # owned by the admin, but shared with a group the labcreator belongs
         # to: forking any lab you can view is allowed
-        group = Groups(groupname="DupCreatorGroup", organization="ORG1")
+        group = Groups(groupname="ForkCreatorGroup", organization="ORG1")
         group.members.append(db.session.get(Users, ids["labcreator_id"]))
         db.session.add(group)
-        lab = Labs(title="Dup Shared With Creator", description="x")
+        lab = Labs(title="Fork Shared With Creator", description="x")
         lab.categories.append(db.session.get(LabCategories, ids["category_id"]))
         lab.allowed_groups.append(group)
         lab.updated_by = ids["admin_id"]
         db.session.add(lab)
         db.session.commit()
 
-        resp = client.get(f"/labs/duplicate/{lab.id}")
+        resp = client.get(f"/labs/fork/{lab.id}")
         assert resp.status_code == 200
-        assert b"Dup Shared With Creator -- Copy" in resp.data
+        assert b"Fork Shared With Creator -- Fork" in resp.data
 
-    def test_labcreator_cannot_duplicate_unshared_lab(self, client, ids):
-        lab_id = _make_lab(ids, "Dup Not Shared", updated_by=ids["admin_id"])
-        resp = client.get(f"/labs/duplicate/{lab_id}")
+    def test_labcreator_cannot_fork_unshared_lab(self, client, ids):
+        lab_id = _make_lab(ids, "Fork Not Shared", updated_by=ids["admin_id"])
+        resp = client.get(f"/labs/fork/{lab_id}")
         assert b"Lab not found" in resp.data
         logout(client)
 
-    def test_duplicate_shares_uploads_and_writes_nothing_to_disk(self, client, ids):
+    def test_fork_shares_uploads_and_writes_nothing_to_disk(self, client, ids):
         login(client, "lbadmin", "admin123")
         upload_dir = flask_app.config["UPLOAD_DIR"]
         os.makedirs(upload_dir, exist_ok=True)
-        src_filename = "dupsource.txt"
+        src_filename = "forksource.txt"
         with open(os.path.join(upload_dir, src_filename), "w") as f:
             f.write("attachment body")
 
-        lab = Labs(title="Dup Upload Lab", description="x")
+        lab = Labs(title="Fork Upload Lab", description="x")
         lab.set_extended_desc("")
         lab.set_lab_guide_md(f"see [notes.txt](/uploads/{src_filename})")
         db.session.add(lab)
@@ -655,65 +655,65 @@ class TestDuplicate:
         db.session.commit()
 
         files_before = sorted(os.listdir(upload_dir))
-        resp = client.get(f"/labs/duplicate/{lab.id}")
+        resp = client.get(f"/labs/fork/{lab.id}")
         assert resp.status_code == 200
-        assert b"Dup Upload Lab -- Copy" in resp.data
-        # the duplicate references the source's file as-is (shared)...
+        assert b"Fork Upload Lab -- Fork" in resp.data
+        # the fork references the source's file as-is (shared)...
         assert src_filename.encode() in resp.data
-        # ...so an abandoned duplicate leaves no orphan copies behind
+        # ...so an abandoned fork leaves no orphan copies behind
         assert sorted(os.listdir(upload_dir)) == files_before
         # source metadata is untouched
         assert lab.lab_metadata.md["uploads"][0]["filename"] == src_filename
 
-    def test_submitting_duplicate_associates_shared_upload(self, client, ids):
-        source = Labs.query.filter_by(title="Dup Upload Lab").first()
+    def test_submitting_fork_associates_shared_upload(self, client, ids):
+        source = Labs.query.filter_by(title="Fork Upload Lab").first()
         resp = client.post(
             "/labs/edit/new",
             data=lab_form(
-                lab_title="Dup Upload Lab -- Copy",
+                lab_title="Fork Upload Lab -- Fork",
                 lab_guide=source.lab_guide_md_str,
                 lab_categories=str(ids["category_id"]),
-                pending_upload_filenames='["dupsource.txt"]',
+                pending_upload_filenames='["forksource.txt"]',
                 pending_upload_orignames='["notes.txt"]',
             ),
             follow_redirects=True,
         )
         assert resp.status_code == 200
 
-        copy = Labs.query.filter_by(title="Dup Upload Lab -- Copy").first()
+        copy = Labs.query.filter_by(title="Fork Upload Lab -- Fork").first()
         assert copy is not None
         uploads = copy.lab_metadata.md.get("uploads", [])
-        assert [u["filename"] for u in uploads] == ["dupsource.txt"]
+        assert [u["filename"] for u in uploads] == ["forksource.txt"]
         # both labs reference the same single file on disk
-        assert source.lab_metadata.md["uploads"][0]["filename"] == "dupsource.txt"
-        assert os.path.exists(os.path.join(flask_app.config["UPLOAD_DIR"], "dupsource.txt"))
+        assert source.lab_metadata.md["uploads"][0]["filename"] == "forksource.txt"
+        assert os.path.exists(os.path.join(flask_app.config["UPLOAD_DIR"], "forksource.txt"))
 
     def test_delete_shared_upload_keeps_file_until_last_reference(self, client, ids):
-        source = Labs.query.filter_by(title="Dup Upload Lab").first()
-        copy = Labs.query.filter_by(title="Dup Upload Lab -- Copy").first()
-        fpath = os.path.join(flask_app.config["UPLOAD_DIR"], "dupsource.txt")
+        source = Labs.query.filter_by(title="Fork Upload Lab").first()
+        copy = Labs.query.filter_by(title="Fork Upload Lab -- Fork").first()
+        fpath = os.path.join(flask_app.config["UPLOAD_DIR"], "forksource.txt")
 
-        # removing the attachment from the duplicate keeps the file on disk:
+        # removing the attachment from the fork keeps the file on disk:
         # the source lab still references it
-        resp = client.delete(f"/labs/{copy.id}/uploads/dupsource.txt")
+        resp = client.delete(f"/labs/{copy.id}/uploads/forksource.txt")
         assert resp.status_code == 200
         assert os.path.exists(fpath)
         db.session.expire_all()
         assert copy.lab_metadata.md.get("uploads") == []
-        assert source.lab_metadata.md["uploads"][0]["filename"] == "dupsource.txt"
+        assert source.lab_metadata.md["uploads"][0]["filename"] == "forksource.txt"
 
         # removing the last reference deletes the file from disk
-        resp = client.delete(f"/labs/{source.id}/uploads/dupsource.txt")
+        resp = client.delete(f"/labs/{source.id}/uploads/forksource.txt")
         assert resp.status_code == 200
         assert not os.path.exists(fpath)
         db.session.expire_all()
         assert source.lab_metadata.md.get("uploads") == []
 
-    def test_duplicate_button_visibility_on_labs_view(self, client, ids):
+    def test_fork_button_visibility_on_labs_view(self, client, ids):
         resp = client.get("/labs/view")
-        assert b"/labs/duplicate/" in resp.data
+        assert b"/labs/fork/" in resp.data
         logout(client)
         login(client, "lbstudent", "stud123")
         resp = client.get("/labs/view")
-        assert b"/labs/duplicate/" not in resp.data
+        assert b"/labs/fork/" not in resp.data
         logout(client)


### PR DESCRIPTION
### Description of the change

The Duplicate Lab feature is now "Fork" everywhere, including the -- Fork title suffix. Full suite passes (434 tests) and both templates are djlint-clean.

Rename complete — the feature is now "Fork" everywhere, including the ` -- Fork` title suffix. Full suite passes (434 tests) and both templates are djlint-clean.

What changed:

- **Backend** ([routes.py:575](apps/home/routes.py#L575)): route is `GET /labs/fork/<lab_id>`, function `fork_lab`, audit action `fork_lab`, template context `forked_from`, and the title suffix is now ` -- Fork` (truncation logic unchanged, the suffix is also 8 chars). The forking/attachment comments in `fork_lab` and `delete_lab_upload` were reworded. No redirect from the old `/labs/duplicate/` URL since the feature was never released.
- **Templates**: the edit-page button is now `Fork` and the info alert reads "Forking Lab / You are forking …" ([labs_edit.html](apps/templates/pages/labs_edit.html)); the list-card button has `title`/`aria-label` "Fork" ([labs_view.html](apps/templates/pages/labs_view.html)). Both use the `fas fa-code-branch` icon, including the alert. The single-lab inline-label JS needed no change since it reads `aria-label`.
- **Tests** ([test_labs.py](tests/test_labs.py)): class is `TestFork`, all method names, URLs, fixture titles, and the `-- Fork` suffix assertions renamed; no feature-related "duplicate"/"-- Copy" string remains (verified by grep — the untouched "duplicate" hits elsewhere in the repo are unrelated: duplicate emails, duplicate question names).
- **Docs**: `git mv doc/duplicate-lab.md` → [doc/fork-lab.md](doc/fork-lab.md), retitled "Fork a Lab" with all terminology, the route path, the icon name, and the suffix updated.
- **PR**: [#260](https://github.com/hackinsdn/dashboard/pull/260) title is now "feat: fork an existing Lab" and the body was rewritten with the fork terminology, `/labs/fork` route, `doc/fork-lab.md` link, and updated test counts.

The rename is uncommitted on `feat/duplicate-lab` (along with your earlier uncommitted UI changes) — note the PR description now says "Fork" while the pushed commits still say "Duplicate", so it's worth committing and pushing soon. You may also want to rename the branch eventually, though that's cosmetic. Want me to commit and push?
