### PR TITLE
feat(k8s): resolve service pods via Discovery API endpoint slices

### DIFF
--- a/apps/controllers/kubernetes.py
+++ b/apps/controllers/kubernetes.py
@@ -43,6 +43,7 @@ class K8sController():
             return
         self.v1_api = client.CoreV1Api()
         self.apps_v1_api = client.AppsV1Api()
+        self.discovery_api = client.DiscoveryV1Api()
         self.k8s_client = client.ApiClient()
         self.k8s_avoid_nodes = set(app_config.K8S_AVOID_NODES)
         self.k8s_nodes_geotag = app_config.TESTBED_NODES_GEOTAG
@@ -177,10 +178,12 @@ class K8sController():
         pod_services = {}
         pod_names = {}
         app_pod_map = defaultdict(list)
+        pods_by_uid = {}
         pods = self.v1_api.list_namespaced_pod(
             namespace=self.namespace
         )
         for pod in pods.items:
+            pods_by_uid[pod.metadata.uid] = pod
             pod_labels = pod.metadata.labels or {}
             app = pod_labels.get("app")
             if app:
@@ -222,6 +225,20 @@ class K8sController():
                 "more": str(pod),
             })
 
+        service_to_pods = defaultdict(list)
+        endpoint_slices = self.discovery_api.list_namespaced_endpoint_slice(
+            namespace=self.namespace
+        )
+        for slice_item in endpoint_slices.items:
+            slice_pods = []
+            for ep in slice_item.endpoints or []:
+                # targetRef is optional (e.g. endpoints backing external IPs)
+                if ep.target_ref and ep.target_ref.uid in pods_by_uid:
+                    slice_pods.append(pods_by_uid[ep.target_ref.uid])
+            # ownerReferences is optional (manually managed slices)
+            for own_ref in slice_item.metadata.owner_references or []:
+                service_to_pods[own_ref.uid].extend(slice_pods)
+
         services = self.v1_api.list_namespaced_service(
             namespace=self.namespace,
         )
@@ -233,9 +250,19 @@ class K8sController():
                 is_child = False
             if srv.metadata.uid not in owners and not is_child:
                 continue
-            pods = app_pod_map.get(srv.spec.selector.get("app"), [])
-            if not pods and (clab_name := srv.spec.selector.get("clabernetes/name")):
+            # selector is optional: selectorless services are resolved via
+            # their endpoint slices below
+            selector = srv.spec.selector or {}
+            pods = app_pod_map.get(selector.get("app"), [])
+            if not pods and (clab_name := selector.get("clabernetes/name")):
                 pods = app_pod_map.get(clab_name, [])
+            if not pods:
+                # only pods that belong to this lab (they are the ones with a
+                # pod_services entry) - a slice may reference foreign pods
+                pods = [
+                    pod for pod in service_to_pods.get(srv.metadata.uid, [])
+                    if pod.metadata.uid in pod_services
+                ]
 
             for port in srv.spec.ports:
                 port_name = port.name if port.name else f"{port.port}/{port.protocol}"

--- a/tests/test_k8s_controller.py
+++ b/tests/test_k8s_controller.py
@@ -73,6 +73,7 @@ def ctrl(monkeypatch):
     monkeypatch.setattr(k8s_module.config, "load_kube_config", lambda **k: None)
     monkeypatch.setattr(k8s_module.client, "CoreV1Api", lambda: MagicMock())
     monkeypatch.setattr(k8s_module.client, "AppsV1Api", lambda: MagicMock())
+    monkeypatch.setattr(k8s_module.client, "DiscoveryV1Api", lambda: MagicMock())
     monkeypatch.setattr(k8s_module.client, "ApiClient", lambda: MagicMock())
     controller = K8sController()
     return controller

