### PR TITLE
feat: add configurable timeout for Kubernetes API calls

### DIFF
--- a/apps/config.py
+++ b/apps/config.py
@@ -109,6 +109,11 @@ class Config(object):
     K8S_NAMESPACE = os.getenv('K8S_NAMESPACE', "")
     K8S_CONFIG = os.path.expanduser(os.getenv("KUBECONFIG", "~/.kube/config"))
     K8S_AVOID_NODES = [n.strip() for n in os.getenv("K8S_AVOID_NODES", "").split(",") if n.strip()]
+    # Timeout (in seconds) applied to every Kubernetes API call, so the app does
+    # not hang indefinitely when the API server is unreachable/unavailable. It is
+    # passed as `_request_timeout` to the kubernetes client library and as
+    # `timeout` to the kubectl subprocess invocations.
+    K8S_REQUEST_TIMEOUT = float(os.getenv("K8S_REQUEST_TIMEOUT", "10"))
 
     # Base URL
     BASE_URL = os.getenv("BASE_URL", 'https://dashboard.hackinsdn.ufba.br')

--- a/apps/controllers/kubernetes.py
+++ b/apps/controllers/kubernetes.py
@@ -47,6 +47,9 @@ class K8sController():
         self.k8s_client = client.ApiClient()
         self.k8s_avoid_nodes = set(app_config.K8S_AVOID_NODES)
         self.k8s_nodes_geotag = app_config.TESTBED_NODES_GEOTAG
+        # timeout (seconds) for every Kubernetes API call, so the app does not
+        # hang indefinitely when the API server is unreachable
+        self.request_timeout = app_config.K8S_REQUEST_TIMEOUT
 
         self.identifiers = {
             "pod_hash": self.get_pod_hash,
@@ -70,7 +73,7 @@ class K8sController():
     def list_pods(self):
         now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
         pods = self.v1_api.list_namespaced_pod(
-            namespace=self.namespace
+            namespace=self.namespace, _request_timeout=self.request_timeout
         )
         response = []
         for pod in pods.items:
@@ -98,7 +101,7 @@ class K8sController():
     def list_deployments(self):
         now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
         deployments = self.apps_v1_api.list_namespaced_deployment(
-            namespace=self.namespace
+            namespace=self.namespace, _request_timeout=self.request_timeout
         )
         response = []
         for dep in deployments.items:
@@ -120,7 +123,7 @@ class K8sController():
     def list_services(self):
         now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
         services = self.v1_api.list_namespaced_service(
-            namespace=self.namespace
+            namespace=self.namespace, _request_timeout=self.request_timeout
         )
         response = []
         for srv in services.items:
@@ -149,7 +152,7 @@ class K8sController():
                 owners.add(resource["uid"])
 
         deployments = self.apps_v1_api.list_namespaced_deployment(
-            namespace=self.namespace,
+            namespace=self.namespace, _request_timeout=self.request_timeout,
         )
         dep_uid = {}
         for dep in deployments.items:
@@ -163,7 +166,7 @@ class K8sController():
         owners.update(dep_uid.keys())
 
         replica_sets = self.apps_v1_api.list_namespaced_replica_set(
-            namespace=self.namespace
+            namespace=self.namespace, _request_timeout=self.request_timeout
         )
         rs_uid_to_dep = {}
         for rs in replica_sets.items:
@@ -180,7 +183,7 @@ class K8sController():
         app_pod_map = defaultdict(list)
         pods_by_uid = {}
         pods = self.v1_api.list_namespaced_pod(
-            namespace=self.namespace
+            namespace=self.namespace, _request_timeout=self.request_timeout
         )
         for pod in pods.items:
             pods_by_uid[pod.metadata.uid] = pod
@@ -227,7 +230,7 @@ class K8sController():
 
         service_to_pods = defaultdict(list)
         endpoint_slices = self.discovery_api.list_namespaced_endpoint_slice(
-            namespace=self.namespace
+            namespace=self.namespace, _request_timeout=self.request_timeout
         )
         for slice_item in endpoint_slices.items:
             slice_pods = []
@@ -240,7 +243,7 @@ class K8sController():
                 service_to_pods[own_ref.uid].extend(slice_pods)
 
         services = self.v1_api.list_namespaced_service(
-            namespace=self.namespace,
+            namespace=self.namespace, _request_timeout=self.request_timeout,
         )
         for srv in services.items:
             srv_labels = srv.metadata.labels or {}
@@ -291,7 +294,8 @@ class K8sController():
         labs = defaultdict(list)
 
         deployments = self.apps_v1_api.list_namespaced_deployment(
-            namespace=self.namespace, label_selector=label_selector
+            namespace=self.namespace, label_selector=label_selector,
+            _request_timeout=self.request_timeout,
         )
         dep_uid = {}
         for dep in deployments.items:
@@ -315,7 +319,7 @@ class K8sController():
             })
 
         replica_sets = self.apps_v1_api.list_namespaced_replica_set(
-            namespace=self.namespace
+            namespace=self.namespace, _request_timeout=self.request_timeout
         )
         rs_uid_to_dep = {}
         for rs in replica_sets.items:
