### PR TITLE
feat: bulk delete for running lab instances and users

### DIFF
--- a/apps/api/routes.py
+++ b/apps/api/routes.py
@@ -97,6 +97,68 @@ def delete_lab(lab_id):
         msg += f"{resource['kind']}/{resource['name']}={status}; "
     return {"status": "ok", "result": msg}, 200
 
+@blueprint.route('/labs', methods=["DELETE"])
+@login_required
+def delete_labs():
+    if current_user.category == "user":
+        return {}, 404
+
+    content = request.get_json(silent=True)
+    if not content or not isinstance(content, list):
+        return {"status": "fail", "result": _("invalid content")}, 400
+
+    labs = []
+    errors = []
+    for lab_id in content:
+        lab = db.session.get(LabInstances, lab_id) if isinstance(lab_id, str) else None
+        if not lab or lab.is_deleted:
+            errors.append(f"Lab instance not found {lab_id=}")
+            continue
+        if current_user.category != "admin" and lab.user_id != current_user.id:
+            errors.append(f"Unauthorized access to this lab {lab_id=}")
+            continue
+        labs.append(lab)
+
+    if errors:
+        return {"status": "fail", "result": _("Invalid labs to delete:") + " " + "<br/>".join(errors)}, 400
+
+    failed = []
+    partial = []
+    for lab in labs:
+        try:
+            results = k8s.delete_resources_by_name(lab.k8s_resources)
+        except Exception as exc:
+            current_app.logger.error(f"Failed to delete resources of lab {lab.id}: {exc}")
+            failed.append(lab.id)
+            continue
+
+        who = "owner" if lab.user_id == current_user.id else "admin"
+        lab.is_deleted = True
+        lab.finish_reason = "Finished by the " + who
+
+        if sum(results) != len(lab.k8s_resources):
+            for idx, resource in enumerate(lab.k8s_resources):
+                if not results[idx]:
+                    partial.append(f"{lab.id}: {resource['kind']}/{resource['name']}")
+
+    try:
+        db.session.commit()
+    except Exception as exc:
+        current_app.logger.error(f"Failed to delete labs: {exc}")
+        return {"status": "fail", "result": _("Failed to save updated data")}, 400
+
+    for user_id in {lab.user_id for lab in labs}:
+        running_labs = LabInstances.query.filter_by(is_deleted=False, user_id=user_id).count()
+        cache.set(f"running_labs-{user_id}", running_labs)
+
+    if failed:
+        return {"status": "fail", "result": _("Failed to delete resources") + ": " + "; ".join(failed)}, 400
+
+    if partial:
+        return {"status": "ok", "result": "Some resources failed to be removed: " + "; ".join(partial)}, 200
+
+    return {"status": "ok", "result": _("Resources removed successfully!")}, 200
+
 @blueprint.route('/nodes', methods=["GET"])
 @login_required
 def get_nodes():
@@ -271,6 +333,22 @@ def delete_user(user_id):
     if labs.count() > 0:
         return {"status": "fail", "result": _("Failed to delete user: user has labs running")}, 400
 
+    _soft_delete_user(user)
+
+    try:
+        db.session.commit()
+    except Exception as exc:
+        current_app.logger.error(f"Failed to delete user {user_id}: {exc}")
+        return {"status": "fail", "result": _("Failed to delete user")}, 400
+
+    return {"status": "ok", "result": _("User deleted successfully")}, 200
+
+
+def _soft_delete_user(user):
+    """Mark a user as deleted, snapshotting and clearing its group memberships.
+
+    Does not commit - the caller is responsible for that.
+    """
     user.is_deleted = True
     deleted = DeletedGroupUsers()
     deleted.object_id = user.id
@@ -283,13 +361,45 @@ def delete_user(user_id):
     user.assistant_of_groups.clear()
     user.owner_of_groups.clear()
 
