### PR TITLE
feat: order Labs listing by a display_order attribute

### DIFF
--- a/apps/home/models.py
+++ b/apps/home/models.py
@@ -59,6 +59,8 @@ class Labs(db.Model, AuditMixin):
     __tablename__ = 'labs'
     id = db.Column(db.String(40), primary_key=True, default=generate_uuid)
     is_deleted = db.Column(db.Boolean, default=False, nullable=False, server_default=db.text('false'))
+    # position in the Labs listing: ascending, ties broken by title
+    display_order = db.Column(db.Integer, default=1000, nullable=False, server_default=db.text('1000'))
     title = db.Column(db.String(255))
     description = db.Column(db.String)
     extended_desc = db.Column(db.LargeBinary)

--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -514,6 +514,14 @@ def edit_lab(lab_id):
     selected_group_ids = request.form.getlist('lab_allowed_groups')
     lab.allowed_groups = Groups.query.filter(Groups.id.in_(selected_group_ids), Groups.is_deleted==False).all()
 
+    # only admins may reposition labs in the listing
+    if current_user.category == "admin":
+        display_order_raw = request.form.get("lab_display_order", "").strip()
+        try:
+            lab.display_order = int(display_order_raw) if display_order_raw else 1000
+        except ValueError:
+            return render_template("pages/labs_edit.html", lab=lab, lab_categories=lab_categories, msg_fail="Invalid display order: must be an integer number.", segment="/labs/edit", groups=groups, allowed_groups=lab.allowed_groups, lab_uploads=lab_uploads)
+
     if not lab.categories or invalid_lab_category:
         return render_template("pages/labs_edit.html", lab=lab, lab_categories=lab_categories, msg_fail=invalid_lab_category+"Please select at least one category", segment="/labs/edit", groups=groups, allowed_groups=lab.allowed_groups, lab_uploads=lab_uploads)
 
@@ -618,6 +626,7 @@ def fork_lab(lab_id):
         description=source.description,
         goals=source.goals,
         manifest=source.manifest,
+        display_order=source.display_order,
         categories=list(source.categories),
         extended_desc_str=extended_desc,
         lab_guide_md_str=lab_guide_md,
@@ -817,7 +826,7 @@ def view_labs(lab_id=None):
     if lab_id:
         labs = labs.filter(Labs.id == lab_id)
 
-    labs = labs.all()
+    labs = labs.order_by(Labs.display_order, db.func.lower(Labs.title)).all()
     user_labs_status = {}
     for lab in LabInstances.query.filter_by(user_id=current_user.id).all():
         user_labs_status.setdefault(lab.lab_id, {"is_running": False, "is_completed": False})

--- a/apps/templates/pages/labs_edit.html
+++ b/apps/templates/pages/labs_edit.html
@@ -110,6 +110,13 @@
                     <label>Short Description</label>
                     <input name="lab_description" type="text" class="form-control" placeholder="Max 255 characters" value="{{ lab.description|default('', true) }}">
                   </div>
+                  {% if current_user.category == "admin" %}
+                  <div class="form-group">
+                    <label>Display order</label>
+                    <input name="lab_display_order" type="number" class="form-control" value="{{ lab.display_order|default(1000, true) }}">
+                    <small class="form-text text-muted">Labs are listed by ascending display order, then by title. Default is 1000.</small>
+                  </div>
+                  {% endif %}
                   <div class="form-group">
                     <label>Lab categories</label>
                     <select name="lab_categories" class="form-control select2" multiple="multiple" data-placeholder="Select one or more categories" style="width: 100%;">

--- a/doc/fork-lab.md
+++ b/doc/fork-lab.md
@@ -57,6 +57,8 @@ found" page used elsewhere, so the route does not leak Lab existence.
 - Lab Guide (markdown)
 - Kubernetes manifest
 - Goals
+- Display order (admin-only field: forks made by non-admins reset it to the
+  default 1000)
 - Lab Guide attachments — shared with the source lab, see below
 
 The audit log (`HomeLogging`) records a `fork_lab` action with the