@@ -328,7 +332,7 @@ class K8sController():
         pod_services = {}
         app_pod_map = defaultdict(list)
         pods = self.v1_api.list_namespaced_pod(
-            namespace=self.namespace
+            namespace=self.namespace, _request_timeout=self.request_timeout
         )
         for pod in pods.items:
             pod_labels = pod.metadata.labels or {}
@@ -377,7 +381,8 @@ class K8sController():
             })
 
         services = self.v1_api.list_namespaced_service(
-            namespace=self.namespace, label_selector=label_selector
+            namespace=self.namespace, label_selector=label_selector,
+            _request_timeout=self.request_timeout,
         )
         for srv in services.items:
             srv_labels = srv.metadata.labels or {}
@@ -418,7 +423,8 @@ class K8sController():
 
         ## ConfigMap
         config_maps = self.v1_api.list_namespaced_config_map(
-            namespace=self.namespace, label_selector=label_selector
+            namespace=self.namespace, label_selector=label_selector,
+            _request_timeout=self.request_timeout,
         )
         for cfg in config_maps.items:
             cfg_labels = cfg.metadata.labels or {}
@@ -464,7 +470,7 @@ class K8sController():
             return
         self.nodes = {}
         self.ready_nodes = []
-        resp = self.v1_api.list_node()
+        resp = self.v1_api.list_node(_request_timeout=self.request_timeout)
         for node in resp.items:
             self.nodes[node.metadata.name] = node
             # update ready_nodes unless we should avoid this node
@@ -539,9 +545,12 @@ class K8sController():
                 ["kubectl", "get", resource["kind"], resource["name"], "-o", "json"],
                 capture_output=True,
                 text=True,
-                check=True
+                check=True,
+                timeout=self.request_timeout,
             )
             result = json.loads(result.stdout)
+        except subprocess.TimeoutExpired as exc:
+            raise Exception(f"Timeout while getting k8s resource: {exc}")
         except subprocess.CalledProcessError as exc:
             raise Exception(f"Failed to get k8s resource: {exc} -- {exc.stderr}")
         except Exception as exc:
@@ -559,6 +568,7 @@ class K8sController():
                 self.k8s_client,
                 data=resource,
                 namespace=self.namespace,
+                _request_timeout=self.request_timeout,
             )
             return k8s_objs[0].to_dict()
         try:
@@ -567,9 +577,12 @@ class K8sController():
                 input=json.dumps(resource),
                 capture_output=True,
                 text=True,
-                check=True
+                check=True,
+                timeout=self.request_timeout,
             )
             result = json.loads(result.stdout)
+        except subprocess.TimeoutExpired as exc:
+            raise Exception(f"Timeout while creating k8s resource: {exc}")
         except subprocess.CalledProcessError as exc:
             raise Exception(f"Failed to create k8s resource: {exc} -- {exc.stderr}")
         except Exception as exc:
@@ -583,8 +596,12 @@ class K8sController():
                 ["kubectl", "delete", resource["kind"], resource["name"], "--timeout=10s"],
                 capture_output=True,
                 text=True,
-                check=True
+                check=True,
+                timeout=self.request_timeout,
             )
+        except subprocess.TimeoutExpired as exc:
+            current_app.logger.error(f"Timeout while deleting k8s resource: {exc}")
+            return False
         except subprocess.CalledProcessError as exc:
             current_app.logger.error(f"Failed to delete k8s resource: {exc} -- {exc.stderr}")
             return False
@@ -688,6 +705,7 @@ class K8sController():
                     type="kubernetes.io/dockerconfigjson",
                     data={".dockerconfigjson": docker_config},
                 ),
+                _request_timeout=self.request_timeout,
             )
         except Exception as exc:
             msg = f"Failed to create secret: {exc}"
