### PR TITLE
Make lab instance answer loading robust

### DIFF
--- a/apps/api/routes.py
+++ b/apps/api/routes.py
@@ -181,7 +181,7 @@ def save_lab_answers(lab_inst_id):
         return {}, 404
 
     content = request.get_json(silent=True)
-    if not content:
+    if not isinstance(content, dict) or not content:
         return {"status": "fail", "result": "invalid content"}, 400
 
     lab_inst = db.session.get(LabInstances, lab_inst_id)
@@ -196,7 +196,17 @@ def save_lab_answers(lab_inst_id):
         lab_answers = LabAnswers(user_id=current_user.id, lab_id=lab_inst.lab_id)
         db.session.add(lab_answers)
 
-    lab_answers.answers = json.dumps(content)
+    # Merge into the stored answers rather than replacing them: keep keys not
+    # present in this payload, and don't let an empty incoming value wipe an
+    # answer that was already saved (guards against a partial/early auto-save
+    # clobbering existing work).
+    merged = lab_answers.answers_dict
+    for name, value in content.items():
+        if (value is None or value == "") and merged.get(name):
+            continue
+        merged[name] = value
+
+    lab_answers.answers = json.dumps(merged)
     db.session.commit()
 
     return {"status": "ok", "result": "Answers saved successfully"}, 200

--- a/apps/templates/pages/lab_instance_view.html
+++ b/apps/templates/pages/lab_instance_view.html
@@ -371,18 +371,41 @@ word-break: break-all;
           location.href = "{{ url_for('home_blueprint.running_labs') }}";
         });
       });