--- a/migrations/versions/2.0.9_add_labs_display_order_2.0.10.py
+++ b/migrations/versions/2.0.9_add_labs_display_order_2.0.10.py
@@ -1,0 +1,29 @@
+"""Added display_order column to labs for explicit listing order
+
+Revision ID: 2.0.10
+Revises: 2.0.9
+Create Date: 2026-07-04 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2.0.10'
+down_revision = '2.0.9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('labs', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('display_order', sa.Integer(), nullable=False, server_default='1000'))
+    # existing labs get the default position explicitly (the server_default
+    # already covers engines that backfill on ADD COLUMN, e.g. SQLite)
+    op.execute("UPDATE labs SET display_order = 1000 WHERE display_order IS NULL")
+
+
+def downgrade():
+    with op.batch_alter_table('labs', schema=None) as batch_op:
+        batch_op.drop_column('display_order')

--- a/tests/test_labs.py
+++ b/tests/test_labs.py
@@ -717,3 +717,113 @@ class TestFork:
         resp = client.get("/labs/view")
         assert b"/labs/fork/" not in resp.data
         logout(client)
+
+
+# --- listing order --------------------------------------------------------
+class TestLabOrdering:
+    def test_new_lab_gets_default_display_order(self, client, ids):
+        login(client, "lbadmin", "admin123")
+        resp = client.post(
+            "/labs/edit/new",
+            data=lab_form(
+                lab_title="Order Default Lab",
+                lab_categories=str(ids["category_id"]),
+            ),
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        lab = Labs.query.filter_by(title="Order Default Lab").first()
+        assert lab is not None
+        assert lab.display_order == 1000
+
+    def test_labs_view_sorts_by_display_order_then_title(self, client, ids):
+        lab1 = _make_lab(ids, "ZZ Ordered First")
+        db.session.get(Labs, lab1).display_order = 1
+        lab2 = _make_lab(ids, "YY Ordered Second")
+        db.session.get(Labs, lab2).display_order = 2
+        # default display_order (1000): sorted among themselves by title,
+        # case-insensitively
+        _make_lab(ids, "aa ordered tie lower")
+        _make_lab(ids, "AB Ordered Tie Upper")
+        db.session.commit()
+
+        resp = client.get("/labs/view")
+        body = resp.data
+        pos = {title: body.index(title.encode()) for title in [
+            "ZZ Ordered First",
+            "YY Ordered Second",
+            "aa ordered tie lower",
+            "AB Ordered Tie Upper",
+        ]}
+        assert pos["ZZ Ordered First"] < pos["YY Ordered Second"]
+        assert pos["YY Ordered Second"] < pos["aa ordered tie lower"]
+        assert pos["aa ordered tie lower"] < pos["AB Ordered Tie Upper"]
+
+    def test_edit_sets_and_clears_display_order(self, client, ids):
+        lab_id = _make_lab(ids, "Order Editable Lab")
+        resp = client.post(
+            f"/labs/edit/{lab_id}",
+            data=lab_form(
+                lab_title="Order Editable Lab",
+                lab_categories=str(ids["category_id"]),
+                lab_display_order="5",
+            ),
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert db.session.get(Labs, lab_id).display_order == 5
+
+        # an empty value resets to the default
+        resp = client.post(
+            f"/labs/edit/{lab_id}",
+            data=lab_form(
+                lab_title="Order Editable Lab",
+                lab_categories=str(ids["category_id"]),
+                lab_display_order="",
+            ),
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert db.session.get(Labs, lab_id).display_order == 1000
+
+    def test_edit_rejects_non_numeric_display_order(self, client, ids):
+        lab_id = _make_lab(ids, "Order Invalid Lab")
+        resp = client.post(
+            f"/labs/edit/{lab_id}",
+            data=lab_form(
+                lab_title="Order Invalid Lab",
+                lab_categories=str(ids["category_id"]),
+                lab_display_order="abc",
+            ),
+        )
+        assert b"Invalid display order" in resp.data
+        assert db.session.get(Labs, lab_id).display_order == 1000
+
+    def test_fork_prefills_display_order(self, client, ids):
+        lab_id = _make_lab(ids, "Order Fork Source")
+        db.session.get(Labs, lab_id).display_order = 7
+        db.session.commit()
+        resp = client.get(f"/labs/fork/{lab_id}")
+        assert resp.status_code == 200
+        assert b'name="lab_display_order" type="number" class="form-control" value="7"' in resp.data
+        logout(client)
+
+    def test_non_admin_cannot_change_display_order(self, client, ids):
+        lab_id = _make_lab(ids, "Order Teacher Lab", updated_by=ids["teacher_id"])
+        login(client, "lbteacher", "teach123")
+        # the field is not rendered for non-admins...
+        resp = client.get(f"/labs/edit/{lab_id}")
+        assert b"lab_display_order" not in resp.data
+        # ...and a crafted POST value is ignored
+        resp = client.post(
+            f"/labs/edit/{lab_id}",
+            data=lab_form(
+                lab_title="Order Teacher Lab",
+                lab_categories=str(ids["category_id"]),
+                lab_display_order="5",
+            ),
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert db.session.get(Labs, lab_id).display_order == 1000
+        logout(client)


### PR DESCRIPTION
## Summary

Labs on the View Labs page are now listed in a deterministic, curatable order: ascending by a new `display_order` attribute, with ties broken by title (case-insensitive). Previously the listing had no `ORDER BY` at all, so the order was engine-dependent.

### Behavior
- New `Labs.display_order` integer column, default **1000** (`server_default` included, mirroring the `is_deleted` pattern).
- `view_labs` orders by `display_order` ascending, then `lower(title)` — labs left at the default sort alphabetically among themselves, so an explicit position below 1000 floats above the pack and above 1000 sinks below it.
- **Admin-only**: the "Display order" field on the Lab edit form is rendered only for admins, and the POST handler ignores the value for any other role. Empty input resets to 1000; non-numeric input is rejected with a validation message.
- Forking a Lab prefills the source's display order for admins; forks made by non-admins reset to the default (documented in `doc/fork-lab.md`).

### Migration
- `2.0.9_add_labs_display_order_2.0.10.py` (revision `2.0.10`): adds the column with `server_default='1000'` via `batch_alter_table` and explicitly backfills existing rows. Verified on a scratch SQLite database: full upgrade from empty, downgrade, re-upgrade, and a row inserted at revision 2.0.9 comes out of the upgrade with `display_order = 1000`.

## Test plan
- `tests/test_labs.py::TestLabOrdering` (6 new tests): new lab defaults to 1000; listing sorts by order then case-insensitive title; edit sets and clears the value; non-numeric input rejected without persisting; fork prefills the source value; non-admins neither see the field nor can change it via a crafted POST.
- Full suite: 440 passed. Template passes the CI djlint flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)