@@ -707,7 +725,8 @@ class K8sController():
     def get_pod_by_name(self, pod):
         """Return pod by its name."""
         pod = self.v1_api.read_namespaced_pod(
-            name=pod["name"], namespace=self.namespace
+            name=pod["name"], namespace=self.namespace,
+            _request_timeout=self.request_timeout,
         )
         pod_dict = pod.to_dict()
         pod_dict["is_ok"] = pod.status.phase == "Running"
@@ -716,7 +735,8 @@ class K8sController():
     def get_deployment_by_name(self, deployment):
         """Return deployment by its name."""
         deployment = self.apps_v1_api.read_namespaced_deployment(
-            name=deployment["name"], namespace=self.namespace
+            name=deployment["name"], namespace=self.namespace,
+            _request_timeout=self.request_timeout,
         )
         dep_dict = deployment.to_dict()
         dep_dict["is_ok"] = deployment.status.replicas == deployment.status.ready_replicas
@@ -725,7 +745,8 @@ class K8sController():
     def get_service_by_name(self, service):
         """Return service by its name."""
         service = self.v1_api.read_namespaced_service(
-            name=service["name"], namespace=self.namespace
+            name=service["name"], namespace=self.namespace,
+            _request_timeout=self.request_timeout,
         )
         service_dict = service.to_dict()
         service_dict["is_ok"] = True
@@ -734,7 +755,8 @@ class K8sController():
     def get_config_map_by_name(self, config_map):
         """Return config_map by its name."""
         config_map = self.v1_api.read_namespaced_config_map(
-            name=config_map["name"], namespace=self.namespace
+            name=config_map["name"], namespace=self.namespace,
+            _request_timeout=self.request_timeout,
         )
         config_map_dict = config_map.to_dict()
         config_map_dict["is_ok"] = True
@@ -760,7 +782,8 @@ class K8sController():
         """Delete pod by its name."""
         try:
             self.v1_api.delete_namespaced_pod(
-                name=pod["name"], namespace=self.namespace
+                name=pod["name"], namespace=self.namespace,
+                _request_timeout=self.request_timeout,
             )
         except Exception as exc:
             current_app.logger.warning(f"Failed to delete pod {pod['name']} {exc}")
@@ -771,7 +794,8 @@ class K8sController():
         """Delete deployment by its name."""
         try:
             self.apps_v1_api.delete_namespaced_deployment(
-                name=deployment["name"], namespace=self.namespace
+                name=deployment["name"], namespace=self.namespace,
+                _request_timeout=self.request_timeout,
             )
         except Exception as exc:
             current_app.logger.warning(f"Failed to delete deployment {deployment['name']} {exc}")
@@ -782,7 +806,8 @@ class K8sController():
         """Delete service by its name."""
         try:
             self.v1_api.delete_namespaced_service(
-                name=service["name"], namespace=self.namespace
+                name=service["name"], namespace=self.namespace,
+                _request_timeout=self.request_timeout,
             )
         except Exception as exc:
             current_app.logger.warning(f"Failed to delete service {service['name']} {exc}")
@@ -793,7 +818,8 @@ class K8sController():
         """Delete config_map by its name."""
         try:
             self.v1_api.delete_namespaced_config_map(
-                name=config_map["name"], namespace=self.namespace
+                name=config_map["name"], namespace=self.namespace,
+                _request_timeout=self.request_timeout,
             )
         except Exception as exc:
             current_app.logger.warning(f"Failed to delete configmap {config_map['name']} {exc}")
@@ -805,7 +831,8 @@ class K8sController():
         name = secret["name"] if isinstance(secret, dict) else secret
         try:
             self.v1_api.delete_namespaced_secret(
-                name=name, namespace=self.namespace
+                name=name, namespace=self.namespace,
+                _request_timeout=self.request_timeout,
             )
         except Exception as exc:
             current_app.logger.warning(f"Failed to delete secret {name}: {exc}")

--- a/apps/events.py
+++ b/apps/events.py
@@ -127,7 +127,11 @@ def pty_connect(auth):
     if kind == "clab":
         kind = "pod"
         start_script = f"ssh {container}"
-    client_stream = k8s.get_pod_exec_stream(pod, container, start_script)
+    try:
+        client_stream = k8s.get_pod_exec_stream(pod, container, start_script)
+    except Exception as exc:
+        current_app.logger.error(f"Failed to open exec stream to {pod=} {container=}: {exc}")
+        return False
     xterm_clients[session_id] = client_stream
     socketio.start_background_task(read_and_forward_k8s_stream_output, session_id, client_stream)
     current_app.logger.info(f"client added to xterm_clients {session_id=}")

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -80,6 +80,8 @@ Here are some options you can use to configure Dashboard HackInSDN:
 
 - `K8S_NAMESPACE`: default namespace that will be used
 
