### PR TITLE
feat: delete a single Lab field version from history modal

### DIFF
--- a/apps/api/routes.py
+++ b/apps/api/routes.py
@@ -815,3 +815,19 @@ def get_lab_field_version(lab_id, field, version):
     if request.args.get("diff"):
         return {"status": "ok", "result": lab_versions.diff_against_current(lab, row)}, 200
     return {"status": "ok", "result": row.content or ""}, 200
+
+
+@blueprint.route('/labs/<lab_id>/field_versions/<field>/<int:version>', methods=["DELETE"])
+@login_required
+def delete_lab_field_version(lab_id, field, version):
+    """Delete one stored version of a tracked Lab field."""
+    lab, error = _get_lab_for_versions(lab_id)
+    if error:
+        return error
+    if field not in lab_versions.TRACKED_FIELDS:
+        return {"status": "fail", "result": f"Unknown field, tracked fields: {', '.join(lab_versions.TRACKED_FIELDS)}"}, 400
+
+    if not lab_versions.delete_version(lab, field, version):
+        return {"status": "fail", "result": "Version not found"}, 404
+    db.session.commit()
+    return {"status": "ok", "result": f"Version v{version} deleted"}, 200

--- a/apps/controllers/lab_versions.py
+++ b/apps/controllers/lab_versions.py
@@ -72,6 +72,15 @@ def get_version(lab, field, version):
     ).first()
 
 
+def delete_version(lab, field, version):
+    """Remove a single stored version. Returns True when a row was deleted."""
+    row = get_version(lab, field, version)
+    if not row:
+        return False
+    db.session.delete(row)
+    return True
+
+
 def diff_against_current(lab, version_row):
     """Unified diff from the stored version to the lab's current field value."""
     old = (version_row.content or "").splitlines()

--- a/apps/templates/pages/labs_edit.html
+++ b/apps/templates/pages/labs_edit.html
@@ -1076,9 +1076,13 @@
         fieldHistoryField = $(this).data('field');
         $('#field-history-title').text(fieldHistoryLabels[fieldHistoryField]);
         $('#field-history-detail').addClass('d-none');
+        $('#modal-field-history').modal('show');
+        loadFieldHistory();
+      });
+
+      async function loadFieldHistory() {
         var items = $('#field-history-items');
         items.html('<tr><td colspan="4">Loading...</td></tr>');
-        $('#modal-field-history').modal('show');
         try {
           const response = await fetch(`/api/labs/${editLabId}/field_versions/${fieldHistoryField}`);
           const data = await response.json();
@@ -1095,16 +1099,20 @@
             row.append($('<td>').text(v.author || '--'));
             var actions = $('<td>');
             actions.append(
-              $('<button type="button" class="btn btn-sm btn-outline-secondary mr-1">Diff vs current</button>')
+              $('<button type="button" class="btn btn-sm btn-outline-secondary mr-1" title="Diff vs current">Diff</button>')
                 .on('click', function () { showFieldVersion(v.version, true); })
             );
             actions.append(
-              $('<button type="button" class="btn btn-sm btn-outline-primary mr-1">View</button>')
+              $('<button type="button" class="btn btn-sm btn-outline-primary mr-1" title="View content">View</button>')
                 .on('click', function () { showFieldVersion(v.version, false); })
             );
             actions.append(
-              $('<button type="button" class="btn btn-sm btn-outline-success">Restore into editor</button>')
+              $('<button type="button" class="btn btn-sm btn-outline-success mr-1" title="Restore into editor">Restore</button>')
                 .on('click', function () { restoreFieldVersionFromApi(v.version); })
+            );
+            actions.append(
+              $('<button type="button" class="btn btn-sm btn-outline-danger" title="Delete this version">Delete</button>')
+                .on('click', function () { deleteFieldVersionFromApi(v.version); })
             );
             row.append(actions);
             items.append(row);
@@ -1112,7 +1120,7 @@
         } catch (err) {
           items.html($('<tr><td colspan="4"></td></tr>').find('td').text('Failed to load history: ' + err.message).end());
         }
-      });
+      }
 
       async function showFieldVersion(version, diff) {
         var url = `/api/labs/${editLabId}/field_versions/${fieldHistoryField}/${version}` + (diff ? '?diff=1' : '');
@@ -1161,6 +1169,23 @@
         }
         restoreFieldVersion(fieldHistoryField, data.result || '');
         $('#modal-field-history').modal('hide');
+      }
+
+      async function deleteFieldVersionFromApi(version) {
+        if (!confirm('Delete version v' + version + '? This cannot be undone.')) {
+          return;
+        }
+        const response = await fetch(`/api/labs/${editLabId}/field_versions/${fieldHistoryField}/${version}`, {
+          method: 'DELETE',
+          credentials: 'same-origin'
+        });
+        const data = await response.json();
+        if (!response.ok) {
+          alert('Failed to delete version: ' + (data.result || 'request failed'));
+          return;
+        }
+        $('#field-history-detail').addClass('d-none');
+        loadFieldHistory();
       }
   </script>
 

