### PR TITLE
fix: correct card filter to avoid gaps

### DIFF
--- a/apps/templates/pages/labs_view.html
+++ b/apps/templates/pages/labs_view.html
@@ -109,8 +109,8 @@
           {% for cat in lab.categories %}
             {% set _ = category_classes.append("category-" ~ cat.id) %}
           {% endfor %}
-          <div class="{{ card_size }}">
-            <div class="card {% if lab.is_deleted %}card-danger{% else %}card-dark{% endif %} filter {{ category_classes|join(' ') }} {% if is_completed %}lab-completed{% else %}lab-not-completed{% endif %} mh-100">
+          <div class="{{ card_size }} filter {{ category_classes|join(' ') }} {% if is_completed %}lab-completed{% else %}lab-not-completed{% endif %}">
+            <div class="card {% if lab.is_deleted %}card-danger{% else %}card-dark{% endif %} mh-100">
               <div class="card-header">
                 <h2 class="card-title">
                   {{ lab.title }}


### PR DESCRIPTION
Fix #274 

## Description of the changes

The JS logic in `applyFilters()` and the filter-button handlers all target `.filter` — which is now the outer column div rather than the inner `.card`, so `.hide()`/`.show()` acts on the whole grid cell and the flex row reflows without leaving empty gaps. No JS changes were needed.

What changed in [labs_view.html:112](apps/templates/pages/labs_view.html:112):
- **Outer column** now carries the filter markers: `filter`, the `category-<id>` classes, and `lab-completed`/`lab-not-completed`.
- **Inner `.card`** keeps only visual classes (`card`, `card-danger`/`card-dark`, `mh-100`).

This works for both layouts since `card_size` (`col-lg-6` / `col-12`) stays on that same column div, and the initial `$('.filter').addClass('category-visible status-visible')` plus the "all"/reset paths continue to show everything.

You can verify in the app by filtering by category and by status in both the multi-lab and single-lab views — the remaining cards should reflow with no empty gaps.


## Local tests

Tested in the testing environment and by filtering by category and by status in both the multi-lab and single-lab views: the remaining cards reflow with no empty gaps