+- `K8S_REQUEST_TIMEOUT`: timeout (in seconds) applied to every Kubernetes API call, so the application does not hang indefinitely when the API server is unreachable/unavailable (default: `10`)
+
 - `SECRET_KEY`: used to create session IDs and other secrets on the application. Choose a secret key for you to use among container restarts to avoid session being invalidated
 
 - `BASE_URL`: used basically to create the redirect URL when submitting external Oauth2 authentication

--- a/tests/test_k8s_controller.py
+++ b/tests/test_k8s_controller.py
@@ -66,10 +66,15 @@ def _app_context():
         yield
 
 
+# a distinctive value so tests can assert it is threaded into every API call
+TEST_TIMEOUT = 7.0
+
+
 @pytest.fixture()
 def ctrl(monkeypatch):
     """A fully-wired K8sController with the kube client mocked out."""
     monkeypatch.setattr(k8s_module.app_config, "K8S_NAMESPACE", "test-ns")
+    monkeypatch.setattr(k8s_module.app_config, "K8S_REQUEST_TIMEOUT", TEST_TIMEOUT)
     monkeypatch.setattr(k8s_module.config, "load_kube_config", lambda **k: None)
     monkeypatch.setattr(k8s_module.client, "CoreV1Api", lambda: MagicMock())
     monkeypatch.setattr(k8s_module.client, "AppsV1Api", lambda: MagicMock())
@@ -354,3 +359,128 @@ class TestMoreByName:
             side_effect=RuntimeError("boom")
         )
         assert ctrl.delete_config_map_by_name({"name": "c1"}) is False
