### PR TITLE
feat: admin web UI for LTI management commands

### DIFF
--- a/apps/lti/keys.py
+++ b/apps/lti/keys.py
@@ -7,6 +7,7 @@ halves stay published in /lti/jwks/ until purged, so platforms validating
 cached tokens keep finding the old kid (publish-then-switch rollover).
 Key file paths are stored in lti_config relative to DATA_DIR.
 """
+import datetime
 import hashlib
 import json
 import os
@@ -90,6 +91,26 @@ def retire_keypair(private_rel, public_rel):
         if not os.path.exists(src):
             continue
         os.replace(src, os.path.join(retired_dir(), os.path.basename(rel_path)))
+
+
+def list_retired_keys():
+    """Return retired key files as {name, retired_at} (mtime), newest first,
+    for the management UI's overview of what is still published in the JWKS
+    during its grace period."""
+    entries = []
+    if not os.path.isdir(retired_dir()):
+        return entries
+    for fname in sorted(os.listdir(retired_dir())):
+        path = os.path.join(retired_dir(), fname)
+        if os.path.isfile(path):
+            entries.append({
+                "name": fname,
+                "retired_at": datetime.datetime.fromtimestamp(
+                    os.path.getmtime(path), tz=datetime.timezone.utc
+                ),
+            })
+    entries.sort(key=lambda e: e["retired_at"], reverse=True)
+    return entries
 
 
 def purge_retired_keys(older_than_days):

--- a/apps/lti/routes.py
+++ b/apps/lti/routes.py
@@ -10,8 +10,8 @@ from urllib.parse import urlparse, urlsplit
 import click
 import requests
 from flask import current_app as app
-from flask import jsonify, redirect, request, session, url_for
-from flask_login import login_user
+from flask import jsonify, redirect, render_template, request, session, url_for
+from flask_login import current_user, login_required, login_user
 from pylti1p3.contrib.flask import (
     FlaskCacheDataStorage,
     FlaskMessageLaunch,
@@ -19,16 +19,18 @@ from pylti1p3.contrib.flask import (
     FlaskRequest,
 )
 from apps import cache, db
-from apps.audit_mixin import get_remote_addr, utcnow
+from apps.audit_mixin import check_user_category, get_remote_addr, utcnow
 from apps.authentication.models import LoginLogging, Users
 from apps.config import app_config
 from apps.lti import blueprint
 from apps.lti.keys import (
     JWKS_CACHE_KEY,
     JWKS_CACHE_TIMEOUT,
+    abs_key_path,
     build_jwks,
     delete_keypair,
     generate_keypair,
+    list_retired_keys,
     purge_retired_keys,
     retire_keypair,
 )
@@ -490,13 +492,18 @@ def register():
     return REGISTRATION_CLOSE_PAGE
 
 
-# ----------------------------------------------------------------------- CLI
+# ------------------------------------------------------- shared management ops
+# The operations below back both the `flask lti ...` CLI commands and the
+# admin web UI (/lti/manage); LtiError carries a human-readable reason the
+# caller maps to a click.ClickException (CLI) or an HTTP error (web).
 
-@blueprint.cli.command("mint-registration-token")
-@click.option("--label", required=True, help="Who this token is for (audit)")
-@click.option("--ttl-hours", default=24, type=int, help="Token validity in hours")
+class LtiError(Exception):
+    """A management operation failed for a reason worth showing the admin."""
+
+
 def mint_registration_token(label, ttl_hours):
-    """Mint a one-time dynamic registration token and print its URL."""
+    """Create a one-time dynamic registration token and return its URL. The
+    plaintext token is only available here (only its hash is stored)."""
     token = secrets.token_urlsafe(32)
     db.session.add(LtiRegistrationToken(
         token_hash=LtiRegistrationToken.hash_token(token),
@@ -504,8 +511,179 @@ def mint_registration_token(label, ttl_hours):
         expires_at=utcnow() + timedelta(hours=ttl_hours),
     ))
     db.session.commit()
+    return f"{lti_base_url()}/register/?token={token}"
+
+
+def _find_registration(issuer, client_id):
+    """Return (row, registration) for the issuer/client_id or raise LtiError."""
+    row = LtiConfig.query.filter_by(
+        issuer=normalize_issuer(issuer), is_deleted=False
+    ).first()
+    if not row:
+        raise LtiError(f"No lti_config entry for issuer {issuer}")
+    registration = row.get_registration(client_id)
+    if not registration:
+        raise LtiError(f"No registration with client_id {client_id} for issuer {issuer}")
+    return row, registration
+
+
+def get_registration_public_key(issuer, client_id=None):
+    """Return a registration's public key PEM (raises LtiError if missing)."""
+    _, registration = _find_registration(issuer, client_id)
+    public_key_file = registration.get("public_key_file")
+    if not public_key_file:
+        raise LtiError("Registration has no public key file recorded")
+    with open(abs_key_path(public_key_file)) as f:
+        return f.read().strip()
+
+
+def rotate_registration_key(issuer, client_id=None):
+    """Rotate a registration's keypair (publish-then-switch): the new key is
+    published in /lti/jwks/, the registration switches to it, and the old key
+    is retired but stays published until purge_retired_keys(). Returns
+    (issuer, client_id, new_private_rel)."""
+    row, registration = _find_registration(issuer, client_id)
+    old_private = registration.get("private_key_file")
+    old_public = registration.get("public_key_file")
+    private_rel, public_rel = generate_keypair(row.issuer, registration["client_id"])
+    registration["private_key_file"] = private_rel
+    registration["public_key_file"] = public_rel
+    row.upsert_registration(registration)
+    db.session.commit()
+    retire_keypair(old_private, old_public)
+    cache.delete(JWKS_CACHE_KEY)
+    return row.issuer, registration["client_id"], private_rel
+
+
+def purge_retired_keys_op(older_than_days):
+    """Delete retired key files older than the grace period; returns names."""
+    removed = purge_retired_keys(older_than_days)
+    cache.delete(JWKS_CACHE_KEY)
+    return removed
+
+
+def list_registrations():
+    """Flat list of every active registration across all issuers, for the
+    management UI (rotate-key/show-public-key act on issuer + client_id)."""
+    result = []
+    for row in LtiConfig.query.filter_by(is_deleted=False).order_by(LtiConfig.issuer).all():
+        for reg in row.config:
+            result.append({
+                "issuer": row.issuer,
+                "client_id": reg.get("client_id"),
+                "deployment_ids": reg.get("deployment_ids") or [],
+                "is_default": bool(reg.get("default")),
+            })
+    return result
+
+
+# ----------------------------------------------------------------- admin web UI
+
+@blueprint.route("/manage", methods=["GET"])
+@login_required
+@check_user_category(["admin"])
+def manage():
+    """LTI management dashboard (MANAGEMENT sidebar): the web equivalent of
+    the `flask lti ...` commands - registrations (rotate key / show public
+    key), one-time registration tokens (mint / list) and retired keys
+    (purge)."""
+    return render_template(
+        "pages/lti_management.html",
+        registrations=list_registrations(),
+        tokens=LtiRegistrationToken.query.order_by(
+            LtiRegistrationToken.id.desc()
+        ).all(),
+        retired_keys=list_retired_keys(),
+    )
+
+
+@blueprint.route("/manage/mint-token", methods=["POST"])
+@login_required
+@check_user_category(["admin"])
+def manage_mint_token():
+    label = (request.form.get("label") or "").strip()
+    if not label:
+        return jsonify({"error": "A label is required (who the token is for)"}), 400
+    try:
+        ttl_hours = int(request.form.get("ttl_hours") or 24)
+    except ValueError:
+        return jsonify({"error": "TTL must be a whole number of hours"}), 400
+    if ttl_hours <= 0:
+        return jsonify({"error": "TTL must be a positive number of hours"}), 400
+    url = mint_registration_token(label, ttl_hours)
+    app.logger.info(
+        f"LTI registration token minted by {current_user.username} "
+        f"label={label!r} ttl_hours={ttl_hours}"
+    )
+    return jsonify({"url": url, "label": label, "ttl_hours": ttl_hours})
+
+
+@blueprint.route("/manage/public-key", methods=["GET"])
+@login_required
+@check_user_category(["admin"])
+def manage_public_key():
+    issuer = request.args.get("issuer", "")
+    client_id = request.args.get("client_id") or None
+    try:
+        pem = get_registration_public_key(issuer, client_id)
+    except LtiError as exc:
+        return jsonify({"error": str(exc)}), 404
+    return jsonify({"issuer": issuer, "client_id": client_id, "public_key": pem})
+
+
+@blueprint.route("/manage/rotate-key", methods=["POST"])
+@login_required
+@check_user_category(["admin"])
+def manage_rotate_key():
+    issuer = request.form.get("issuer", "")
+    client_id = request.form.get("client_id") or None
+    try:
+        issuer, client_id, _ = rotate_registration_key(issuer, client_id)
+    except LtiError as exc:
+        return jsonify({"error": str(exc)}), 404
+    app.logger.info(
+        f"LTI key rotated by {current_user.username} issuer={issuer} client_id={client_id}"
+    )
+    return jsonify({
+        "result": (
+            f"Rotated key for {client_id} @ {issuer}. The old key is retired "
+            "but stays published in /lti/jwks/ until you purge it after the "
+            "grace period."
+        ),
+    })
+
+
+@blueprint.route("/manage/purge-retired-keys", methods=["POST"])
+@login_required
+@check_user_category(["admin"])
+def manage_purge_retired_keys():
+    try:
+        older_than_days = int(request.form.get("older_than_days") or 30)
+    except ValueError:
+        return jsonify({"error": "Grace period must be a whole number of days"}), 400
+    if older_than_days < 0:
+        return jsonify({"error": "Grace period cannot be negative"}), 400
+    removed = purge_retired_keys_op(older_than_days)
+    app.logger.info(
+        f"LTI retired keys purged by {current_user.username} "
+        f"older_than_days={older_than_days} removed={len(removed)}"
+    )
+    return jsonify({
+        "result": f"Removed {len(removed)} retired key file(s)",
+        "removed": removed,
+    })
+
+
+# ----------------------------------------------------------------------- CLI
+
+@blueprint.cli.command("mint-registration-token")
+@click.option("--label", required=True, help="Who this token is for (audit)")
+@click.option("--ttl-hours", default=24, type=int, help="Token validity in hours")
+def mint_registration_token_cmd(label, ttl_hours):
+    """Mint a one-time dynamic registration token and print its URL."""
+    url = mint_registration_token(label, ttl_hours)
     click.echo("Registration URL (shown once, hand it to the LMS admin):")
