### PR TITLE
fix(xterm): restore /pty Socket.IO connect under Flask 3.1.3 (bump flask_socketio to 5.6.1)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ gunicorn==26.0.0
 gevent==26.5.0
 eventlet==0.41.0
 Flask-Minify==0.50
-flask_socketio==5.5.1
+flask_socketio==5.6.1
 kubernetes==34.1.0
 markdown2==2.5.4
 flask_mail==0.10.0

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -185,6 +185,40 @@ class TestPtyConnect:
         assert events.xterm_clients["sid1"] is sentinel  # not overwritten
 
 
+# --- Socket.IO connect dispatch (session-management regression) ----------
+class TestSocketIOConnectDispatch:
+    """Regression for the xterm /pty connect crash.
+
+    Under Flask >= 3.1.3, ``RequestContext.session`` became a read-only
+    property. flask_socketio <= 5.5.1 assigned ``ctx.session = session_obj``
+    while managing the per-client session in ``_handle_event``, which raised
+    ``AttributeError: property 'session' of 'RequestContext' object has no
+    setter`` on *every* connect to the ``/pty`` namespace (see requirements.txt
+    pin flask_socketio>=5.6.1).
+
+    Unlike the other tests here, this one drives a real Socket.IO test client so
+    the connect flows through flask_socketio's own ``_handle_event`` - the exact
+    crash site. Calling ``pty_connect`` directly would not exercise it.
+    """
+
+    def test_pty_connect_through_real_dispatch(self, logged_in, monkeypatch):
+        fake_stream = MagicMock()
+        monkeypatch.setattr(events, "k8s", types.SimpleNamespace(
+            get_pod_exec_stream=MagicMock(return_value=fake_stream)))
+        monkeypatch.setattr(events.socketio, "start_background_task", MagicMock())
+
+        client = events.socketio.test_client(
+            flask_app, namespace="/pty", query_string="host=pod/mypod/mycont")
+        try:
+            # Before the fix, constructing/connecting the client raised
+            # AttributeError inside _handle_event; a successful connect proves
+            # the session-management path works under Flask >= 3.1.3.
+            assert client.is_connected("/pty") is True
+            assert events.xterm_clients  # handler ran and registered the session
+        finally:
+            client.disconnect(namespace="/pty")
+
+
 # --- pty_input ----------------------------------------------------------
 class TestPtyInput:
     def test_not_connected_returns_false(self, logged_in):


### PR DESCRIPTION
Fix #287 

## Description of the changes

- Bump `flask_socketio` from `5.5.1` to `5.6.1` and add a regression test for the xterm terminal connect path.

Recent changes pulled Flask up to **3.1.3**, in which `RequestContext.session` became a **read-only property** (backed by `_session`, part of a session-cookie security fix). `flask_socketio 5.5.1` still assigns `ctx.session = session_obj` while managing the per-client session in `_handle_event`, so **every** connect to the `/pty` namespace raised:

```
AttributeError: property 'session' of 'RequestContext' object has no setter
  File ".../flask_socketio/__init__.py", line 816, in _handle_event
    ctx.session = session_obj
```

This broke all xterm terminal sessions (`GET /xterm`). `flask_socketio 5.6.1` assigns `ctx._session` when available, restoring compatibility with Flask ≥ 3.1.3.

## Reviewer notes

- The existing `test_events.py` tests call `pty_connect` **directly** and deliberately bypass Socket.IO's own machinery, so they did **not** catch this bug. The new test drives a real `socketio.test_client` connect through the `/pty` namespace, exercising `flask_socketio._handle_event` — the exact crash site.
- Verified the new test **fails on 5.5.1** with the exact `AttributeError` and **passes on 5.6.1**.
- Full suite green: `540 passed` (events module: `17 passed`).