+
+
+# --- request timeout ----------------------------------------------------
+class TestRequestTimeout:
+    """The controller must thread a configurable timeout into every call so a
+    stalled API server cannot hang the whole application."""
+
+    def test_timeout_from_config(self, ctrl):
+        assert ctrl.request_timeout == TEST_TIMEOUT
+
+    def test_list_pods_passes_timeout(self, ctrl):
+        ctrl.v1_api.list_namespaced_pod = MagicMock(
+            return_value=types.SimpleNamespace(items=[])
+        )
+        ctrl.list_pods()
+        _, kwargs = ctrl.v1_api.list_namespaced_pod.call_args
+        assert kwargs["_request_timeout"] == TEST_TIMEOUT
+
+    def test_list_deployments_passes_timeout(self, ctrl):
+        ctrl.apps_v1_api.list_namespaced_deployment = MagicMock(
+            return_value=types.SimpleNamespace(items=[])
+        )
+        ctrl.list_deployments()
+        _, kwargs = ctrl.apps_v1_api.list_namespaced_deployment.call_args
+        assert kwargs["_request_timeout"] == TEST_TIMEOUT
+
+    def test_list_services_passes_timeout(self, ctrl):
+        ctrl.v1_api.list_namespaced_service = MagicMock(
+            return_value=types.SimpleNamespace(items=[])
+        )
+        ctrl.list_services()
+        _, kwargs = ctrl.v1_api.list_namespaced_service.call_args
+        assert kwargs["_request_timeout"] == TEST_TIMEOUT
+
+    def test_update_nodes_passes_timeout(self, ctrl):
+        ctrl.v1_api.list_node = MagicMock(return_value=types.SimpleNamespace(items=[]))
+        ctrl.nodes_last_updated = 0
+        ctrl.update_nodes()
+        _, kwargs = ctrl.v1_api.list_node.call_args
+        assert kwargs["_request_timeout"] == TEST_TIMEOUT
+
+    def test_read_pod_passes_timeout(self, ctrl):
+        pod = MagicMock()
+        pod.to_dict.return_value = {}
+        pod.status.phase = "Running"
+        ctrl.v1_api.read_namespaced_pod = MagicMock(return_value=pod)
+        ctrl.get_pod_by_name({"name": "p1"})
+        _, kwargs = ctrl.v1_api.read_namespaced_pod.call_args
+        assert kwargs["_request_timeout"] == TEST_TIMEOUT
+
+    def test_delete_pod_passes_timeout(self, ctrl):
+        ctrl.v1_api.delete_namespaced_pod = MagicMock()
+        ctrl.delete_pod_by_name({"name": "p1"})
+        _, kwargs = ctrl.v1_api.delete_namespaced_pod.call_args
+        assert kwargs["_request_timeout"] == TEST_TIMEOUT
+
+    def test_create_registry_secret_passes_timeout(self, ctrl):
+        ctrl.v1_api.create_namespaced_secret = MagicMock()
+        ctrl.create_registry_secret("s1", "reg.io", "bob", "pw")
+        _, kwargs = ctrl.v1_api.create_namespaced_secret.call_args
+        assert kwargs["_request_timeout"] == TEST_TIMEOUT
+
+    def test_create_from_dict_passes_timeout(self, ctrl, monkeypatch):
+        created = MagicMock()
+        created.to_dict.return_value = {"kind": "Pod"}
+        capture = {}
+
+        def fake_create(client, data, namespace, _request_timeout):
+            capture["_request_timeout"] = _request_timeout
+            return [created]
+
+        monkeypatch.setattr(k8s_module, "create_from_dict", fake_create)
+        ctrl.create_k8s_resource({"kind": "Pod", "metadata": {}})
+        assert capture["_request_timeout"] == TEST_TIMEOUT
+
+    def test_subprocess_get_passes_timeout(self, ctrl, monkeypatch):
+        capture = {}
+
+        def fake_run(*a, **k):
+            capture.update(k)
+            return _completed(json.dumps({}))
+
+        monkeypatch.setattr(k8s_module.subprocess, "run", fake_run)
+        ctrl.get_k8s_resource({"kind": "Foo", "name": "f1"})
+        assert capture["timeout"] == TEST_TIMEOUT
+
+    def test_subprocess_delete_passes_timeout(self, ctrl, monkeypatch):
+        capture = {}
+
+        def fake_run(*a, **k):
+            capture.update(k)
+            return _completed("")
+
+        monkeypatch.setattr(k8s_module.subprocess, "run", fake_run)
+        ctrl.delete_k8s_resource({"kind": "Foo", "name": "f1"})
+        assert capture["timeout"] == TEST_TIMEOUT
+
+
+# --- timeout / connectivity error handling ------------------------------
+class TestTimeoutHandling:
+    """A stalled server surfaces as a timeout; each wrapper must handle it in
+    the same way it handles any other failure (raise vs. return False)."""
+
+    def test_get_k8s_resource_timeout_raises(self, ctrl, monkeypatch):
+        def boom(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="kubectl", timeout=k.get("timeout"))
+
+        monkeypatch.setattr(k8s_module.subprocess, "run", boom)
+        with pytest.raises(Exception, match="Timeout while getting"):
+            ctrl.get_k8s_resource({"kind": "Foo", "name": "f1"})
+
+    def test_create_k8s_resource_timeout_raises(self, ctrl, monkeypatch):
+        def boom(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="kubectl", timeout=k.get("timeout"))
+
+        monkeypatch.setattr(k8s_module.subprocess, "run", boom)
+        with pytest.raises(Exception, match="Timeout while creating"):
+            ctrl.create_k8s_resource({"kind": "Topology", "metadata": {}})
+
+    def test_delete_k8s_resource_timeout_returns_false(self, ctrl, monkeypatch):
+        def boom(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="kubectl", timeout=k.get("timeout"))
+
+        monkeypatch.setattr(k8s_module.subprocess, "run", boom)
+        assert ctrl.delete_k8s_resource({"kind": "Foo", "name": "f1"}) is False

--- a/tests/test_k8s_tape.py
+++ b/tests/test_k8s_tape.py
@@ -61,6 +61,7 @@ flask_app.config["TESTING"] = True
 
 TAPE = os.path.join(os.path.dirname(__file__), "data", "k8s_tape.yaml")
 NAMESPACE = "hackinsdn"
+REQUEST_TIMEOUT = 30.0
 
 
 # --- rebuild the taped JSON into real kubernetes model objects ----------
@@ -152,6 +153,7 @@ def _app_context():
 def ctrl(monkeypatch):
     """A fully-wired K8sController with the kube client patched out."""
     monkeypatch.setattr(k8s_module.app_config, "K8S_NAMESPACE", NAMESPACE)
+    monkeypatch.setattr(k8s_module.app_config, "K8S_REQUEST_TIMEOUT", REQUEST_TIMEOUT)
     monkeypatch.setattr(k8s_module.config, "load_kube_config", lambda **k: None)
     monkeypatch.setattr(k8s_module.client, "CoreV1Api", lambda: MagicMock())
     monkeypatch.setattr(k8s_module.client, "AppsV1Api", lambda: MagicMock())
