### PR TITLE
fix: detect duplicate question names involving select boxes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,3 +67,26 @@ jobs:
         # Fails the job if overall coverage drops below the floor. Bump this up
         # over time as coverage improves.
         run: python -m coverage report --fail-under=85
+
+  js-test:
+    name: JavaScript regression tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        working-directory: tests/js
+        run: npm install
+
+      - name: Run JavaScript tests
+        # Exercises the inline template JS (e.g. duplicate-question detection in
+        # labs_edit.html) with jsdom + the project's real jQuery/marked builds.
+        working-directory: tests/js
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,7 @@ apps/static/assets/node_modules
 apps/static/assets/yarn.lock
 apps/static/assets/.temp
 
+tests/js/node_modules
+
 *.pem
 kube-config.yaml

--- a/apps/templates/pages/labs_edit.html
+++ b/apps/templates/pages/labs_edit.html
@@ -888,11 +888,20 @@
             $(this).css('border', '2px solid red');
             return;
           }
-          if (seenNames[name] && this.type !== 'radio' && this.type !== 'checkbox') {
+          // radio/checkbox inputs may legitimately repeat a name (they form a
+          // single option group), so a repeated name is only accepted when both
+          // the first occurrence and this one are radio/checkbox. Any other
+          // repeat (e.g. a second select, or a select reusing a radio's name)
+          // is a duplicate question.
+          var groupable = (this.type === 'radio' || this.type === 'checkbox');
+          if (seenNames.hasOwnProperty(name)) {
+            if (groupable && seenNames[name]) {
+              return;
+            }
             duplicates.push(name);
             $(this).css('border', '2px solid red');
           } else {
-            seenNames[name] = true;
+            seenNames[name] = groupable;
           }
         });
         questionCounter = Object.keys(seenNames).length;

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -1,0 +1,25 @@
+# JavaScript regression tests
+
+Tests for inline JavaScript that ships inside the Jinja templates under
+`apps/templates/`.
+
+These run in Node with [jsdom](https://github.com/jsdom/jsdom) and load the
+project's actual jQuery and `marked` builds from `apps/static/assets/plugins/`,
+so they exercise the same code paths as the browser.
+
+## Running
+
+```bash
+cd tests/js
+npm install    # once, pulls jsdom
+npm test
+```
+
+## Tests
+
+- `parseLabGuide.test.js` — verifies duplicate-question detection in
+  `apps/templates/pages/labs_edit.html`. The function source is extracted from
+  the template at test time (not copied), so a regression in the template is
+  caught. Covers the fix where a `<select>` question name reused by another
+  field (including a following radio/checkbox) must be reported as a duplicate,
+  while legitimate radio/checkbox option groups are not.

--- a/tests/js/package.json
+++ b/tests/js/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "hackinsdn-dashboard-js-tests",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Regression tests for inline JavaScript in the dashboard templates",
+  "scripts": {
+    "test": "node parseLabGuide.test.js"
+  },
+  "devDependencies": {
+    "jsdom": "^24.0.0"
+  }
+}