+      var answersLoaded = false;   // suppress auto-save until the initial load settles
       function saveAnswers(showToast = true) {
         var answers = {};
+        var checkboxGroups = {};   // name -> list of checked values (multi-select groups)
         $("#lab-guide input, #lab-guide textarea, #lab-guide select").each(function(){
           var input = $(this);
-          var inputVal = input.val();
-          if ((input.attr('type') == "radio" || input.attr('type') == "checkbox") && !this.checked) {
-            inputVal = "";
+          var name = input.attr('name');
+          if (!name) {
+            return;
           }
-          if (!input.val()) {
-            inputVal = "";
+          var type = input.attr('type');
+          if (type == "checkbox") {
+            // accumulate every checked box sharing this name so groups round-trip
+            if (!(name in checkboxGroups)) {
+              checkboxGroups[name] = [];
+            }
+            if (this.checked) {
+              checkboxGroups[name].push(input.val());
+            }
+          } else if (type == "radio") {
+            // only the checked radio contributes; never let an unchecked
+            // sibling overwrite the selected value with ""
+            if (this.checked) {
+              answers[name] = input.val();
+            } else if (!(name in answers)) {
+              answers[name] = "";
+            }
+          } else {
+            answers[name] = input.val() || "";
           }
-          answers[input.attr('name')] = inputVal;
+        });
+        // store checkbox groups as a stable, sorted string so they load back
+        // correctly and still grade as text (answer sheet compares via regex)
+        $.each(checkboxGroups, function(name, values) {
+          answers[name] = values.sort().join(", ");
         });
         if (!answers || Object.keys(answers).length === 0) {
           return;
@@ -420,38 +443,56 @@ word-break: break-all;
       });
       var timeoutSave;
       $("#lab-guide input, #lab-guide textarea, #lab-guide select").on('input propertychange change', function() {
+          // don't auto-save until the initial load has settled, otherwise a
+          // half-populated form could overwrite the stored answers with blanks
+          if (!answersLoaded) {
+            return;
+          }
           clearTimeout(timeoutSave);
           timeoutSave = setTimeout(function() {
               saveAnswers(true);
           }, 1000);
       });
-      // load answers
-      $(window).on("load", function () {
-        var request = $.ajax({
-          url:  "/api/lab_answers/{{ lab['lab_instance_id'] }}",
-          type: "GET",
-        });
-        request.done(function(data) {
-          if (!data.result || $.isEmptyObject(data.result)) {
+      // ---- load answers ----
+      function applyAnswers(result) {
+        $("#lab-guide input, #lab-guide textarea, #lab-guide select").each(function(){
+          var input = $(this);
+          var name = input.attr('name');
+          if (!name || !(name in result)) {
             return;
           }
-          $("#lab-guide input, #lab-guide textarea, #lab-guide select").each(function(){
-            var input = $(this);
-            if (input.attr('name') in data.result) {
-              if (input.attr('type') == "radio") {
-                if (input.val() == data.result[input.attr('name')]) {
-                  this.checked = true;
-                }
-              } else if (input.attr('type') == "checkbox") {
-                input.prop("checked", true);
-              } else {
-                input.val(data.result[input.attr('name')]);
-              }
-            }
-          });
+          var saved = result[name];
+          var type = input.attr('type');
+          if (type == "radio") {
+            input.prop("checked", String(input.val()) === String(saved));
+          } else if (type == "checkbox") {
+            // saved is a sorted, ", "-joined list of the checked values
+            var selected = String(saved == null ? "" : saved).split(", ");
+            input.prop("checked", selected.indexOf(String(input.val())) !== -1);
+          } else {
+            input.val(saved);
+          }
         });
-        request.fail(function(xhr) {
-          if (xhr.status == 401) {
+      }
+      function loadAnswers(attempt) {
+        attempt = attempt || 1;
+        $.ajax({
+          url:  "/api/lab_answers/{{ lab['lab_instance_id'] }}",
+          type: "GET",
+        }).done(function(data) {
+          if (data.result && !$.isEmptyObject(data.result)) {
+            applyAnswers(data.result);
+          }
+          answersLoaded = true;   // only now is it safe to auto-save
+        }).fail(function(xhr) {
+          if (xhr.status == 401 || xhr.status == 404) {
+            // no answers to load (unauthorized / not applicable), not transient
+            answersLoaded = true;
+            return;
+          }
+          if (attempt < 3) {
+            // retry transient failures with a small backoff before giving up
+            setTimeout(function() { loadAnswers(attempt + 1); }, 1000 * attempt);
             return;
           }
           $(document).Toasts('create', {
@@ -462,7 +503,11 @@ word-break: break-all;
             body: xhr.responseText
           });
         });
-      });
+      }
+      // the lab guide is server-rendered inline, so the inputs already exist
+      // here; run immediately instead of waiting for window "load" (which can
+      // be delayed by images or may have already fired)
+      loadAnswers();
     })
     // Extends lab expiration
     function extendLabExpiration(hours) {

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -23,3 +23,12 @@ npm test
   caught. Covers the fix where a `<select>` question name reused by another
   field (including a following radio/checkbox) must be reported as a duplicate,
   while legitimate radio/checkbox option groups are not.
+
+- `labAnswers.test.js` — verifies `saveAnswers()` / `applyAnswers()` in
+  `apps/templates/pages/lab_instance_view.html`, which serialize the lab-guide
+  form and repopulate it when the instance is reopened. Both functions are
+  extracted from the template at test time. Covers text/textarea/select values,
+  radio selections that aren't the last option, checkbox groups (stored as a
+  sorted `", "`-joined string), value-aware reloading of checkboxes, untouched
+  fields whose name is absent from the saved data, and a full save→apply
+  round-trip.

--- a/tests/js/labAnswers.test.js
+++ b/tests/js/labAnswers.test.js
@@ -1,0 +1,219 @@
+/*
+ * Regression tests for saveAnswers() and applyAnswers() in
+ * apps/templates/pages/lab_instance_view.html
+ *
+ * saveAnswers() collects the lab-guide form into a { name: value } object and
+ * POSTs it; applyAnswers() takes such an object back and repopulates the form.
+ * Together they must round-trip text, textarea, select, radio groups and
+ * checkbox groups without losing or mangling a value.
+ *
+ * These tests extract the real functions from the template (rather than copying
+ * their bodies) and exercise them with the project's actual jQuery build, so a
+ * regression in the shipped template is caught. $.ajax is stubbed to capture
+ * the POST body instead of hitting the network.
+ *
+ * Run with:  cd tests/js && npm install && npm test
+ */
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const TEMPLATE = path.join(REPO_ROOT, 'apps', 'templates', 'pages', 'lab_instance_view.html');
+const JQUERY = path.join(REPO_ROOT, 'apps', 'static', 'assets', 'plugins', 'jquery', 'jquery.min.js');
+
+// --- Extract a named function's real source from the template --------------
+function extractFunction(src, marker) {
+  const start = src.indexOf(marker);
+  if (start === -1) throw new Error(`${marker} not found in template`);
+  let depth = 0;
+  let seenBrace = false;
+  for (let i = src.indexOf('{', start); i < src.length; i++) {
+    const ch = src[i];
+    if (ch === '{') { depth++; seenBrace = true; }
+    else if (ch === '}') { depth--; }
+    if (seenBrace && depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error(`Could not brace-match ${marker} body`);
+}
+
+// --- Build a jsdom window with jQuery and the real functions ---------------
+function makeEnv() {
+  const jquerySrc = fs.readFileSync(JQUERY, 'utf8');
+  const src = fs.readFileSync(TEMPLATE, 'utf8');
+  // Jinja placeholders ({{ ... }}) are not valid JS; stub them out.
+  const stub = (s) => s.replace(/\{\{[^}]*\}\}/g, 'STUB');
+  const saveSrc = stub(extractFunction(src, 'function saveAnswers'));
+  const applySrc = stub(extractFunction(src, 'function applyAnswers'));
+
+  const dom = new JSDOM(
+    `<!DOCTYPE html><body><div id="lab-guide"></div>` +
+    `<script>${jquerySrc}</script></body>`,
+    { runScripts: 'dangerously' }
+  );
+  const { window } = dom;
+  const $ = window.$;
+
+  // toast plugin used on save success/failure paths
+  $.fn.Toasts = function () { return this; };
+
+  // capture the POST payload instead of hitting the network
+  $.ajax = function (opts) {
+    if (opts.type === 'POST') {
+      window.__lastPost = JSON.parse(opts.data);
+    }
+    return { done() { return this; }, fail() { return this; } };
+  };
+
+  window.eval(
+    saveSrc + '\n' + applySrc + '\n' +
+    'window.__saveAnswers = saveAnswers; window.__applyAnswers = applyAnswers;'
+  );
+
+  return {
+    $,
+    setForm(html) { $('#lab-guide').html(html); },
+    save() {
+      window.__lastPost = undefined;
+      window.__saveAnswers(false);
+      return window.__lastPost;
+    },
+    apply(result) { window.__applyAnswers(result); },
+    // read helpers
+    val(sel) { return $(sel).val(); },
+    checked(sel) { return $(sel).prop('checked'); },
+  };
+}
+
+// --- A form covering every input kind the guide can contain ----------------
+const FORM =
+  `<input type='text' name='q_text'>` +
+  `<textarea name='q_ta'></textarea>` +
+  `<select name='q_sel'><option value=''>--</option><option value='a'>a</option><option value='b'>b</option></select>` +
+  `<input type='radio' name='q_radio' value='A'>` +
+  `<input type='radio' name='q_radio' value='B'>` +
+  `<input type='radio' name='q_radio' value='C'>` +
+  `<input type='checkbox' name='q_cb' value='X'>` +
+  `<input type='checkbox' name='q_cb' value='Y'>` +
+  `<input type='checkbox' name='q_cb' value='Z'>` +
+  `<input type='checkbox' name='q_single'>`;
+
+// --- Assertion helpers -----------------------------------------------------
+let failures = 0;
+let total = 0;
+function check(label, cond, detail) {
+  total++;
+  if (cond) {
+    console.log(`  ok    ${label}`);
+  } else {
+    failures++;
+    console.error(`  FAIL  ${label}`);
+    if (detail) console.error(`        ${detail}`);
+  }
+}
+function eq(label, got, want) {
+  check(label, JSON.stringify(got) === JSON.stringify(want),
+        `expected ${JSON.stringify(want)}, got ${JSON.stringify(got)}`);
+}
+
+const env = makeEnv();
+const { $ } = env;
+
+// === saveAnswers: collects every field type ================================
+{
+  env.setForm(FORM);
+  $("input[name=q_text]").val('hello world');
+  $("textarea[name=q_ta]").val('line1\nline2');
+  $("select[name=q_sel]").val('b');
+  $("input[name=q_radio][value=B]").prop('checked', true);
+  $("input[name=q_cb][value=X]").prop('checked', true);
+  $("input[name=q_cb][value=Z]").prop('checked', true);
+  $("input[name=q_single]").prop('checked', true);
+
+  const post = env.save();
+  eq('save: text value',              post.q_text, 'hello world');
+  eq('save: textarea value',          post.q_ta, 'line1\nline2');
+  eq('save: select value',            post.q_sel, 'b');
+  eq('save: radio keeps selection',   post.q_radio, 'B');
+  eq('save: checkbox group joined',   post.q_cb, 'X, Z');   // sorted, ", "-joined
+  eq('save: single checkbox',         post.q_single, 'on');
+}
+
+// === saveAnswers: radio selection isn't lost when it's not the last option ==
+{
+  env.setForm(FORM);
+  $("input[name=q_radio][value=A]").prop('checked', true);  // first option
+  const post = env.save();
+  eq('save: first radio not clobbered by later unchecked siblings', post.q_radio, 'A');
+}
+
+// === saveAnswers: empty / unchecked groups serialize as "" =================
+{
+  env.setForm(FORM);
+  const post = env.save();
+  eq('save: empty text',              post.q_text, '');
+  eq('save: unchecked checkbox group', post.q_cb, '');
+  eq('save: no radio selected',        post.q_radio, '');
+}
+
+// === applyAnswers: repopulates a blank form ================================
+{
+  env.setForm(FORM);
+  env.apply({
+    q_text: 'restored',
+    q_ta: 'a\nb',
+    q_sel: 'a',
+    q_radio: 'C',
+    q_cb: 'Y, Z',
+    q_single: 'on',
+  });
+  eq('apply: text',        env.val('input[name=q_text]'), 'restored');
+  eq('apply: textarea',    env.val('textarea[name=q_ta]'), 'a\nb');
+  eq('apply: select',      env.val('select[name=q_sel]'), 'a');
+  eq('apply: radio C checked',  env.checked('input[name=q_radio][value=C]'), true);
+  eq('apply: radio A unchecked', env.checked('input[name=q_radio][value=A]'), false);
+  eq('apply: checkbox Y checked', env.checked('input[name=q_cb][value=Y]'), true);
+  eq('apply: checkbox Z checked', env.checked('input[name=q_cb][value=Z]'), true);
+  eq('apply: checkbox X unchecked (value-aware)', env.checked('input[name=q_cb][value=X]'), false);
+  eq('apply: single checkbox', env.checked('input[name=q_single]'), true);
+}
+
+// === applyAnswers: only a single value in a group checks exactly that box ==
+{
+  env.setForm(FORM);
+  env.apply({ q_cb: 'Y' });
+  eq('apply: only Y checked',  env.checked('input[name=q_cb][value=Y]'), true);
+  eq('apply: X stays unchecked', env.checked('input[name=q_cb][value=X]'), false);
+  eq('apply: Z stays unchecked', env.checked('input[name=q_cb][value=Z]'), false);
+}
+
+// === applyAnswers: leaves fields whose name is absent untouched ============
+{
+  env.setForm(FORM);
+  $("input[name=q_text]").val('prefilled');
+  env.apply({ q_radio: 'B' });   // no q_text key
+  eq('apply: absent field left intact', env.val('input[name=q_text]'), 'prefilled');
+}
+
+// === Full round-trip: save then apply reproduces the original selection ====
+{
+  env.setForm(FORM);
+  $("input[name=q_text]").val('round trip');
+  $("select[name=q_sel]").val('b');
+  $("input[name=q_radio][value=C]").prop('checked', true);
+  $("input[name=q_cb][value=X]").prop('checked', true);
+  $("input[name=q_cb][value=Y]").prop('checked', true);
+  const post = env.save();
+
+  env.setForm(FORM);              // fresh, blank form
+  env.apply(post);
+  eq('round-trip: text',   env.val('input[name=q_text]'), 'round trip');
+  eq('round-trip: select', env.val('select[name=q_sel]'), 'b');
+  eq('round-trip: radio C', env.checked('input[name=q_radio][value=C]'), true);
+  eq('round-trip: checkbox X', env.checked('input[name=q_cb][value=X]'), true);
+  eq('round-trip: checkbox Y', env.checked('input[name=q_cb][value=Y]'), true);
+  eq('round-trip: checkbox Z unchecked', env.checked('input[name=q_cb][value=Z]'), false);
+}
+
+console.log(`\n${total - failures}/${total} passed`);
+if (failures > 0) process.exit(1);

--- a/tests/js/package.json
+++ b/tests/js/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Regression tests for inline JavaScript in the dashboard templates",
   "scripts": {
-    "test": "node parseLabGuide.test.js"
+    "test": "node parseLabGuide.test.js && node labAnswers.test.js"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"


### PR DESCRIPTION
Fix #279

## What & why

The lab guide answers sometimes failed to load on the lab instance page, leaving the questions blank. This hardens the load/save logic in `lab_instance_view.html` and the backend save endpoint so existing answers are always restored, and adds regression tests.

## Frontend (`apps/templates/pages/lab_instance_view.html`)

- **Load runs immediately instead of on `window.load`.** The guide is server-rendered inline, so the inputs already exist at DOM-ready. Waiting for `load` meant loading could be delayed by slow/broken images, or skipped entirely if the event had already fired (bfcache / fully-cached navigation) — a silent failure that left fields empty.
- **Retry transient failures** — the GET now retries up to 3× with backoff; `401`/`404` are treated as "nothing to load" (no error toast).
- **Auto-save gated behind an `answersLoaded` flag** — the debounced auto-save is suppressed until the initial load settles, so a half-populated form can't POST blanks over the stored answers. The manual **Save answers** button is intentionally *not* gated, so an explicit save always works.
- **Value-aware checkbox/radio reload** — checkboxes now compare against the saved value instead of blindly checking every box sharing a name.
- **Fixed pre-existing save bugs for radios and checkboxes** — the old loop let an unchecked sibling overwrite the selected value with `""` (last-in-DOM won) and kept only one value per checkbox group. Radios now keep the checked value; checkbox groups are stored as a sorted, `", "`-joined string that round-trips.

## Backend (`apps/api/routes.py`)

- **Non-destructive merge on save** — POST now merges into the stored answers instead of replacing them: keys absent from the payload are preserved, and an empty incoming value won't wipe an already-saved answer. Input guard tightened to require a JSON object.

## Compatibility notes

- Checkbox groups are stored as a **joined string** (not an array) on purpose, so grading's `re.match(f"^{expected}$", answers.get(question))` in `check_lab_answer` keeps working unchanged. Existing single-value answers load fine.
- Trade-off from the backend merge: clearing a field to blank via auto-save won't erase a previously-saved non-empty value. Since the frontend no longer emits spurious blanks, this mainly acts as a safety net against work loss.

## Tests

- New `tests/js/labAnswers.test.js` — jsdom regression suite (29 assertions) that extracts the real `saveAnswers()` / `applyAnswers()` from the template and runs them against the project's actual jQuery build. Covers text/textarea/select values, radio selection that isn't the last option, checkbox-group serialization, value-aware checkbox reload, untouched absent fields, and a full save→apply round-trip.
- Wired into the `tests/js` npm `test` script, so the existing CI job runs it. All tests pass.
- Manually verified with multiple loads of a re-run of a lab and so far it is working very well