@@ -415,10 +417,12 @@ class TestDeleteResourcesByName:
 
         assert results == [True, True]
         ctrl.apps_v1_api.delete_namespaced_deployment.assert_called_once_with(
-            name="helloworld-hackinsdn-18fb2637c46a47", namespace=NAMESPACE
+            name="helloworld-hackinsdn-18fb2637c46a47", namespace=NAMESPACE,
+            _request_timeout=REQUEST_TIMEOUT,
         )
         ctrl.v1_api.delete_namespaced_service.assert_called_once_with(
-            name="helloworld-hackinsdn-18fb2637c46a47", namespace=NAMESPACE
+            name="helloworld-hackinsdn-18fb2637c46a47", namespace=NAMESPACE,
+            _request_timeout=REQUEST_TIMEOUT,
         )
 
     def test_delete_failure_returns_false(self, ctrl):
@@ -441,7 +445,7 @@ class TestListPods:
         ) as mock_list:
             pods = ctrl.list_pods()
 
-        mock_list.assert_called_once_with(namespace=NAMESPACE)
+        mock_list.assert_called_once_with(namespace=NAMESPACE, _request_timeout=REQUEST_TIMEOUT)
         assert len(pods) == 2
         by_name = {p["name"]: p for p in pods}
 
@@ -480,7 +484,7 @@ class TestListDeployments:
         ) as mock_list:
             deployments = ctrl.list_deployments()
 
-        mock_list.assert_called_once_with(namespace=NAMESPACE)
+        mock_list.assert_called_once_with(namespace=NAMESPACE, _request_timeout=REQUEST_TIMEOUT)
         assert len(deployments) == 2
         by_name = {d["name"]: d for d in deployments}
 
@@ -513,7 +517,7 @@ class TestListServices:
         ) as mock_list:
             services = ctrl.list_services()
 
-        mock_list.assert_called_once_with(namespace=NAMESPACE)
+        mock_list.assert_called_once_with(namespace=NAMESPACE, _request_timeout=REQUEST_TIMEOUT)
         assert len(services) == 2
         by_name = {s["name"]: s for s in services}
 


### PR DESCRIPTION
## What

Adds a configurable timeout to every Kubernetes API call made by the controller, so the application no longer hangs indefinitely when the API server is unreachable or unavailable.

## Why

`K8sController` issued kubernetes client-library calls and `kubectl` subprocesses with **no timeout**. If the API server stalled, requests (dashboards, lab status, node maps, exec terminals, etc.) would block indefinitely and tie up workers.

## Changes

- **New config option** `K8S_REQUEST_TIMEOUT` (`apps/config.py`) — env-configurable, **default `10` seconds**.
- **Controller** (`apps/controllers/kubernetes.py`):
  - Reads `self.request_timeout` from config in `__init__`.
  - Threads `_request_timeout=self.request_timeout` into all **25** client-library calls (`list_*`, `read_*`, `delete_*`, `create_namespaced_secret`, `list_node`) and into `create_from_dict`.
  - Adds `timeout=self.request_timeout` to the **3** `kubectl` subprocess calls, with an explicit `except subprocess.TimeoutExpired` branch each (`get`/`create` re-raise a clear "Timeout while…" error; `delete` logs and returns `False`).
- **Unhandled exception** (`apps/events.py`): the socketio `pty_connect` handler called `get_pod_exec_stream()` with no error handling — the one call site not already wrapped by a caller. Now wrapped so a stalled API server logs and rejects the connection instead of crashing the handler.
- **Docs**: `doc/INSTALL.md` documents the new option.
- **Tests**: new `TestRequestTimeout` and `TestTimeoutHandling` in `test_k8s_controller.py`; updated exact-signature assertions in `test_k8s_tape.py`.

## Notes for reviewers

- The interactive exec stream (`connect_get_namespaced_pod_exec`) is **intentionally left without** `_request_timeout` — a request timeout would break long-lived terminal sessions.
- Data-returning methods (`list_pods`, `get_lab_resources`, `get_resources_by_name`, …) still let exceptions propagate on purpose: every route-level caller already wraps them in `try/except`, and some (e.g. the API status endpoint) rely on propagation to return the correct error status. Only the one genuinely unprotected call site (`pty_connect`) got new handling.

## Testing

Full suite passes: `572 passed`.