+
+@blueprint.route('/users/bulk', methods=["DELETE"])
+@login_required
+def delete_users():
+    if current_user.category != "admin":
+        return {"status": "fail", "result": _("Unauthorized access")}, 401
+
+    content = request.get_json(silent=True)
+    if not content or not isinstance(content, list):
+        return {"status": "fail", "result": _("invalid content")}, 400
+
+    users = []
+    errors = []
+    for user_id in content:
+        if not isinstance(user_id, str) or not user_id.isdigit():
+            errors.append(f"Invalid user provided {user_id=}")
+            continue
+        user = db.session.get(Users, int(user_id))
+        if not user or user.is_deleted:
+            errors.append(f"User not found {user_id=}")
+            continue
+        if LabInstances.query.filter_by(user_id=user.id, is_deleted=False).count() > 0:
+            errors.append(f"User has labs running {user_id=}")
+            continue
+        users.append(user)
+
+    if errors:
+        return {"status": "fail", "result": _("Invalid users to delete:") + " " + "<br/>".join(errors)}, 400
+
+    for user in users:
+        _soft_delete_user(user)
+
     try:
         db.session.commit()
     except Exception as exc:
-        current_app.logger.error(f"Failed to delete user {user_id}: {exc}")
-        return {"status": "fail", "result": _("Failed to delete user")}, 400
+        current_app.logger.error(f"Failed to delete users: {exc}")
+        return {"status": "fail", "result": _("Failed to delete users")}, 400
 
-    return {"status": "ok", "result": _("User deleted successfully")}, 200
+    return {"status": "ok", "result": _("Users deleted successfully")}, 200
 
 
 @blueprint.route('/groups/<int:group_id>', methods=["DELETE"])

