### PR TITLE
feat: elapsed-wait timer and staged messages on the Run Lab Status page

### DIFF
--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -21,7 +21,7 @@ from flask_login import login_required, current_user
 from jinja2 import TemplateNotFound
 from apps.audit_mixin import get_remote_addr, check_user_category
 from apps.authentication.forms import GroupForm
-from apps.utils import update_running_labs_stats, parse_lab_expiration, datetime_from_ts, update_category_stats, update_stats_lab_instances_answers, utcnow
+from apps.utils import update_running_labs_stats, parse_lab_expiration, datetime_from_ts, epoch_from_datetime, update_category_stats, update_stats_lab_instances_answers, utcnow
 from sqlalchemy import desc
 
 
@@ -244,7 +244,7 @@ def run_lab(lab_id):
         running_labs = LabInstances.query.filter_by(is_deleted=False, user_id=current_user.id).count()
         cache.set(f"running_labs-{current_user.id}", running_labs)
 
-        return render_template("pages/run_lab_status.html", resources=msg, lab_instance_id=pod_hash)
+        return render_template("pages/run_lab_status.html", resources=msg, lab_instance_id=pod_hash, lab_requested_ts=epoch_from_datetime(lab_inst.created_at))
     else:
         create_lab_log_error = HomeLogging(ipaddr=get_remote_addr(), action="create_lab", success=False, lab_id=lab.id, user_id=current_user.id)
         db.session.add(create_lab_log_error)
@@ -264,7 +264,7 @@ def check_lab_status(lab_id):
     if lab.user_id != current_user.id:
         return render_template("pages/error.html", title="Error checking lab status", msg="You are not authorized to run this lab")
 
-    return render_template("pages/run_lab_status.html", resources=lab.k8s_resources, lab_instance_id=lab_id)
+    return render_template("pages/run_lab_status.html", resources=lab.k8s_resources, lab_instance_id=lab_id, lab_requested_ts=epoch_from_datetime(lab.created_at))
 
 @blueprint.route('/xterm/<lab_id>/<kind>/<pod>/<container>', methods=["GET"])
 @login_required

--- a/apps/templates/pages/run_lab_status.html
+++ b/apps/templates/pages/run_lab_status.html
@@ -46,6 +46,7 @@
         <div class="row">
           <div class="col-12">
             <h4>Wait while checking for resource statuses... <span id="elapsedTimer" class="badge badge-info"></span></h4>
+            <p id="waitMessage" class="text-muted"></p>
           </div>
         </div>
         <div class="row">
@@ -69,7 +70,7 @@
                         {% endfor %}
                       </ul>
                       <p id="statusText"></p>
-                      <p id="waitMessage" class="text-muted"></p>
+                      <p id="resourceExtraInfo" class="text-muted"></p>
                       <a style="display: none;" id="labLink" class="btn btn-outline-success" href="{{ url_for('home_blueprint.view_lab_instance', lab_id=lab_instance_id) }}">Start using the Lab resources and Lab guide!</a>
                     </div>
                   </div>
@@ -135,6 +136,8 @@
         clearInterval(timerInterval);
         document.getElementById("loading").style.display = "none";
         $("#labLink").text("Check the running Lab").show();