--- a/tests/js/parseLabGuide.test.js
+++ b/tests/js/parseLabGuide.test.js
@@ -1,0 +1,123 @@
+/*
+ * Regression tests for parseLabGuide() in
+ * apps/templates/pages/labs_edit.html
+ *
+ * parseLabGuide() previews the lab guide Markdown and rejects the form when two
+ * questions share the same `name` attribute. radio/checkbox inputs are allowed
+ * to repeat a name (they form a single option group); every other repeat is a
+ * duplicate question.
+ *
+ * These tests extract the real function from the template (rather than copying
+ * its body) and exercise it with the project's actual jQuery and marked builds,
+ * so a regression in the shipped template is caught.
+ *
+ * Run with:  cd tests/js && npm install && npm test
+ */
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const TEMPLATE = path.join(REPO_ROOT, 'apps', 'templates', 'pages', 'labs_edit.html');
+const JQUERY = path.join(REPO_ROOT, 'apps', 'static', 'assets', 'plugins', 'jquery', 'jquery.min.js');
+const MARKED = path.join(REPO_ROOT, 'apps', 'static', 'assets', 'plugins', 'marked', 'marked.min.js');
+
+// --- Extract the real parseLabGuide() source from the template -------------
+function extractParseLabGuide(src) {
+  const start = src.indexOf('function parseLabGuide');
+  if (start === -1) throw new Error('parseLabGuide not found in template');
+  let depth = 0;
+  let seenBrace = false;
+  for (let i = src.indexOf('{', start); i < src.length; i++) {
+    const ch = src[i];
+    if (ch === '{') { depth++; seenBrace = true; }
+    else if (ch === '}') { depth--; }
+    if (seenBrace && depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error('Could not brace-match parseLabGuide body');
+}
+
+// --- Build a jsdom window with jQuery + marked and the real function -------
+function makeRunner() {
+  const jquerySrc = fs.readFileSync(JQUERY, 'utf8');
+  const markedSrc = fs.readFileSync(MARKED, 'utf8');
+  const fnSrc = extractParseLabGuide(fs.readFileSync(TEMPLATE, 'utf8'));
+
+  const dom = new JSDOM(
+    `<!DOCTYPE html><body><div id="custom-tabs-labguide-preview"></div>` +
+    `<script>${jquerySrc}</script><script>${markedSrc}</script></body>`,
+    { runScripts: 'dangerously' }
+  );
+  const { window } = dom;
+
+  let lastAlert = null;
+  window.alert = (msg) => { lastAlert = msg; };
+  window.questionCounter = 0;
+  window.editorLabGuide = { getValue: () => window.__md };
+  window.eval(fnSrc + '\nwindow.__parseLabGuide = parseLabGuide;');
+
+  return function run(md) {
+    lastAlert = null;
+    window.__md = md;
+    const event = { preventDefault() { this.prevented = true; } };
+    const ret = window.__parseLabGuide(event, true);
+    return { ret, alert: lastAlert, prevented: !!event.prevented };
+  };
+}
+
+// --- Markdown snippets mirroring what the editor buttons insert ------------
+const SELECT = (n) => `<select name='${n}'>\n  <option value=''>--</option>\n  <option>a</option>\n</select>\n`;
+const SELECT_MULTI = (n) => `<select multiple name='${n}'><option>a</option></select>\n`;
+const TEXT = (n) => `<input type='text' name='${n}' placeholder='x'>\n`;
+const TEXTAREA = (n) => `<textarea name='${n}' rows='6' cols='80'> </textarea>\n`;
+const RADIO = (n) => `<input type='radio' name='${n}' value='1'/>\n`;
+const CHECKBOX = (n) => `<input type='checkbox' name='${n}' value='1'/>\n`;
+
+// { name: [markdown, expectDuplicate] }
+const cases = {
+  // --- the reported bug: a select name reused by another field ------------
+  'two identical selects':               [SELECT('q1') + SELECT('q1'), true],
+  'multi-selects same name':             [SELECT_MULTI('q1') + SELECT_MULTI('q1'), true],
+  'select then radio (regression)':      [SELECT('q1') + RADIO('q1'), true],
+  'select then checkbox (regression)':   [SELECT('q1') + CHECKBOX('q1'), true],
+  'radio then select':                   [RADIO('q1') + SELECT('q1'), true],
+  'checkbox then select':                [CHECKBOX('q1') + SELECT('q1'), true],
+  'text then select':                    [TEXT('q1') + SELECT('q1'), true],
+  'select then text':                    [SELECT('q1') + TEXT('q1'), true],
+  'textarea then select':                [TEXTAREA('q1') + SELECT('q1'), true],
+  'selects split by markdown':           [`## Q1\ntext\n\n${SELECT('q1')}\n## Q2\n\n${SELECT('q1')}`, true],
+
+  // --- non-select duplicates still caught --------------------------------
+  'two text inputs same name':           [TEXT('q1') + TEXT('q1'), true],
+  'two textareas same name':             [TEXTAREA('q1') + TEXTAREA('q1'), true],
+
+  // --- legitimate content that must NOT be flagged -----------------------
+  'single select':                       [SELECT('q1'), false],
+  'distinct selects':                    [SELECT('q1') + SELECT('q2'), false],
+  'radio option group':                  [RADIO('q1') + RADIO('q1') + RADIO('q1'), false],
+  'checkbox option group':               [CHECKBOX('q1') + CHECKBOX('q1'), false],
+  'one of each distinct':                [TEXT('q1') + SELECT('q2') + TEXTAREA('q3') + RADIO('q4') + RADIO('q4'), false],
+  'empty guide':                         ['', false],
+};
+
+// --- Run -------------------------------------------------------------------
+const run = makeRunner();
+let failures = 0;
+for (const [label, [md, expectDup]] of Object.entries(cases)) {
+  const { ret, alert, prevented } = run(md);
+  const gotDup = ret === false;
+  const ok =
+    gotDup === expectDup &&
+    (expectDup ? alert && /Duplicated question name found/.test(alert) && prevented
+               : alert === null && !prevented);
+  if (ok) {
+    console.log(`  ok    ${label}`);
+  } else {
+    failures++;
+    console.error(`  FAIL  ${label}`);
+    console.error(`        expected duplicate=${expectDup}, got=${gotDup}, alert=${JSON.stringify(alert)}, prevented=${prevented}`);
+  }
+}
+
+console.log(`\n${Object.keys(cases).length - failures}/${Object.keys(cases).length} passed`);
+if (failures > 0) process.exit(1);


### PR DESCRIPTION
Fix #272 

## What

`parseLabGuide()` in `apps/templates/pages/labs_edit.html` validates that no two lab-guide questions share the same `name` attribute before the form is submitted. This fixes a case where a duplicate involving a `<select>` question was silently accepted, and adds a regression test suite plus a CI job.

## Why

The radio/checkbox exemption (grouped radios/checkboxes legitimately repeat a name) was evaluated **only on the current element**:

```js
if (seenNames[name] && this.type !== 'radio' && this.type !== 'checkbox') { ... }
```

So when a `<select>` question's name was later reused by a radio or checkbox input, the exemption fired on that later element and the duplicate was **not** reported. Verified against the project's real jQuery + `marked` builds (jsdom and headless Chrome):

- two `<select>`s with the same name → already caught ✓
- `<select>` then `radio`/`checkbox` with the same name → **accepted (bug)** ✗

## Fix

Track whether the *first* occurrence of a name was groupable, and only allow a repeat when both the previous and current elements are radio/checkbox. Any other repeat — a second select, or a select's name reused by any other field — is now reported. `questionCounter` (unique-name count) is unaffected.

## Tests

Added `tests/js/` — a jsdom-based suite that **extracts the real `parseLabGuide()` from the template** (not a copy) and runs it with the repo's actual jQuery/`marked`, covering select↔select, select↔radio/checkbox/text/textarea, legitimate radio/checkbox groups, distinct names, and empty guide (18 cases).

```bash
cd tests/js && npm install && npm test   # 18/18
```

Confirmed the suite fails exactly the two `select then radio`/`select then checkbox` cases when run against the pre-fix code, so it's a genuine regression guard.

## CI

Added a parallel `js-test` job to `.github/workflows/tests.yml` (same triggers/concurrency as the Python job) that runs `npm test` in `tests/js`.

## Reviewer notes

- No JS build step / test harness existed before; this introduces `tests/js/` with `jsdom` as the only dev dependency. `tests/js/node_modules` is gitignored.
- No changes to Python code, models, or routes.

## Local tests

Reproduced the testes from issue #272 and it now shows as duplicated.