-    click.echo(f"{lti_base_url()}/register/?token={token}")
+    click.echo(url)
 
 
 @blueprint.cli.command("list-registration-tokens")
@@ -527,18 +705,10 @@ def show_public_key(issuer, client_id):
     Moodle's symptom is a token.php 404 with
     'jwks_helper::fix_jwks_alg(): ... null given' on the first grade/roster
     call (launches still work, they never need platform->tool calls)."""
-    row = LtiConfig.query.filter_by(issuer=normalize_issuer(issuer), is_deleted=False).first()
-    if not row:
-        raise click.ClickException(f"No lti_config entry for issuer {issuer}")
-    registration = row.get_registration(client_id)
-    if not registration:
-        raise click.ClickException(f"No registration with client_id {client_id} for issuer {issuer}")
-    public_key_file = registration.get("public_key_file")
-    if not public_key_file:
-        raise click.ClickException("Registration has no public key file recorded")
-    from apps.lti.keys import abs_key_path
-    with open(abs_key_path(public_key_file)) as f:
-        click.echo(f.read().strip())
+    try:
+        click.echo(get_registration_public_key(issuer, client_id))
+    except LtiError as exc:
+        raise click.ClickException(str(exc))
 
 
 @blueprint.cli.command("rotate-key")
@@ -548,24 +718,12 @@ def rotate_key(issuer, client_id):
     """Rotate a registration's keypair (publish-then-switch): the new key is
     published in /lti/jwks/, the registration switches to it, and the old
     key is retired but stays published until purge-retired-keys."""
-    row = LtiConfig.query.filter_by(issuer=normalize_issuer(issuer), is_deleted=False).first()
-    if not row:
-        raise click.ClickException(f"No lti_config entry for issuer {issuer}")
-    registration = row.get_registration(client_id)
-    if not registration:
-        raise click.ClickException(f"No registration with client_id {client_id} for issuer {issuer}")
-
-    old_private = registration.get("private_key_file")
-    old_public = registration.get("public_key_file")
-    private_rel, public_rel = generate_keypair(row.issuer, registration["client_id"])
-    registration["private_key_file"] = private_rel
-    registration["public_key_file"] = public_rel
-    row.upsert_registration(registration)
-    db.session.commit()
-    retire_keypair(old_private, old_public)
-    cache.delete(JWKS_CACHE_KEY)
+    try:
+        issuer, client_id, private_rel = rotate_registration_key(issuer, client_id)
+    except LtiError as exc:
+        raise click.ClickException(str(exc))
     click.echo(
-        f"Rotated key for issuer={row.issuer} client_id={registration['client_id']}: "
+        f"Rotated key for issuer={issuer} client_id={client_id}: "
         f"new key {private_rel}, old key retired (still published in /lti/jwks/; "
         f"run 'flask lti purge-retired-keys' after the grace period)"
     )
@@ -575,8 +733,7 @@ def rotate_key(issuer, client_id):
 @click.option("--older-than-days", default=30, type=int, help="Grace period in days")
 def purge_retired_keys_cmd(older_than_days):
     """Delete retired key files older than the grace period."""
-    removed = purge_retired_keys(older_than_days)
-    cache.delete(JWKS_CACHE_KEY)
+    removed = purge_retired_keys_op(older_than_days)
     click.echo(f"Removed {len(removed)} retired key file(s)")
     for fname in removed:
         click.echo(f"  {fname}")

--- a/apps/templates/includes/sidebar.html
+++ b/apps/templates/includes/sidebar.html
@@ -147,6 +147,16 @@
               </p>
             </a>
           </li>
+          {% if config.get('ENABLE_LTI') and current_user.category == "admin" %}
+          <li class="nav-item">
+            <a href="{{ url_for('lti_blueprint.manage') }}" class="nav-link {% if request.url_rule.endpoint == 'lti_blueprint.manage' %} active {% endif %}">
+              <i class="nav-icon fas fa-graduation-cap"></i>
+              <p>
+                LTI
+              </p>
+            </a>
+          </li>
+          {% endif %}
           <li class="nav-item has-treeview {% if request.url_rule.endpoint.startswith('k8s_blueprint') %} menu-open {% endif %}">
             <a href="#" class="nav-link {% if request.url_rule.endpoint.startswith('k8s_blueprint') %} active {% endif %}">
               <i class="nav-icon far fa-dharmachakra"></i>

--- a/apps/templates/pages/lti_management.html
+++ b/apps/templates/pages/lti_management.html
@@ -1,0 +1,435 @@
+{% extends "layouts/base.html" %}
+
+{% block title %} LTI Management {% endblock title %}
+
+<!-- Element injected in the BODY element -->
+{% block body_class %} sidebar-mini layout-navbar-fixed {% endblock body_class %}
+
+<!-- Specific Page CSS goes HERE  -->
+{% block stylesheets %}
+
+  <!-- Google Font: Source Sans Pro -->
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
+  <!-- Font Awesome -->
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/fontawesome-free/css/all.min.css') }}">
+  <!-- DataTables -->
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/plugins/datatables-responsive/css/responsive.bootstrap4.min.css') }}">
+  <!-- Theme style -->
+  <link rel="stylesheet" href="{{ url_for('static', filename='assets/css/adminlte.min.css') }}">
+{% endblock stylesheets %}
+
+{% block content %}
+
+  <!-- Content Wrapper. Contains page content -->
+  <div class="content-wrapper">
+    <!-- Content Header (Page header) -->
+    <section class="content-header">
+      <div class="container-fluid">
+        <div class="row mb-2">
+          <div class="col-sm-6">
+            <h1>LTI Management</h1>
+          </div>
+          <div class="col-sm-6">
+            <ol class="breadcrumb float-sm-right">
+              <li class="breadcrumb-item"><a href="{{ url_for('home_blueprint.index') }}">Home</a></li>
+              <li class="breadcrumb-item active">LTI</li>
+            </ol>
+          </div>
+        </div>
+      </div><!-- /.container-fluid -->
+    </section>
+
+    <!-- Main content -->
+    <section class="content">
+
+      <!-- Registrations -->
+      <div class="row">
+        <div class="col-md-12">
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title"><i class="fas fa-plug mr-1"></i> Platform Registrations</h3>
+            </div>
+            <div class="card-body">
+              <p class="text-muted">
+                LTI 1.3 platform registrations (created by dynamic registration).
+                Rotate a registration's signing key or show its public key (PEM) to
+                paste into the LMS when it cannot fetch <code>/lti/jwks/</code>.
+              </p>
+              <table id="tableRegistrations" class="table table-striped display">
+                <thead>
+                  <tr>
+                    <th>Issuer</th>
+                    <th>Client ID</th>
+                    <th>Deployment IDs</th>
+                    <th>Default</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                {% for reg in registrations %}
+                <tr>
+                  <td>{{ reg.issuer }}</td>
+                  <td>{{ reg.client_id }}</td>
+                  <td>{{ reg.deployment_ids | join(', ') }}</td>
+                  <td>{% if reg.is_default %}<span class="badge badge-success">default</span>{% endif %}</td>
+                  <td>
+                    <button type="button" class="btn btn-outline-dark btn-sm btn-show-key"
+                            data-issuer="{{ reg.issuer }}" data-client-id="{{ reg.client_id }}">
+                      <i class="fas fa-key"></i> Public Key
+                    </button>
+                    <button type="button" class="btn btn-outline-warning btn-sm btn-rotate-key"
+                            data-issuer="{{ reg.issuer }}" data-client-id="{{ reg.client_id }}">
+                      <i class="fas fa-sync-alt"></i> Rotate Key
+                    </button>
+                  </td>
+                </tr>
+                {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Registration tokens -->
+      <div class="row">
+        <div class="col-md-12">
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title"><i class="fas fa-ticket-alt mr-1"></i> Registration Tokens</h3>
+              <div class="float-right">
+                <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#modal-mint-token">
+                  <i class="fas fa-plus"></i> Mint Token
+                </button>
+              </div>
+            </div>
+            <div class="card-body">
+              <p class="text-muted">
+                One-time credentials for the dynamic registration endpoint. The token
+                itself is shown only once, at mint time; only its hash is stored.
+              </p>
+              <table id="tableTokens" class="table table-striped display">
+                <thead>
+                  <tr>
+                    <th>ID</th>
+                    <th>Label</th>
+                    <th>Created</th>
+                    <th>Expires</th>
+                    <th>Used</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                {% for token in tokens %}
+                <tr>
+                  <td>{{ token.id }}</td>
+                  <td>{{ token.label }}</td>
+                  <td>{{ token.created_at.strftime('%Y-%m-%d %H:%M') if token.created_at else '-' }}</td>
+                  <td>{{ token.expires_at.strftime('%Y-%m-%d %H:%M') if token.expires_at else '-' }}</td>
+                  <td>{{ token.used_at.strftime('%Y-%m-%d %H:%M') if token.used_at else '-' }}</td>
+                  <td>
+                    {% if token.used_at %}
+                      <span class="badge badge-secondary">used</span>
+                    {% elif token.is_expired %}
+                      <span class="badge badge-danger">expired</span>
+                    {% else %}
+                      <span class="badge badge-success">valid</span>
+                    {% endif %}
+                  </td>
+                </tr>
+                {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Retired keys -->
+      <div class="row">
+        <div class="col-md-12">
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title"><i class="fas fa-archive mr-1"></i> Retired Keys</h3>
+              <div class="float-right">
+                <button type="button" class="btn btn-danger btn-sm" data-toggle="modal" data-target="#modal-purge-keys">
+                  <i class="far fa-trash-alt"></i> Purge Retired Keys
+                </button>
+              </div>
+            </div>
+            <div class="card-body">
+              <p class="text-muted">
+                Rotated keys stay published in <code>/lti/jwks/</code> during a grace
+                period so platforms validating cached tokens keep finding the old key.
+                Purge them once the grace period has passed.
+              </p>
+              <table id="tableRetired" class="table table-striped display">
+                <thead>
+                  <tr>
+                    <th>Key File</th>
+                    <th>Retired At (UTC)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                {% for key in retired_keys %}
+                <tr>
+                  <td>{{ key.name }}</td>
+                  <td>{{ key.retired_at.strftime('%Y-%m-%d %H:%M') }}</td>
+                </tr>
+                {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mint token modal -->
+      <div class="modal fade" id="modal-mint-token">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h4 class="modal-title">Mint Registration Token</h4>
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div class="modal-body">
+              <div class="form-group">
+                <label for="mint-label">Label (who this token is for)</label>
+                <input type="text" class="form-control" id="mint-label" placeholder="e.g. Prof. Smith / Moodle prod">
+              </div>
+              <div class="form-group">
+                <label for="mint-ttl">Validity (hours)</label>
+                <input type="number" class="form-control" id="mint-ttl" value="24" min="1">
+              </div>
+              <div id="mint-result" class="d-none">
+                <label>Registration URL (shown once — hand it to the LMS admin):</label>
+                <div class="input-group">
+                  <input type="text" class="form-control" id="mint-url" readonly>
+                  <div class="input-group-append">
+                    <button type="button" class="btn btn-default" id="mint-copy" title="Copy URL"><i class="far fa-copy"></i></button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="modal-footer justify-content-between">
+              <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+              <button type="button" class="btn btn-primary" id="mint-submit">Mint Token</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Rotate key confirmation modal -->
+      <div class="modal fade" id="modal-rotate-key">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h4 class="modal-title">Rotate Signing Key</h4>
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div class="modal-body">
+              <p>Rotate the signing key for this registration?</p>
+              <ul>
+                <li><strong>Issuer:</strong> <span id="rotate-issuer"></span></li>
+                <li><strong>Client ID:</strong> <span id="rotate-client-id"></span></li>
+              </ul>
+              <p class="text-muted">
+                The new key is published immediately; the old key is retired but stays
+                published in <code>/lti/jwks/</code> until you purge it after the grace period.
+              </p>
+            </div>
+            <div class="modal-footer justify-content-between">
+              <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+              <button type="button" class="btn btn-warning" id="rotate-confirm">Rotate Key</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Purge retired keys modal -->
+      <div class="modal fade" id="modal-purge-keys">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h4 class="modal-title">Purge Retired Keys</h4>
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div class="modal-body">
+              <p>Delete retired key files older than the grace period.</p>
+              <div class="form-group">
+                <label for="purge-days">Grace period (days)</label>
+                <input type="number" class="form-control" id="purge-days" value="30" min="0">
+              </div>
+            </div>
+            <div class="modal-footer justify-content-between">
+              <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+              <button type="button" class="btn btn-danger" id="purge-confirm">Purge</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Show public key modal -->
+      <div class="modal fade" id="modal-show-key">
+        <div class="modal-dialog modal-lg">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h4 class="modal-title">Registration Public Key</h4>
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div class="modal-body">
+              <p class="text-muted">Paste this into the LMS as the tool's RSA key when it cannot fetch <code>/lti/jwks/</code>.</p>
+              <pre id="show-key-pem" style="white-space: pre-wrap; word-break: break-all;"></pre>
+            </div>
+            <div class="modal-footer justify-content-between">
+              <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+              <button type="button" class="btn btn-primary" id="show-key-copy"><i class="far fa-copy"></i> Copy</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </section>
+    <!-- /.content -->
+  </div>
+  <!-- /.content-wrapper -->
+
+{% endblock content %}
+
+<!-- Specific Page JS goes HERE  -->
+{% block javascripts %}
+
+  <!-- jQuery -->
+  <script src="{{ url_for('static', filename='assets/plugins/jquery/jquery.min.js') }}"></script>
+  <!-- Bootstrap 4 -->
+  <script src="{{ url_for('static', filename='assets/plugins/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
+  <!-- DataTables -->
+  <script src="{{ url_for('static', filename='assets/plugins/datatables/jquery.dataTables.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/dataTables.responsive.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='assets/plugins/datatables-responsive/js/responsive.bootstrap4.min.js') }}"></script>
+  <!-- AdminLTE App -->
+  <script src="{{ url_for('static', filename='assets/js/adminlte.min.js') }}"></script>
+  <!-- Page Script -->
+  <script>
+    $(function () {
+      $("#tableRegistrations").DataTable({ responsive: true, autoWidth: false,
+        language: { emptyTable: 'No platform registrations yet' } });
+      $("#tableTokens").DataTable({ responsive: true, autoWidth: false, order: [[0, 'desc']],
+        language: { emptyTable: 'No registration tokens minted yet' } });
+      $("#tableRetired").DataTable({ responsive: true, autoWidth: false,
+        language: { emptyTable: 'No retired keys' } });
+
+      function toast(cls, title, body) {
+        $(document).Toasts('create', { class: cls, title: title, body: body, autohide: true, delay: 5000 });
+      }
+      function showFail(xhr) {
+        var msg = 'Request failed';
+        try { msg = JSON.parse(xhr.responseText).error || msg; } catch (e) {}
+        toast('bg-danger', 'Failure', msg);
+      }
+      function copyText(text) {
+        if (navigator.clipboard) { navigator.clipboard.writeText(text); }
+      }
+
+      // pop success toasts persisted across a reload
+      if (sessionStorage.getItem('msgSuccess')) {
+        toast('bg-success', 'Success', sessionStorage.getItem('msgSuccess'));
+        sessionStorage.removeItem('msgSuccess');
+      }
+
+      // --- mint token -----------------------------------------------------
+      $('#modal-mint-token').on('show.bs.modal', function () {
+        $('#mint-result').addClass('d-none');
+        $('#mint-url').val('');
+        $('#mint-submit').prop('disabled', false);
+      });
+      $('#mint-submit').click(function () {
+        var label = $('#mint-label').val().trim();
+        if (!label) { toast('bg-warning', 'Missing label', 'Please enter a label'); return; }
+        $('#mint-submit').prop('disabled', true);
+        $.ajax({
+          url: '{{ url_for("lti_blueprint.manage_mint_token") }}',
+          type: 'POST',
+          data: { label: label, ttl_hours: $('#mint-ttl').val() },
+        }).done(function (data) {
+          $('#mint-url').val(data.url);
+          $('#mint-result').removeClass('d-none');
+        }).fail(function (xhr) {
+          showFail(xhr);
+          $('#mint-submit').prop('disabled', false);
+        });
+      });
+      $('#mint-copy').click(function () { copyText($('#mint-url').val()); });
+
+      // --- show public key ------------------------------------------------
+      $('.btn-show-key').click(function () {
+        var issuer = $(this).data('issuer');
+        var clientId = $(this).data('client-id');
+        $('#show-key-pem').text('Loading...');
+        $('#modal-show-key').modal('show');
+        $.ajax({
+          url: '{{ url_for("lti_blueprint.manage_public_key") }}',
+          type: 'GET',
+          data: { issuer: issuer, client_id: clientId },
+        }).done(function (data) {
+          $('#show-key-pem').text(data.public_key);
+        }).fail(function (xhr) {
+          $('#modal-show-key').modal('hide');
+          showFail(xhr);
+        });
+      });
+      $('#show-key-copy').click(function () { copyText($('#show-key-pem').text()); });
+
+      // --- rotate key -----------------------------------------------------
+      $('.btn-rotate-key').click(function () {
+        $('#rotate-issuer').text($(this).data('issuer'));
+        $('#rotate-client-id').text($(this).data('client-id'));
+        $('#rotate-confirm')
+          .data('issuer', $(this).data('issuer'))
+          .data('client-id', $(this).data('client-id'));
+        $('#modal-rotate-key').modal('show');
+      });
+      $('#rotate-confirm').click(function () {
+        $(this).prop('disabled', true);
+        $.ajax({
+          url: '{{ url_for("lti_blueprint.manage_rotate_key") }}',
+          type: 'POST',
+          data: { issuer: $(this).data('issuer'), client_id: $(this).data('client-id') },
+        }).done(function (data) {
+          sessionStorage.setItem('msgSuccess', data.result);
+          location.reload();
+        }).fail(function (xhr) {
+          showFail(xhr);
+          $('#rotate-confirm').prop('disabled', false);
+        });
+      });
+
+      // --- purge retired keys --------------------------------------------
+      $('#purge-confirm').click(function () {
+        $(this).prop('disabled', true);
+        $.ajax({
+          url: '{{ url_for("lti_blueprint.manage_purge_retired_keys") }}',
+          type: 'POST',
+          data: { older_than_days: $('#purge-days').val() },
+        }).done(function (data) {
+          sessionStorage.setItem('msgSuccess', data.result);
+          location.reload();
+        }).fail(function (xhr) {
+          showFail(xhr);
+          $('#purge-confirm').prop('disabled', false);
+        });
+      });
+    });
+  </script>
+
+{% endblock javascripts %}

--- a/tests/test_lti.py
+++ b/tests/test_lti.py
@@ -675,3 +675,120 @@ class TestOidcLogin:
         assert location.startswith(ISSUER + "/mod/lti/auth.php")
         assert "state=" in location and "nonce=" in location
         assert "client_id=client-1" in location
+
+
+# --- admin management web UI --------------------------------------------------
+
+def _ensure_user(username, category):
+    """Create (once) a password-login user for the web UI tests."""
+    user = Users.query.filter_by(username=username).first()
+    if not user:
+        user = Users(
+            username=username, password="lti-web-pass",
+            email=f"{username}@lti-web.example", category=category,
+        )
+        db.session.add(user)
+        db.session.commit()
+    return user
+
+
+def _web_login(client, username):
+    return client.post(
+        "/login/",
+        data={"identifier": username, "password": "lti-web-pass", "login": "1"},
+    )
+
+
+class TestManagementWebUI:
+    def test_non_admin_is_rejected(self, client):
+        _ensure_user("ltiwebstudent", "student")
+        _web_login(client, "ltiwebstudent")
+        resp = client.get("/lti/manage")
+        assert b"Unauthorized request" in resp.data
+        client.get("/logout")
+
+    def test_admin_dashboard_lists_registrations(self, client):
+        _seed_registration()
+        _ensure_user("ltiwebadmin", "admin")
+        _web_login(client, "ltiwebadmin")
+        resp = client.get("/lti/manage")
+        assert resp.status_code == 200
+        assert b"LTI Management" in resp.data
+        assert ISSUER.encode() in resp.data
+        assert b"client-1" in resp.data
+
+    def test_mint_token_creates_row_and_returns_url(self, client):
+        _web_login(client, "ltiwebadmin")
+        before = LtiRegistrationToken.query.count()
+        resp = client.post("/lti/manage/mint-token", data={
+            "label": "web-ui token", "ttl_hours": "12",
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "/lti/register/?token=" in data["url"]
+        assert LtiRegistrationToken.query.count() == before + 1
+        row = LtiRegistrationToken.query.order_by(
+            LtiRegistrationToken.id.desc()).first()
+        assert row.label == "web-ui token"
+        # only the hash is stored, never the plaintext token
+        token_value = data["url"].split("token=", 1)[1]
+        assert row.token_hash == LtiRegistrationToken.hash_token(token_value)
+
+    def test_mint_token_requires_label(self, client):
+        _web_login(client, "ltiwebadmin")
+        resp = client.post("/lti/manage/mint-token", data={"label": "  "})
+        assert resp.status_code == 400
+        assert "label" in resp.get_json()["error"].lower()
+
+    def test_show_public_key(self, client):
+        _web_login(client, "ltiwebadmin")
+        resp = client.get("/lti/manage/public-key", query_string={
+            "issuer": ISSUER, "client_id": "client-1",
+        })
+        assert resp.status_code == 200
+        assert "BEGIN PUBLIC KEY" in resp.get_json()["public_key"]
+        # unknown issuer -> 404 with a reason
+        resp = client.get("/lti/manage/public-key", query_string={
+            "issuer": "https://nope.example",
+        })
+        assert resp.status_code == 404
+        assert "No lti_config entry" in resp.get_json()["error"]
+
+    def test_rotate_key_publish_then_switch(self, client):
+        _web_login(client, "ltiwebadmin")
+        row = LtiConfig.query.filter_by(issuer=ISSUER).first()
+        old_public = row.get_registration("client-1")["public_key_file"]
+        resp = client.post("/lti/manage/rotate-key", data={
+            "issuer": ISSUER, "client_id": "client-1",
+        })
+        assert resp.status_code == 200
+        assert "Rotated key" in resp.get_json()["result"]
+        db.session.expire_all()
+        row = LtiConfig.query.filter_by(issuer=ISSUER).first()
+        assert row.get_registration("client-1")["public_key_file"] != old_public
+        assert not os.path.exists(lti_keys.abs_key_path(old_public))
+        assert os.path.basename(old_public) in os.listdir(lti_keys.retired_dir())
+
+    def test_rotate_key_unknown_issuer(self, client):
+        _web_login(client, "ltiwebadmin")
+        resp = client.post("/lti/manage/rotate-key", data={
+            "issuer": "https://nope.example",
+        })
+        assert resp.status_code == 404
+        assert "No lti_config entry" in resp.get_json()["error"]
+
+    def test_purge_retired_keys(self, client):
+        _web_login(client, "ltiwebadmin")
+        # the rotate test above left a retired key behind: the dashboard must
+        # render it (exercises the retired-key row / timestamp formatting)
+        assert os.listdir(lti_keys.retired_dir()) != []
+        resp = client.get("/lti/manage")
+        assert resp.status_code == 200
+        assert b"Retired Keys" in resp.data
+        resp = client.post("/lti/manage/purge-retired-keys", data={
+            "older_than_days": "0",
+        })
+        assert resp.status_code == 200
+        assert "Removed" in resp.get_json()["result"]
+        assert os.listdir(lti_keys.retired_dir()) == []
+        client.get("/logout")


### PR DESCRIPTION
## Summary

Adds an admin-only web UI for the LTI management operations that previously existed only as `flask lti ...` CLI commands, surfaced under the **MANAGEMENT** sidebar section. Covers: `list-registration-tokens`, `mint-registration-token`, `purge-retired-keys`, `rotate-key`, and `show-public-key`.

## Approach

Rather than duplicate logic between CLI and web, the operations are extracted into shared helper functions in `apps/lti/routes.py` (`mint_registration_token`, `get_registration_public_key`, `rotate_registration_key`, `purge_retired_keys_op`, `list_registrations`), backed by a small `LtiError` exception that each layer maps to its own error style — `click.ClickException` for the CLI, JSON HTTP error for the web. The existing CLI commands now call these helpers, so behavior is unchanged.

## Changes

- **`apps/lti/routes.py`** — extracted shared ops; added admin-gated routes (`@login_required` + `@check_user_category(["admin"])`):
  - `GET  /lti/manage` — dashboard
  - `POST /lti/manage/mint-token`
  - `GET  /lti/manage/public-key`
  - `POST /lti/manage/rotate-key`
  - `POST /lti/manage/purge-retired-keys`
  - (list-registration-tokens is rendered directly in the dashboard table)
- **`apps/lti/keys.py`** — added `list_retired_keys()` (name + UTC retire time) for the retired-keys table.
- **`apps/templates/pages/lti_management.html`** — new AdminLTE page: three cards (Registrations, Registration Tokens, Retired Keys) with per-row Public Key / Rotate Key actions and modals for mint/rotate/purge/view. Uses the existing AJAX + toast/`sessionStorage` pattern.
- **`apps/templates/includes/sidebar.html`** — LTI entry in MANAGEMENT, gated on `config.ENABLE_LTI` + admin (mirrors the `ENABLE_CLABS` pattern), so it only appears when the optional module is loaded.
- **`tests/test_lti.py`** — added `TestManagementWebUI`: role gating, dashboard render, token minting (incl. hash-only storage + label validation), public-key display (+ unknown-issuer 404), key rotation (publish-then-switch, old key retired), and purge.

## Testing

- Full suite: **540 passed** (8 new web-UI tests).
- `djlint` clean on the new template and sidebar.
- Local tests: To be done