--- a/doc/release-notes-2.0.13.md
+++ b/doc/release-notes-2.0.13.md
@@ -43,7 +43,7 @@ upgrades, and a big jump in automated test coverage.
 | [#266](https://github.com/hackinsdn/dashboard/pull/266) | Version control for editable Lab fields (manifest, lab guide, extended description) |
 | [#267](https://github.com/hackinsdn/dashboard/pull/267) | LTI 1.3 integration (optional module `lti`) |
 | [#270](https://github.com/hackinsdn/dashboard/pull/270) | Resolve service pods via Discovery API endpoint slices |
-| _(pending)_ | Bulk delete of running Lab instances and of users (`DELETE /api/labs`, `DELETE /api/users/bulk`) |
+| [#290](https://github.com/hackinsdn/dashboard/pull/290) | Bulk delete of running Lab instances and of users (`DELETE /api/labs`, `DELETE /api/users/bulk`) |
 
 ## Fixes
 

--- a/doc/release-notes-2.0.13.md
+++ b/doc/release-notes-2.0.13.md
@@ -1,11 +1,13 @@
 # Release Notes — v2.0.13
 
 This release delivers a large batch of new features across lab management, an
-LTI 1.3 integration, a support-chat system, plus numerous fixes, dependency
-upgrades, and a big jump in automated test coverage.
+LTI 1.3 integration, a support-chat system, full internationalization, plus
+numerous fixes, dependency upgrades, and a big jump in automated test coverage.
 
 ## Highlights
 
+- **Internationalization (EN + pt_BR)** — the whole UI is now translatable, with a
+  navbar language switcher and a per-user language preference.
 - **LTI 1.3 integration** — HackInSDN can now be embedded as an external tool in
   Moodle/LMS platforms, including grade passback.
 - **Support chat** — an in-app chat widget with admin thread management and open-case
@@ -43,6 +45,7 @@ upgrades, and a big jump in automated test coverage.
 | [#266](https://github.com/hackinsdn/dashboard/pull/266) | Version control for editable Lab fields (manifest, lab guide, extended description) |
 | [#267](https://github.com/hackinsdn/dashboard/pull/267) | LTI 1.3 integration (optional module `lti`) |
 | [#270](https://github.com/hackinsdn/dashboard/pull/270) | Resolve service pods via Discovery API endpoint slices |
+| [#286](https://github.com/hackinsdn/dashboard/pull/286) | Internationalization with Flask-Babel: English + Brazilian Portuguese, navbar language switcher, per-user `locale` preference |
 | [#290](https://github.com/hackinsdn/dashboard/pull/290) | Bulk delete of running Lab instances and of users (`DELETE /api/labs`, `DELETE /api/users/bulk`) |
 
 ## Fixes
@@ -55,6 +58,7 @@ upgrades, and a big jump in automated test coverage.
 | [#258](https://github.com/hackinsdn/dashboard/pull/258) | `Users.created_at` can be null for old migrated data |
 | [#259](https://github.com/hackinsdn/dashboard/pull/259) | Fix djlint errors in templates and add lint CI workflow |
 | [#271](https://github.com/hackinsdn/dashboard/pull/271) | Add timeout to kubectl delete operations |
+| [#286](https://github.com/hackinsdn/dashboard/pull/286) | Password-reset e-mails showed a literal `{url_for(...)}` instead of the reset link (missing f-prefix) |
 
 ## Dependencies & Security
 
@@ -74,8 +78,14 @@ upgrades, and a big jump in automated test coverage.
 
 ## Upgrade Notes
 
-- This release includes new Alembic migrations up to **2.0.13**
-  (`2.0.11_add_lti_2.0.12` and `2.0.12_add_lti_launch_context_2.0.13`). Run
-  `flask db upgrade` after deploying.
+- This release includes new Alembic migrations up to **2.0.14**
+  (`2.0.11_add_lti_2.0.12`, `2.0.12_add_lti_launch_context_2.0.13` and
+  `2.0.13_add_users_locale_2.0.14`). Run `flask db upgrade` after deploying.
 - The LTI integration is shipped as an **optional module** (`lti`); enable it only
   where needed.
+- **Translations must be compiled** before the app can serve a non-default locale.
+  The Docker build runs this automatically; for source deployments run
+  `make i18n-compile` to build the `.mo` catalogs. The available locales are
+  controlled by `LANGUAGES` (default `en,pt_BR`), and the fallback by
+  `BABEL_DEFAULT_LOCALE` (default `en`). See [i18n.md](i18n.md) for the
+  maintainer workflow.

--- a/doc/release-notes-2.0.13.md
+++ b/doc/release-notes-2.0.13.md
@@ -59,6 +59,8 @@ numerous fixes, dependency upgrades, and a big jump in automated test coverage.
 | [#259](https://github.com/hackinsdn/dashboard/pull/259) | Fix djlint errors in templates and add lint CI workflow |
 | [#271](https://github.com/hackinsdn/dashboard/pull/271) | Add timeout to kubectl delete operations |
 | [#286](https://github.com/hackinsdn/dashboard/pull/286) | Password-reset e-mails showed a literal `{url_for(...)}` instead of the reset link (missing f-prefix) |
+| [#288](https://github.com/hackinsdn/dashboard/pull/288) | Restore xterm terminal sessions: every `/pty` Socket.IO connect crashed under Flask 3.1.3 (bumps `flask_socketio` to 5.6.1) |
+| [#289](https://github.com/hackinsdn/dashboard/pull/289) | Stop the browser-console crash when an xterm terminal disconnects, and report the process exit code on the Kubernetes exec path |
 
 ## Dependencies & Security
 

--- a/doc/release-notes-2.0.13.md
+++ b/doc/release-notes-2.0.13.md
@@ -43,6 +43,7 @@ upgrades, and a big jump in automated test coverage.
 | [#266](https://github.com/hackinsdn/dashboard/pull/266) | Version control for editable Lab fields (manifest, lab guide, extended description) |
 | [#267](https://github.com/hackinsdn/dashboard/pull/267) | LTI 1.3 integration (optional module `lti`) |
 | [#270](https://github.com/hackinsdn/dashboard/pull/270) | Resolve service pods via Discovery API endpoint slices |
+| _(pending)_ | Bulk delete of running Lab instances and of users (`DELETE /api/labs`, `DELETE /api/users/bulk`) |
 
 ## Fixes
 

--- a/tests/test_api_k8s.py
+++ b/tests/test_api_k8s.py
@@ -212,6 +212,88 @@ class TestDeleteLab:
         logout(client)
 
 
+# --- delete_labs (bulk) -------------------------------------------------
+class TestDeleteLabsBulk:
+    @pytest.fixture
+    def bulk_ids(self, ids):
+        """Two fresh running instances owned by akstudent, plus one by akother."""
+        mine = [LabInstances(user_id=ids["student_id"], lab_id=ids["lab_id"], is_deleted=False) for _ in range(2)]
+        theirs = LabInstances(user_id=ids["other_id"], lab_id=ids["lab_id"], is_deleted=False)
+        for inst in mine + [theirs]:
+            inst.k8s_resources = []
+        db.session.add_all(mine + [theirs])
+        db.session.commit()
+        return {"mine": [i.id for i in mine], "theirs": theirs.id}
+
+    def test_unapproved_user_is_rejected(self, client, bulk_ids):
+        logout(client)
+        login(client, "akpending", "pend123")
+        resp = client.delete("/api/labs", json=bulk_ids["mine"])
+        assert resp.status_code == 404
+        logout(client)
+
+    def test_invalid_payload_is_rejected(self, client, bulk_ids):
+        login(client, "akstudent", "stud123")
+        resp = client.delete("/api/labs", json={"nope": 1})
+        assert resp.status_code == 400
+
+    def test_missing_instance_aborts_whole_batch(self, client, bulk_ids):
+        resp = client.delete("/api/labs", json=[bulk_ids["mine"][0], "does-not-exist"])
+        assert resp.status_code == 400
+        # nothing was deleted
+        assert db.session.get(LabInstances, bulk_ids["mine"][0]).is_deleted is False
+
+    def test_non_owner_is_rejected(self, client, bulk_ids):
+        resp = client.delete("/api/labs", json=[bulk_ids["theirs"]])
+        assert resp.status_code == 400
+        assert db.session.get(LabInstances, bulk_ids["theirs"]).is_deleted is False
+        logout(client)
+
+    def test_owner_can_delete_many(self, client, bulk_ids, monkeypatch):
+        monkeypatch.setattr("apps.api.routes.k8s.delete_resources_by_name", lambda res: [])
+        login(client, "akstudent", "stud123")
+        resp = client.delete("/api/labs", json=bulk_ids["mine"])
+        assert resp.status_code == 200
+        for inst_id in bulk_ids["mine"]:
+            assert db.session.get(LabInstances, inst_id).is_deleted is True
+        logout(client)
+
+    def test_admin_can_delete_other_users_labs(self, client, bulk_ids, monkeypatch):
+        monkeypatch.setattr("apps.api.routes.k8s.delete_resources_by_name", lambda res: [])
+        login(client, "akadmin", "admin123")
+        resp = client.delete("/api/labs", json=[bulk_ids["theirs"]])
+        assert resp.status_code == 200
+        inst = db.session.get(LabInstances, bulk_ids["theirs"])
+        assert inst.is_deleted is True
+        assert inst.finish_reason == "Finished by the admin"
+        logout(client)
+
+    def test_k8s_failure_reports_error(self, client, bulk_ids, monkeypatch):
+        def boom(res):
+            raise RuntimeError("k8s down")
+
+        monkeypatch.setattr("apps.api.routes.k8s.delete_resources_by_name", boom)
+        login(client, "akstudent", "stud123")
+        resp = client.delete("/api/labs", json=bulk_ids["mine"])
+        assert resp.status_code == 400
+        for inst_id in bulk_ids["mine"]:
+            assert db.session.get(LabInstances, inst_id).is_deleted is False
+        logout(client)
+
+    def test_partial_resource_removal_is_reported(self, client, bulk_ids, monkeypatch):
+        inst_id = bulk_ids["mine"][0]
+        inst = db.session.get(LabInstances, inst_id)
+        inst.k8s_resources = [{"kind": "pod", "name": "p1"}, {"kind": "pod", "name": "p2"}]
+        db.session.commit()
+        monkeypatch.setattr("apps.api.routes.k8s.delete_resources_by_name", lambda res: [True, False])
+        login(client, "akstudent", "stud123")
+        resp = client.delete("/api/labs", json=[inst_id])
+        assert resp.status_code == 200
+        assert "pod/p2" in resp.get_json()["result"]
+        assert db.session.get(LabInstances, inst_id).is_deleted is True
+        logout(client)
+
+
 # --- get_nodes ----------------------------------------------------------
 class TestGetNodes:
     def test_unapproved_user_is_rejected(self, client, ids):

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -295,6 +295,70 @@ class TestDeleteApi:
         logout(client)
 
 
+# --- admin-only bulk soft-delete API -------------------------------------
+class TestBulkDeleteApi:
+    @pytest.fixture(scope="class")
+    def bulk_ids(self, ids):
+        """Two fresh deletable users, plus one that still has a running lab."""
+        targets = [
+            Users(username=f"usbulk{n}", password="bulk123", email=f"usbulk{n}@test.local", category="student")
+            for n in range(2)
+        ]
+        busy = Users(username="usbulkbusy", password="bulk123", email="usbulkbusy@test.local", category="student")
+        db.session.add_all(targets + [busy])
+        db.session.commit()
+
+        lab = Labs(title="Bulk Blocker Lab", description="lab used to block bulk user delete")
+        db.session.add(lab)
+        db.session.commit()
+        db.session.add(LabInstances(user_id=busy.id, lab_id=lab.id, is_deleted=False))
+        db.session.commit()
+
+        return {"targets": [str(u.id) for u in targets], "busy": str(busy.id)}
+
+    def test_student_cannot_bulk_delete(self, client, bulk_ids):
+        logout(client)
+        login(client, "usstudent", "stud123")
+        resp = client.delete("/api/users/bulk", json=bulk_ids["targets"])
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_teacher_cannot_bulk_delete(self, client, bulk_ids):
+        login(client, "usteacher", "teach123")
+        resp = client.delete("/api/users/bulk", json=bulk_ids["targets"])
+        assert resp.status_code == 401
+        logout(client)
+
+    def test_invalid_payload_is_rejected(self, client, bulk_ids):
+        login(client, "usadmin", "admin123")
+        resp = client.delete("/api/users/bulk", json={"nope": 1})
+        assert resp.status_code == 400
+
+    def test_unknown_user_aborts_whole_batch(self, client, bulk_ids):
+        resp = client.delete("/api/users/bulk", json=[bulk_ids["targets"][0], "999999"])
+        assert resp.status_code == 400
+        assert db.session.get(Users, int(bulk_ids["targets"][0])).is_deleted is False
+
+    def test_running_lab_aborts_whole_batch(self, client, bulk_ids):
+        resp = client.delete("/api/users/bulk", json=bulk_ids["targets"] + [bulk_ids["busy"]])
+        assert resp.status_code == 400
+        assert b"labs running" in resp.data
+        for user_id in bulk_ids["targets"]:
+            assert db.session.get(Users, int(user_id)).is_deleted is False
+
+    def test_admin_can_bulk_delete(self, client, bulk_ids):
+        resp = client.delete("/api/users/bulk", json=bulk_ids["targets"])
+        assert resp.status_code == 200
+        for user_id in bulk_ids["targets"]:
+            assert db.session.get(Users, int(user_id)).is_deleted is True
+
+    def test_already_deleted_user_is_rejected(self, client, bulk_ids):
+        client.delete("/api/users/bulk", json=bulk_ids["targets"])
+        resp = client.delete("/api/users/bulk", json=bulk_ids["targets"])
+        assert resp.status_code == 400
+        logout(client)
+
+
 # --- approval notes -------------------------------------------------------
 class TestApprovalNotes:
     def test_pending_user_sees_note_form_on_waiting_page(self, client, ids):


### PR DESCRIPTION
## Summary

Adds the two bulk-delete endpoints the frontend was already calling but that had no server-side implementation:

- `DELETE /api/labs` — called by `running.html` when more than one lab instance is selected
- `DELETE /api/users/bulk` — called by `users.html` when more than one user is selected

Both mirror the existing single-item routes (`delete_lab()` / `delete_user()`).

## Behavior

**`DELETE /api/labs`** — rejects unapproved users (404), accepts a JSON list of lab-instance ids, deletes the k8s resources, and soft-deletes each instance with the usual `owner`/`admin` finish reason. Refreshes the `running_labs-<user_id>` cache for **each** affected user, since an admin can delete across users (the single-lab route only ever refreshed `current_user`).

**`DELETE /api/users/bulk`** — admin-only, applies the same "user still has labs running" guard as `delete_user()`.

Both validate the whole batch up front: any unknown id, already-deleted item, or ownership violation returns 400 with a per-item error list and mutates nothing, so a bad id can't leave the operation half applied. This follows the existing `bulk_approve_users()` pattern.

`_soft_delete_user()` is extracted so `delete_user()` and `delete_users()` share the `DeletedGroupUsers` snapshot + group-clearing logic instead of duplicating it.

## Testing

Added `TestDeleteLabsBulk` (`tests/test_api_k8s.py`) and `TestBulkDeleteApi` (`tests/test_users.py`) covering role rejection, invalid payloads, batch abort on a bad id, non-owner rejection, admin cross-user delete, k8s failure, and partial resource removal.

Full suite: 556 passed.

## Note on the base branch

This is stacked on `i18n` (#286) rather than `main`, because it was cut from that branch and `routes.py` here touches lines that #286 rewrote (the `_()` wrappers). It should merge into `i18n` and reach `main` once #286 lands.