+        $("#elapsedTimer").removeClass('badge-info');
+        $("#elapsedTimer").addClass('badge-danger');
       }
 
       function updateElapsed() {

--- a/apps/templates/pages/run_lab_status.html
+++ b/apps/templates/pages/run_lab_status.html
@@ -45,7 +45,7 @@
       <div class="container-fluid">
         <div class="row">
           <div class="col-12">
-            <h4>Wait while checking for resource statuses...</h4>
+            <h4>Wait while checking for resource statuses... <span id="elapsedTimer" class="badge badge-info"></span></h4>
           </div>
         </div>
         <div class="row">
@@ -69,6 +69,7 @@
                         {% endfor %}
                       </ul>
                       <p id="statusText"></p>
+                      <p id="waitMessage" class="text-muted"></p>
                       <a style="display: none;" id="labLink" class="btn btn-outline-success" href="{{ url_for('home_blueprint.view_lab_instance', lab_id=lab_instance_id) }}">Start using the Lab resources and Lab guide!</a>
                     </div>
                   </div>
@@ -104,6 +105,55 @@
   <!-- Page script -->
   <script>
     $(function () {
+      // elapsed time since the lab instance was requested (server-provided so
+      // a page refresh resumes at the right stage; falls back to page load)
+      var requestedTs = {{ lab_requested_ts|default(none)|tojson }};
+      var startTime = requestedTs ? requestedTs * 1000 : Date.now();
+      var gaveUp = false;
+      var giveUpSeconds = 300;
+      // staged wait messages: highest matching threshold (seconds) wins
+      var waitMessages = [
+        [giveUpSeconds, "We could not confirm all resources became ready within 5 minutes. Your Lab may still be provisioning in the background — open the Lab page below to check it."],
+        [240, "Taking more than expected, but still waiting for resources."],
+        [180, "Almost there — provisioning can take a few minutes on busy clusters. Please bear with us a little longer."],
+        [120, "Still waiting for all resources to be provisioned."],
+        [60, "This is taking a little longer than usual — thank you for your patience!"]
+      ];
+
+      function elapsedSeconds() {
+        return Math.max(0, Math.floor((Date.now() - startTime) / 1000));
+      }
+
+      function stopWaiting() {
+        clearInterval(timerInterval);
+        $("#waitMessage").text("");
+        document.getElementById("loading").style.display = "none";
+      }
+
+      function giveUp() {
+        gaveUp = true;
+        clearInterval(timerInterval);
+        document.getElementById("loading").style.display = "none";
+        $("#labLink").text("Check the running Lab").show();
+      }
+
+      function updateElapsed() {
+        var elapsed = elapsedSeconds();
+        $("#elapsedTimer").text("Waiting for " + elapsed + "s");
+        for (var i = 0; i < waitMessages.length; i++) {
+          if (elapsed >= waitMessages[i][0]) {
+            $("#waitMessage").text(waitMessages[i][1]);
+            break;
+          }
+        }
+        if (elapsed >= giveUpSeconds && !gaveUp) {
+          giveUp();
+        }
+      }
+
+      var timerInterval = setInterval(updateElapsed, 1000);
+      updateElapsed();
+
       var checkStatus = function() {
         var request = $.ajax({
           url: "/api/lab/status/{{ lab_instance_id }}",
@@ -114,7 +164,7 @@
         request.done(function(data) {
           if (data.status != "ok") {
             $("#statusText").text("Failed to get data");
-            document.getElementById("loading").style.display = "none";
+            stopWaiting();
             return;
           }
           var allOk = true;
@@ -130,18 +180,18 @@
           });
           if (allOk) {
             $("#statusText").text("All resources are ready!");
-            $("#labLink").show();
+            $("#labLink").text("Start using the Lab resources and Lab guide!").show();
             $(".status-badge").text("Ready");
             $(".status-badge").removeClass("badge-secondary");
             $(".status-badge").addClass("badge-success");
-            document.getElementById("loading").style.display = "none"
-          } else {
+            stopWaiting();
+          } else if (!gaveUp) {
             setTimeout(checkStatus, 2000);
           }
         });
         request.fail(function(xhr) {
           $("#statusText").text("Failed to process request: " + xhr.responseText);
-          document.getElementById("loading").style.display = "none"
+          stopWaiting();
         });
       };
       setTimeout(checkStatus, 3000);

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -182,6 +182,14 @@ def datetime_from_ts(timestamp):
         return None
 
 
+def epoch_from_datetime(dt):
+    """Epoch seconds from a datetime; naive values are assumed to be UTC
+    (utcnow() stores UTC, but SQLite returns them back naive)."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    return int(dt.timestamp())
+
+
 def secure_filename(filename: str) -> str:
     r"""Pass it a filename and it will return a secure version of it.  This
     filename can then safely be stored on a regular file system and passed

--- a/tests/test_lab_instances.py
+++ b/tests/test_lab_instances.py
@@ -59,6 +59,7 @@ from run import app as flask_app  # noqa: E402
 from apps import db  # noqa: E402
 from apps.authentication.models import Users, Groups  # noqa: E402
 from apps.home.models import Labs, LabInstances, HomeLogging  # noqa: E402
+from apps.utils import epoch_from_datetime  # noqa: E402
 
 flask_app.config["TESTING"] = True
 flask_app.config["WTF_CSRF_ENABLED"] = False
@@ -215,6 +216,12 @@ class TestRunLab:
         log = HomeLogging.query.filter_by(action="create_lab", success=True, lab_id=ids["lab_b_id"], user_id=ids["student_id"]).first()
         assert log is not None
 
+        # the status page embeds the request time so the elapsed-wait timer
+        # survives page refreshes
+        assert b'id="elapsedTimer"' in resp.data
+        assert b'id="waitMessage"' in resp.data
+        assert f"var requestedTs = {epoch_from_datetime(inst.created_at)};".encode() in resp.data
+
     def test_post_failure_logs_error(self, client, ids, monkeypatch):
         monkeypatch.setattr("apps.home.routes.k8s.create_lab", lambda *a, **k: (False, "boom"))
         resp = client.post(f"/run_lab/{ids['lab_c_id']}", data={"lab_expiration": "4"})
@@ -240,6 +247,8 @@ class TestCheckLabStatus:
     def test_owner_sees_status(self, client, ids):
         resp = client.get(f"/lab_status/{ids['inst_student_id']}")
         assert resp.status_code == 200
+        inst = db.session.get(LabInstances, ids["inst_student_id"])
+        assert f"var requestedTs = {epoch_from_datetime(inst.created_at)};".encode() in resp.data
         logout(client)
 
 


### PR DESCRIPTION
## Summary

Adds an elapsed-time counter and staged wait messages to `pages/run_lab_status.html` while resources are being provisioned, and stops polling after 5 minutes with guidance to check the running Lab.

### Behavior
- A badge next to the page heading ticks every second showing how long the user has been waiting ("Waiting for 73s"). The timer is anchored to the lab instance's `created_at` (passed by the server as `lab_requested_ts`), so refreshing the page resumes at the real elapsed time instead of restarting at zero.
- While `checkStatus()` has not reported all resources ready, a message below the resource list escalates over time:
  - **≥ 60s** — polite ask for patience
  - **≥ 120s** — "Still waiting for all resources to be provisioned."
  - **≥ 180s** — ask for a little more patience
  - **≥ 240s** — "Taking more than expected, but still waiting for resources."
  - **≥ 300s** — give up: polling and the spinner stop, and the user is told the Lab may still be provisioning in the background, with the existing link revealed as "Check the running Lab".
- A status response already in flight at the deadline still wins: an all-ok result restores the normal success message and button label.
- Thresholds and wording live in a single `waitMessages` table for easy tuning.

### Implementation
- New `epoch_from_datetime()` helper in `apps/utils.py` (naive datetimes are assumed UTC, since `utcnow()` values come back naive from SQLite).
- Both render sites pass `lab_requested_ts`: the post-creation render in `run_lab` and `check_lab_status`.
- Success, API failure, and give-up all stop the 1s interval; on success the badge freezes, showing total provisioning time.

## Test plan
- `tests/test_lab_instances.py`: `test_post_success_creates_instance_and_log` and `test_owner_sees_status` now assert the rendered page embeds the exact `requestedTs` epoch from the instance's `created_at` plus the new timer/message elements, covering both routes.
- Full suite: 434 passed. Template passes the CI djlint flags; inline JS syntax-checked with `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)