--- a/tests/test_k8s_tape.py
+++ b/tests/test_k8s_tape.py
@@ -17,11 +17,13 @@ Usage:
     pytest tests/test_k8s_cluster_pods.py -v
 """
 
+import copy
 import importlib
 import os
 import sys
 import tempfile
 import types
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -153,6 +155,7 @@ def ctrl(monkeypatch):
     monkeypatch.setattr(k8s_module.config, "load_kube_config", lambda **k: None)
     monkeypatch.setattr(k8s_module.client, "CoreV1Api", lambda: MagicMock())
     monkeypatch.setattr(k8s_module.client, "AppsV1Api", lambda: MagicMock())
+    monkeypatch.setattr(k8s_module.client, "DiscoveryV1Api", lambda: MagicMock())
     monkeypatch.setattr(k8s_module.client, "ApiClient", lambda: MagicMock())
     controller = K8sController()
     controller.k8s_avoid_nodes = set()
@@ -253,16 +256,34 @@ class TestCreateLab:
 
 # --- get_lab_resources --------------------------------------------------
 class TestGetLabResources:
-    def test_links_pod_service_and_node_ip(self, ctrl):
-        """Given the owning deployment+service uids, get_lab_resources() walks the
-        deployment -> replicaset -> pod -> service chain from the tape and builds a
-        NodePort URL using the node InternalIP."""
+    # owner uids of the lab's deployment and service (as create_lab would return)
+    RESOURCES = [
+        {"uid": "8755b19e-1ccf-43d1-a277-a99981a542af"},  # deployment
+        {"uid": "755f9dba-bb5c-4cde-ad83-36f390ad27a5"},  # service
+    ]
+    SVC_UID = "755f9dba-bb5c-4cde-ad83-36f390ad27a5"       # helloworld service
+    POD_UID = "10e078e9-acd1-4347-bdfc-33626bc0c7b8"       # helloworld pod (owned)
+    FOREIGN_POD_UID = "a11da0d1-6b78-4f38-878f-1b9ab5bd908a"  # mnsec-proxy pod (not owned)
+    NODEPORT_LINK = ["http-helloworld-webserver", "http://198.51.100.10:30996"]
+
+    @staticmethod
+    def _endpoint_slice(endpoints, owner_uids):
+        """Minimal EndpointSlice stand-in: the controller only reads
+        .endpoints[].target_ref.uid and .metadata.owner_references[].uid."""
+        return SimpleNamespace(
+            endpoints=endpoints,
+            metadata=SimpleNamespace(
+                owner_references=(
+                    [SimpleNamespace(uid=uid) for uid in owner_uids]
+                    if owner_uids is not None else None
+                )
+            ),
+        )
+
+    def _get_lab_resources(self, ctrl, service_list=None, endpoint_slices=None):
+        """Drive get_lab_resources() with the taped objects, allowing the
+        service list and the endpoint-slice collection to be overridden."""
         ctrl.nodes_last_updated = 0
-        # owner uids of the lab's deployment and service (as create_lab would return)
-        resources = [
-            {"uid": "8755b19e-1ccf-43d1-a277-a99981a542af"},  # deployment
-            {"uid": "755f9dba-bb5c-4cde-ad83-36f390ad27a5"},  # service
-        ]
         with patch.object(
             ctrl.apps_v1_api,
             "list_namespaced_deployment",
@@ -276,11 +297,31 @@ class TestGetLabResources:
         ), patch.object(
             ctrl.v1_api,
             "list_namespaced_service",
-            return_value=TAPE_OBJECTS["service_list"],
+            return_value=service_list if service_list is not None else TAPE_OBJECTS["service_list"],
         ), patch.object(
             ctrl.v1_api, "list_node", return_value=TAPE_OBJECTS["node_list"]
+        ), patch.object(
+            ctrl.discovery_api,
+            "list_namespaced_endpoint_slice",
+            return_value=SimpleNamespace(items=endpoint_slices or []),
         ):
-            labs = ctrl.get_lab_resources(resources)
+            return ctrl.get_lab_resources(self.RESOURCES)
+
+    def _selectorless_service_list(self):
+        """The taped services with the helloworld service made selectorless,
+        so only the endpoint-slice fallback can associate its pods."""
+        service_list = copy.deepcopy(TAPE_OBJECTS["service_list"])
+        for srv in service_list.items:
+            if srv.metadata.uid == self.SVC_UID:
+                srv.spec.selector = None
+        return service_list
+
+    def test_links_pod_service_and_node_ip(self, ctrl):
+        """Given the owning deployment+service uids, get_lab_resources() walks the
+        deployment -> replicaset -> pod -> service chain from the tape and builds a
+        NodePort URL using the node InternalIP (selector match; no endpoint
+        slices needed)."""
+        labs = self._get_lab_resources(ctrl)
 
         # only the helloworld pod belongs to the requested owners (the mnsec-proxy
         # pod/service are unrelated and must be filtered out).
@@ -290,9 +331,72 @@ class TestGetLabResources:
         assert lab["node_name"] == "k8s-testing"
         assert lab["containers"] == ["helloworld-hackinsdn"]
         # NodePort 30996 exposed via the node InternalIP (redacted in the tape)
-        assert lab["services"] == [
-            ["http-helloworld-webserver", "http://198.51.100.10:30996"]
+        assert lab["services"] == [self.NODEPORT_LINK]
+
+    def test_selectorless_service_resolved_via_endpoint_slices(self, ctrl):
+        """A service without a selector cannot be matched through pod labels;
+        its pods are found through the Discovery API endpoint slices (slice
+        owned by the service, endpoints targeting the pod by uid)."""
+        slices = [
+            self._endpoint_slice(
+                endpoints=[SimpleNamespace(target_ref=SimpleNamespace(uid=self.POD_UID))],
+                owner_uids=[self.SVC_UID],
+            ),
         ]
+        labs = self._get_lab_resources(
+            ctrl, service_list=self._selectorless_service_list(), endpoint_slices=slices)
+
+        assert len(labs) == 1
+        assert labs[0]["services"] == [self.NODEPORT_LINK]
+
+    def test_selector_match_wins_over_endpoint_slices(self, ctrl):
+        """When the selector already associates pods, the endpoint-slice
+        mapping is not consulted (here a slice pointing the service at the
+        foreign mnsec pod must be ignored)."""
+        slices = [
+            self._endpoint_slice(
+                endpoints=[SimpleNamespace(target_ref=SimpleNamespace(uid=self.FOREIGN_POD_UID))],
+                owner_uids=[self.SVC_UID],
+            ),
+        ]
+        labs = self._get_lab_resources(ctrl, endpoint_slices=slices)
+
+        assert len(labs) == 1
+        assert labs[0]["services"] == [self.NODEPORT_LINK]
+
+    def test_degenerate_endpoint_slices_are_tolerated(self, ctrl):
+        """Slices without endpoints, endpoints without targetRef (external
+        IPs), unknown pod uids, slices without ownerReferences and slices
+        mapping pods that do not belong to the lab must neither crash nor
+        attach wrong service links."""
+        slices = [
+            # endpoints list missing entirely
+            self._endpoint_slice(endpoints=None, owner_uids=[self.SVC_UID]),
+            # endpoint without targetRef + endpoint targeting an unknown pod
+            self._endpoint_slice(
+                endpoints=[
+                    SimpleNamespace(target_ref=None),
+                    SimpleNamespace(target_ref=SimpleNamespace(uid="unknown-uid")),
+                ],
+                owner_uids=[self.SVC_UID],
+            ),
+            # slice not owned by any service
+            self._endpoint_slice(
+                endpoints=[SimpleNamespace(target_ref=SimpleNamespace(uid=self.POD_UID))],
+                owner_uids=None,
+            ),
+            # slice mapping a pod that is not part of the requested lab
+            self._endpoint_slice(
+                endpoints=[SimpleNamespace(target_ref=SimpleNamespace(uid=self.FOREIGN_POD_UID))],
+                owner_uids=[self.SVC_UID],
+            ),
+        ]
+        labs = self._get_lab_resources(
+            ctrl, service_list=self._selectorless_service_list(), endpoint_slices=slices)
+
+        assert len(labs) == 1
+        # none of the degenerate slices may produce a service link
+        assert labs[0]["services"] == []
 
 
 # --- delete_resources_by_name -------------------------------------------


### PR DESCRIPTION
Services whose selector does not match pod app/clabernetes labels (or selectorless services) are now associated with their pods through the EndpointSlice collection: slices owned by the service map its endpoints' targetRef uids back to the listed pods.

Hardening on top of the initial change, all pinned by tests:
- list_namespaced_endpoint_slice used self.namespace (NameError before)
- DiscoveryV1Api held on the controller like the other API clients
- optional fields tolerated: endpoints, endpoint.target_ref (external IPs), metadata.owner_references (manually managed slices)
- selectorless services (spec.selector None) no longer crash the listing
- slice-mapped pods that do not belong to the requested lab are ignored (would KeyError on pod_services for NodePort links)