--- a/tests/test_lab_field_versions.py
+++ b/tests/test_lab_field_versions.py
@@ -356,3 +356,89 @@ class TestRetention:
         # other fields are unaffected by the manifest pruning
         assert [v.version for v in versions_of(lab.id, "lab_guide")] == [1]
         logout(client)
+
+
+# --- delete a single version ------------------------------------------------
+class TestVersionDelete:
+    """DELETE /api/labs/<lab>/field_versions/<field>/<version>.
+
+    Uses its own lab ("lv Delete Lab") so removing versions never disturbs the
+    other stateful classes above.
+    """
+
+    def _make_lab(self, client, ids):
+        login(client, "lvadmin", "admin123")
+        client.post(
+            "/labs/edit/new",
+            data=lab_form(
+                lab_title="lv Delete Lab",
+                lab_description="x",
+                lab_categories=str(ids["category_id"]),
+                lab_manifest="apiVersion: del-v1",
+            ),
+            follow_redirects=True,
+        )
+        lab = get_lab("lv Delete Lab")
+        # add a second manifest version so we have v1 and v2 to work with
+        client.post(
+            f"/labs/edit/{lab.id}",
+            data=lab_form(
+                lab_title="lv Delete Lab",
+                lab_description="x",
+                lab_categories=str(ids["category_id"]),
+                lab_manifest="apiVersion: del-v2",
+            ),
+            follow_redirects=True,
+        )
+        return lab
+
+    def test_admin_deletes_a_version(self, client, ids):
+        logout(client)
+        lab = self._make_lab(client, ids)
+        assert [v.version for v in versions_of(lab.id, "manifest")] == [1, 2]
+
+        resp = client.delete(f"/api/labs/{lab.id}/field_versions/manifest/1")
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "ok"
+
+        # only v1 is gone; v2 and other fields untouched
+        assert [v.version for v in versions_of(lab.id, "manifest")] == [2]
+        assert [v.version for v in versions_of(lab.id, "lab_guide")] == [1]
+        logout(client)
+
+    def test_delete_unknown_version_404(self, client, ids):
+        login(client, "lvadmin", "admin123")
+        lab = get_lab("lv Delete Lab")
+        resp = client.delete(f"/api/labs/{lab.id}/field_versions/manifest/999")
+        assert resp.status_code == 404
+        logout(client)
+
+    def test_delete_unknown_field_rejected(self, client, ids):
+        login(client, "lvadmin", "admin123")
+        lab = get_lab("lv Delete Lab")
+        resp = client.delete(f"/api/labs/{lab.id}/field_versions/title/1")
+        assert resp.status_code == 400
+        logout(client)
+
+    def test_delete_missing_lab_404(self, client, ids):
+        login(client, "lvadmin", "admin123")
+        resp = client.delete("/api/labs/does-not-exist/field_versions/manifest/1")
+        assert resp.status_code == 404
+        logout(client)
+
+    def test_student_denied_delete(self, client, ids):
+        login(client, "lvstudent", "stud123")
+        lab = get_lab("lv Delete Lab")
+        resp = client.delete(f"/api/labs/{lab.id}/field_versions/manifest/2")
+        assert resp.status_code == 403
+        # nothing was removed
+        assert [v.version for v in versions_of(lab.id, "manifest")] == [2]
+        logout(client)
+
+    def test_labcreator_denied_on_others_lab(self, client, ids):
+        login(client, "lvlabcreator", "lc123")
+        lab = get_lab("lv Delete Lab")  # owned by admin
+        resp = client.delete(f"/api/labs/{lab.id}/field_versions/manifest/2")
+        assert resp.status_code == 403
+        assert [v.version for v in versions_of(lab.id, "manifest")] == [2]
+        logout(client)


### PR DESCRIPTION
Fix #277 

## Summary

Adds the ability to delete an individual version from the **Version History** modal in the Lab editor.

Stacked on top of #280 (diff colors), so this PR's base is `feat/issue-276-field-version-colors` and it only shows the delete changes. Merge #280 first.

## Changes

- **Frontend** (`labs_edit.html`): new red-outlined **Delete** button per row (confirm dialog → DELETE request → refresh list). Shortened the other action labels — "Diff vs current" → "Diff", "Restore into editor" → "Restore" — to keep the actions column compact, with the full text preserved as `title` tooltips. History-loading logic was extracted into a reusable `loadFieldHistory()` so the table can re-render after a delete.
- **API** (`routes.py`): `DELETE /api/labs/<lab_id>/field_versions/<field>/<version>`, reusing the existing `_get_lab_for_versions` access rules (admin/teacher any lab, labcreator own labs only, students denied); 400 for unknown field, 404 for missing lab/version.
- **Controller** (`lab_versions.py`): `delete_version()` helper.

## Tests

New `TestVersionDelete` class in `tests/test_lab_field_versions.py` covering successful delete (only the target removed, other fields untouched), unknown-version 404, unknown-field 400, missing-lab 404, and permission denial for student and for labcreator on another user's lab. Full suite: 21 passed.

Local Tests: to be executed