### PR TITLE
feat: multiple kubeconfigs with failover for the Kubernetes controller

### DIFF
--- a/apps/config.py
+++ b/apps/config.py
@@ -107,13 +107,28 @@ class Config(object):
 
     # Kubernetes
     K8S_NAMESPACE = os.getenv('K8S_NAMESPACE', "")
-    K8S_CONFIG = os.path.expanduser(os.getenv("KUBECONFIG", "~/.kube/config"))
+    # KUBECONFIG may list several kubeconfig files separated by commas. They are
+    # treated as redundant (HA) access paths to the *same* cluster: one is used
+    # at a time and, when it fails for a connectivity/auth reason, the controller
+    # fails over to the next one. A single path (the common case) behaves exactly
+    # as before. NOTE: comma is the separator on purpose -- a colon-separated
+    # KUBECONFIG is interpreted by kubectl/the client lib as files to *merge*.
+    K8S_CONFIGS = [
+        os.path.expanduser(p.strip())
+        for p in os.getenv("KUBECONFIG", "~/.kube/config").split(",")
+        if p.strip()
+    ]
+    # Backward-compatible alias: the first (preferred) kubeconfig path.
+    K8S_CONFIG = K8S_CONFIGS[0] if K8S_CONFIGS else ""
     K8S_AVOID_NODES = [n.strip() for n in os.getenv("K8S_AVOID_NODES", "").split(",") if n.strip()]
     # Timeout (in seconds) applied to every Kubernetes API call, so the app does
     # not hang indefinitely when the API server is unreachable/unavailable. It is
     # passed as `_request_timeout` to the kubernetes client library and as
     # `timeout` to the kubectl subprocess invocations.
     K8S_REQUEST_TIMEOUT = float(os.getenv("K8S_REQUEST_TIMEOUT", "10"))
+    # Number of failovers within a 5-minute window that flags the kubeconfig set
+    # as "flapping" (surfaced in get_statistics() and logged once as an ERROR).
+    K8S_FLAP_THRESHOLD = int(os.getenv("K8S_FLAP_THRESHOLD", "3"))
 
     # Base URL
     BASE_URL = os.getenv("BASE_URL", 'https://dashboard.hackinsdn.ufba.br')

--- a/apps/controllers/kubernetes.py
+++ b/apps/controllers/kubernetes.py
@@ -7,6 +7,9 @@ import json
 import yaml
 import string
 import re
+import socket
+import threading
+import functools
 import traceback
 import datetime
 import uuid
@@ -14,16 +17,196 @@ import random
 import subprocess
 import base64
 
+import urllib3
+
 from kubernetes import config, client
 from kubernetes.stream import stream
 from kubernetes.utils import create_from_dict, duration, parse_quantity
+from kubernetes.client.exceptions import ApiException
+from kubernetes.config.config_exception import ConfigException
 
 from flask import current_app
 from flask_login import current_user
-from collections import defaultdict
+from collections import defaultdict, deque
 
 from apps.config import app_config
 from apps.utils import format_duration
+
+
+# kubectl stderr fragments that indicate the API server is unreachable or the
+# credentials in the current kubeconfig were rejected -> worth failing over to
+# the next kubeconfig. Anything else (NotFound, AlreadyExists, validation, ...)
+# means the cluster answered a valid request and must NOT trigger a failover.
+_KUBECTL_FAILOVER_STRINGS = (
+    "unable to connect to the server",
+    "connection refused",
+    "i/o timeout",
+    "tls handshake timeout",
+    "no route to host",
+    "eof",
+    "unauthorized",
+    "you must be logged in",
+    "the server has asked for the client to provide credentials",
+    "forbidden",
+)
+
+# ApiException HTTP statuses that mean "try another kubeconfig": auth failures
+# (an HA path may carry an expired/invalid credential) and server-side / no
+# response conditions.
+_AUTH_STATUSES = (401, 403)
+
+
+class _FailoverError(Exception):
+    """A connectivity/auth failure a wrapper raises to trigger failover while
+    still carrying a human-friendly message (so the message survives when all
+    kubeconfigs are exhausted and the error propagates to the caller)."""
+
+    def __init__(self, reason, message):
+        self.reason = reason
+        super().__init__(message)
+
+
+def _kubectl_stderr_is_failover(stderr):
+    """True when a kubectl stderr indicates a connectivity/auth failure."""
+    if not stderr:
+        return False
+    low = stderr.lower()
+    return any(s in low for s in _KUBECTL_FAILOVER_STRINGS)
+
+
+def _is_failover_error(exc):
+    """Classify an exception as a failover trigger (connectivity or auth).
+
+    Connectivity: timeouts, connection errors, API status 0/None, HTTP 5xx, and
+    kubeconfig build/load errors (a broken standby file). Auth: HTTP 401/403.
+    Every other ApiException (a valid request the cluster answered: 400/404/409/
+    422/...) returns False so it propagates to the caller unchanged.
+    """
+    if isinstance(exc, _FailoverError):
+        return True
+    if isinstance(exc, ApiException):
+        status = exc.status or 0
+        return status == 0 or status in _AUTH_STATUSES or status >= 500
+    if isinstance(exc, subprocess.TimeoutExpired):
+        return True
+    if isinstance(exc, subprocess.CalledProcessError):
+        return _kubectl_stderr_is_failover(exc.stderr)
+    if isinstance(exc, (ConfigException, OSError)):
+        # broken/absent kubeconfig for this endpoint -> move to the next one
+        return True
+    return isinstance(exc, (
+        urllib3.exceptions.MaxRetryError,
+        urllib3.exceptions.ReadTimeoutError,
+        urllib3.exceptions.ConnectTimeoutError,
+        urllib3.exceptions.ProtocolError,
+        socket.timeout,
+        TimeoutError,
+        ConnectionError,
+    ))
+
+
+def _reason_for(exc):
+    """A short, log/metric-friendly tag for why a failover happened."""
+    if isinstance(exc, _FailoverError):
+        return exc.reason
+    if isinstance(exc, ApiException):
+        status = exc.status or 0
+        if status == 401:
+            return "auth_401"
+        if status == 403:
+            return "auth_403"
+        if status >= 500:
+            return "server_5xx"
+        return "conn_error"
+    if isinstance(exc, subprocess.TimeoutExpired):
+        return "timeout"
+    if isinstance(exc, subprocess.CalledProcessError):
+        low = (exc.stderr or "").lower()
+        if "unauthorized" in low or "you must be logged in" in low or "credentials" in low:
+            return "auth"
+        if "forbidden" in low:
+            return "auth"
+        return "conn_refused"
+    if isinstance(exc, (ConfigException, OSError)):
+        return "config_error"
+    if isinstance(exc, (urllib3.exceptions.ReadTimeoutError,
+                        urllib3.exceptions.ConnectTimeoutError,
+                        socket.timeout, TimeoutError)):
+        return "timeout"
+    return "conn_refused"
+
+
+_RAISE = object()  # sentinel: re-raise the last error when all kubeconfigs fail
+
+
+def with_failover(method=None, *, default=_RAISE):
+    """Retry a controller method against the next kubeconfig on a failover error.
+
+    Sticky + circular: the active endpoint is advanced only when the call fails
+    for a connectivity/auth reason, and each endpoint is tried at most once per
+    call. When every kubeconfig has failed, the last error is re-raised -- unless
+    ``default`` is given, in which case it is returned instead (used by the
+    best-effort delete/secret helpers that historically returned False rather
+    than raising).
+    """
+    def decorate(method):
+        @functools.wraps(method)
+        def wrapper(self, *args, **kwargs):
+            if not self._endpoints:
+                # disabled controller: behave as the single-config code path
+                return method(self, *args, **kwargs)
+            last_exc = None
+            for _ in range(len(self._endpoints)):
+                ep = self._current_endpoint()
+                try:
+                    return method(self, *args, **kwargs)
+                except Exception as exc:
+                    if not _is_failover_error(exc):
+                        raise
+                    last_exc = exc
+                    self._record_failover(ep, exc)
+                    self._rotate_from(ep)
+            if default is not _RAISE:
+                current_app.logger.error(
+                    f"k8s: all kubeconfigs failed for {method.__name__}: {last_exc}"
+                )
+                return default
+            raise last_exc
+        return wrapper
+
+    # support both @with_failover and @with_failover(default=...)
+    return decorate(method) if callable(method) else decorate
+
+
+class _KubeEndpoint:
+    """One kubeconfig file and its (lazily built) API clients.
+
+    Each endpoint owns an isolated ``client.Configuration`` so switching the
+    active endpoint never mutates state shared with another one.
+    """
+
+    def __init__(self, path):
+        self.path = path
+        self.built = False
+        self.v1_api = None
+        self.apps_v1_api = None
+        self.discovery_api = None
+        self.k8s_client = None
+
+    def ensure_built(self, lock):
+        if self.built:
+            return
+        with lock:
+            if self.built:
+                return
+            cfg = client.Configuration()
+            config.load_kube_config(config_file=self.path, client_configuration=cfg)
+            api = client.ApiClient(configuration=cfg)
+            self.v1_api = client.CoreV1Api(api)
+            self.apps_v1_api = client.AppsV1Api(api)
+            self.discovery_api = client.DiscoveryV1Api(api)
+            self.k8s_client = api
+            self.built = True
 
 
 class K8sController():
@@ -31,25 +214,23 @@ class K8sController():
 
     def __init__(self):
         self.namespace = app_config.K8S_NAMESPACE
-        self.v1_api = None
+        # failover state must exist even when the controller is disabled, since
+        # the client properties read self._endpoints.
+        self._lock = threading.Lock()
+        self._endpoints = []
+        self._active_idx = 0
+        self._flap_logged = False
+        self._failover_stats = None
         if not self.namespace:
             return
-        try:
-            config.load_kube_config(config_file=app_config.K8S_CONFIG)
-        except Exception as exc:
-            msg = f"Error while loading kube config ({app_config.K8S_CONFIG}): {exc}"
-            err = traceback.format_exc().replace("\n", ", ")
-            print(msg + " -- " + err)
-            return
-        self.v1_api = client.CoreV1Api()
-        self.apps_v1_api = client.AppsV1Api()
-        self.discovery_api = client.DiscoveryV1Api()
-        self.k8s_client = client.ApiClient()
-        self.k8s_avoid_nodes = set(app_config.K8S_AVOID_NODES)
-        self.k8s_nodes_geotag = app_config.TESTBED_NODES_GEOTAG
         # timeout (seconds) for every Kubernetes API call, so the app does not
         # hang indefinitely when the API server is unreachable
         self.request_timeout = app_config.K8S_REQUEST_TIMEOUT
+        self.flap_threshold = app_config.K8S_FLAP_THRESHOLD
+        self._endpoints = [_KubeEndpoint(p) for p in app_config.K8S_CONFIGS]
+        self._init_failover_stats()
+        self.k8s_avoid_nodes = set(app_config.K8S_AVOID_NODES)
+        self.k8s_nodes_geotag = app_config.TESTBED_NODES_GEOTAG
 
         self.identifiers = {
             "pod_hash": self.get_pod_hash,
@@ -59,7 +240,147 @@ class K8sController():
         }
         self.nodes = {}
         self.ready_nodes = []
-        self.nodes_last_updated = 0 
+        self.nodes_last_updated = 0
+
+        # eagerly build the preferred endpoint so a misconfiguration surfaces at
+        # startup (mirrors the old behaviour); standbys stay lazy. A failure
+        # here is non-fatal: the failover machinery will try it (and the others)
+        # again on the first real call.
+        try:
+            self._current_endpoint().ensure_built(self._lock)
+        except Exception as exc:
+            msg = f"Error while loading kube config ({app_config.K8S_CONFIG}): {exc}"
+            err = traceback.format_exc().replace("\n", ", ")
+            print(msg + " -- " + err)
+
+    # -- multi-kubeconfig plumbing ----------------------------------------
+
+    def _current_endpoint(self):
+        """Active endpoint (not built); None when the controller is disabled."""
+        if not self._endpoints:
+            return None
+        return self._endpoints[self._active_idx]
+
+    def _client(self, attr):
+        """Return the active endpoint's client, building it lazily."""
+        ep = self._current_endpoint()
+        if ep is None:
+            return None
+        ep.ensure_built(self._lock)
+        return getattr(ep, attr)
+
+    @property
+    def v1_api(self):
+        return self._client("v1_api")
+
+    @property
+    def apps_v1_api(self):
+        return self._client("apps_v1_api")
+
+    @property
+    def discovery_api(self):
+        return self._client("discovery_api")
+
+    @property
+    def k8s_client(self):
+        return self._client("k8s_client")
+
+    def _kubectl_base(self):
+        """kubectl command prefix pinned to the active kubeconfig."""
+        ep = self._current_endpoint()
+        if ep is None:
+            return ["kubectl"]
+        return ["kubectl", "--kubeconfig", ep.path]
+
+    def _init_failover_stats(self):
+        active = self._endpoints[0].path if self._endpoints else None
+        self._failover_stats = {
+            "active_path": active,
+            "active_since": time.time(),
+            "total_failovers": 0,
+            "per_endpoint": {
+                ep.path: {"failovers": 0, "last_error": None, "last_failover_ts": 0.0}
+                for ep in self._endpoints
+            },
+            "recent": deque(maxlen=50),
+        }
+
+    def _rotate_from(self, failed_ep):
+        """Advance the active endpoint, but only if it is still the failed one.
+
+        The compare-and-swap keeps a burst of concurrent failures (gevent
+        greenlets all hitting the same dead endpoint) from skipping past healthy
+        endpoints: the fleet advances exactly one step.
+        """
+        with self._lock:
+            if not self._endpoints or self._endpoints[self._active_idx] is not failed_ep:
+                return
+            self._active_idx = (self._active_idx + 1) % len(self._endpoints)
+            new_ep = self._endpoints[self._active_idx]
+            self._failover_stats["active_path"] = new_ep.path
+            self._failover_stats["active_since"] = time.time()
+        current_app.logger.info(f"k8s active kubeconfig is now {new_ep.path}")
+
+    def _record_failover(self, failed_ep, exc):
+        """Count a failover, log it, and edge-trigger the flapping alarm."""
+        reason = _reason_for(exc)
+        now = time.time()
+        n_endpoints = len(self._endpoints)
+        next_path = failed_ep.path
+        if n_endpoints > 1:
+            nxt_idx = (self._endpoints.index(failed_ep) + 1) % n_endpoints
+            next_path = self._endpoints[nxt_idx].path
+        with self._lock:
+            st = self._failover_stats
+            st["total_failovers"] += 1
+            pe = st["per_endpoint"].setdefault(
+                failed_ep.path,
+                {"failovers": 0, "last_error": None, "last_failover_ts": 0.0},
+            )
+            pe["failovers"] += 1
+            pe["last_error"] = f"{type(exc).__name__}: {reason}"
+            pe["last_failover_ts"] = now
+            st["recent"].append({
+                "ts": now, "from": failed_ep.path, "to": next_path, "reason": reason,
+            })
+            recent_5m = sum(1 for e in st["recent"] if now - e["ts"] <= 300)
+        current_app.logger.warning(
+            f"k8s failover: {failed_ep.path} -> {next_path} reason={reason} ({exc})"
+        )
+        # edge-triggered so a flapping set is logged once, not on every rotation
+        if recent_5m >= self.flap_threshold and not self._flap_logged:
+            self._flap_logged = True
+            current_app.logger.error(
+                f"k8s endpoints flapping: {recent_5m} failovers in last 5m"
+            )
+        elif recent_5m < self.flap_threshold:
+            self._flap_logged = False
+
+    def get_failover_stats(self):
+        """Failover metrics for get_statistics()/health; None when <2 configs."""
+        if len(self._endpoints) < 2:
+            return None
+        now = time.time()
+        with self._lock:
+            st = self._failover_stats
+            recent_5m = sum(1 for e in st["recent"] if now - e["ts"] <= 300)
+            active_path = st["active_path"]
+            return {
+                "active": active_path,
+                "active_since": st["active_since"],
+                "total_failovers": st["total_failovers"],
+                "failovers_last_5m": recent_5m,
+                "is_flapping": recent_5m >= self.flap_threshold,
+                "endpoints": [
+                    {
+                        "path": ep.path,
+                        "failovers": st["per_endpoint"].get(ep.path, {}).get("failovers", 0),
+                        "last_error": st["per_endpoint"].get(ep.path, {}).get("last_error"),
+                        "active": ep.path == active_path,
+                    }
+                    for ep in self._endpoints
+                ],
+            }
 
     def try_get_app(self, port_name):
         if not port_name:
@@ -70,6 +391,7 @@ class K8sController():
                 return app + "://"
         return "http://"
 
+    @with_failover
     def list_pods(self):
         now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
         pods = self.v1_api.list_namespaced_pod(
@@ -98,6 +420,7 @@ class K8sController():
             })
         return response
 
+    @with_failover
     def list_deployments(self):
         now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
         deployments = self.apps_v1_api.list_namespaced_deployment(
@@ -120,6 +443,7 @@ class K8sController():
             })
         return response
 
+    @with_failover
     def list_services(self):
         now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
         services = self.v1_api.list_namespaced_service(
@@ -141,6 +465,7 @@ class K8sController():
             })
         return response
 
+    @with_failover
     def get_lab_resources(self, resources, published_ports={}):
         labs = []
         owners = set()
@@ -282,6 +607,7 @@ class K8sController():
 
         return labs
 
+    @with_failover
     def get_labs_by_user(self, f_user_uid, f_lab_id=None):
         if not self.v1_api:
             return []
@@ -465,6 +791,7 @@ class K8sController():
         self.update_nodes()
         return random.choice(self.ready_nodes)
 
+    @with_failover
     def update_nodes(self):
         if time.time() - self.nodes_last_updated < 60:
             return
@@ -538,11 +865,12 @@ class K8sController():
 
         return True, data
 
+    @with_failover
     def get_k8s_resource(self, resource):
         """Get k8s resource using kubectl."""
         try:
             result = subprocess.run(
-                ["kubectl", "get", resource["kind"], resource["name"], "-o", "json"],
+                self._kubectl_base() + ["get", resource["kind"], resource["name"], "-o", "json"],
                 capture_output=True,
                 text=True,
                 check=True,
@@ -550,8 +878,10 @@ class K8sController():
             )
             result = json.loads(result.stdout)
         except subprocess.TimeoutExpired as exc:
-            raise Exception(f"Timeout while getting k8s resource: {exc}")
+            raise _FailoverError("timeout", f"Timeout while getting k8s resource: {exc}")
         except subprocess.CalledProcessError as exc:
+            if _kubectl_stderr_is_failover(exc.stderr):
+                raise _FailoverError(_reason_for(exc), f"Failed to get k8s resource: {exc} -- {exc.stderr}")
             raise Exception(f"Failed to get k8s resource: {exc} -- {exc.stderr}")
         except Exception as exc:
             raise Exception(f"Failed to get k8s resource: {exc}")
@@ -561,8 +891,16 @@ class K8sController():
             result["is_ok"] = True
         return result
 
+    @with_failover
     def create_k8s_resource(self, resource):
-        """Create k8s resource trying to use kubernetes lib and fallback to kubectl."""
+        """Create k8s resource trying to use kubernetes lib and fallback to kubectl.
+
+        Failover granularity is deliberately this single-resource call (not
+        create_lab): if the active endpoint dies mid-manifest, only the failing
+        doc is retried on the sibling endpoint (same cluster) so the lab still
+        completes; a genuine 409/AlreadyExists is not a failover error and flows
+        into create_lab's rollback.
+        """
         if resource["kind"] in ["Pod", "Service", "Deployment", "ConfigMap"]:
             k8s_objs = create_from_dict(
                 self.k8s_client,
@@ -573,7 +911,7 @@ class K8sController():
             return k8s_objs[0].to_dict()
         try:
             result = subprocess.run(
-                ["kubectl", "create", "-f", "-", "-o", "json"],
+                self._kubectl_base() + ["create", "-f", "-", "-o", "json"],
                 input=json.dumps(resource),
                 capture_output=True,
                 text=True,
@@ -582,27 +920,31 @@ class K8sController():
             )
             result = json.loads(result.stdout)
         except subprocess.TimeoutExpired as exc:
-            raise Exception(f"Timeout while creating k8s resource: {exc}")
+            raise _FailoverError("timeout", f"Timeout while creating k8s resource: {exc}")
         except subprocess.CalledProcessError as exc:
+            if _kubectl_stderr_is_failover(exc.stderr):
+                raise _FailoverError(_reason_for(exc), f"Failed to create k8s resource: {exc} -- {exc.stderr}")
             raise Exception(f"Failed to create k8s resource: {exc} -- {exc.stderr}")
         except Exception as exc:
             raise Exception(f"Failed to create k8s resource: {exc}")
         return result
 
+    @with_failover(default=False)
     def delete_k8s_resource(self, resource):
         """Delete k8s resource using kubectl."""
         try:
             result = subprocess.run(
-                ["kubectl", "delete", resource["kind"], resource["name"], "--timeout=10s"],
+                self._kubectl_base() + ["delete", resource["kind"], resource["name"], "--timeout=10s"],
                 capture_output=True,
                 text=True,
                 check=True,
                 timeout=self.request_timeout,
             )
         except subprocess.TimeoutExpired as exc:
-            current_app.logger.error(f"Timeout while deleting k8s resource: {exc}")
-            return False
+            raise _FailoverError("timeout", f"Timeout while deleting k8s resource: {exc}")
         except subprocess.CalledProcessError as exc:
+            if _kubectl_stderr_is_failover(exc.stderr):
+                raise _FailoverError(_reason_for(exc), f"Failed to delete k8s resource: {exc} -- {exc.stderr}")
             current_app.logger.error(f"Failed to delete k8s resource: {exc} -- {exc.stderr}")
             return False
         except Exception as exc:
@@ -680,6 +1022,7 @@ class K8sController():
 
         return True, results
 
+    @with_failover(default=(False, "Failed to create secret: all kubeconfigs unreachable"))
     def create_registry_secret(self, name, server, username, password):
         """Create to pull an image from a private container image registry or repository."""
         auth = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("utf-8")
@@ -708,6 +1051,8 @@ class K8sController():
                 _request_timeout=self.request_timeout,
             )
         except Exception as exc:
+            if _is_failover_error(exc):
+                raise  # let @with_failover try the next kubeconfig
             msg = f"Failed to create secret: {exc}"
             err = traceback.format_exc().replace("\n", ", ")
             current_app.logger.error(msg + " -- " + err)
@@ -722,6 +1067,7 @@ class K8sController():
         """Return all pods with a certain lab_id label."""
         return []
 
+    @with_failover
     def get_pod_by_name(self, pod):
         """Return pod by its name."""
         pod = self.v1_api.read_namespaced_pod(
@@ -732,6 +1078,7 @@ class K8sController():
         pod_dict["is_ok"] = pod.status.phase == "Running"
         return pod_dict
 
+    @with_failover
     def get_deployment_by_name(self, deployment):
         """Return deployment by its name."""
         deployment = self.apps_v1_api.read_namespaced_deployment(
@@ -742,6 +1089,7 @@ class K8sController():
         dep_dict["is_ok"] = deployment.status.replicas == deployment.status.ready_replicas
         return dep_dict
 
+    @with_failover
     def get_service_by_name(self, service):
         """Return service by its name."""
         service = self.v1_api.read_namespaced_service(
@@ -752,6 +1100,7 @@ class K8sController():
         service_dict["is_ok"] = True
         return service_dict
 
+    @with_failover
     def get_config_map_by_name(self, config_map):
         """Return config_map by its name."""
         config_map = self.v1_api.read_namespaced_config_map(
@@ -778,6 +1127,7 @@ class K8sController():
                 results.append(self.get_k8s_resource(resource))
         return results
 
+    @with_failover(default=False)
     def delete_pod_by_name(self, pod):
         """Delete pod by its name."""
         try:
@@ -786,10 +1136,13 @@ class K8sController():
                 _request_timeout=self.request_timeout,
             )
         except Exception as exc:
+            if _is_failover_error(exc):
+                raise
             current_app.logger.warning(f"Failed to delete pod {pod['name']} {exc}")
             return False
         return True
 
+    @with_failover(default=False)
     def delete_deployment_by_name(self, deployment):
         """Delete deployment by its name."""
         try:
@@ -798,10 +1151,13 @@ class K8sController():
                 _request_timeout=self.request_timeout,
             )
         except Exception as exc:
+            if _is_failover_error(exc):
+                raise
             current_app.logger.warning(f"Failed to delete deployment {deployment['name']} {exc}")
             return False
         return True
 
+    @with_failover(default=False)
     def delete_service_by_name(self, service):
         """Delete service by its name."""
         try:
@@ -810,10 +1166,13 @@ class K8sController():
                 _request_timeout=self.request_timeout,
             )
         except Exception as exc:
+            if _is_failover_error(exc):
+                raise
             current_app.logger.warning(f"Failed to delete service {service['name']} {exc}")
             return False
         return True
 
+    @with_failover(default=False)
     def delete_config_map_by_name(self, config_map):
         """Delete config_map by its name."""
         try:
@@ -822,10 +1181,13 @@ class K8sController():
                 _request_timeout=self.request_timeout,
             )
         except Exception as exc:
+            if _is_failover_error(exc):
+                raise
             current_app.logger.warning(f"Failed to delete configmap {config_map['name']} {exc}")
             return False
         return True
 
+    @with_failover(default=False)
     def delete_secret_by_name(self, secret):
         """Delete secret by its name."""
         name = secret["name"] if isinstance(secret, dict) else secret
@@ -835,6 +1197,8 @@ class K8sController():
                 _request_timeout=self.request_timeout,
             )
         except Exception as exc:
+            if _is_failover_error(exc):
+                raise
             current_app.logger.warning(f"Failed to delete secret {name}: {exc}")
             return False
         return True
@@ -946,14 +1310,20 @@ class K8sController():
             pods_capacity = int(node.status.capacity.get("pods", 0))
             total_pods += pods_capacity
 
-        return {
+        stats = {
             "total_cpu_capacity": total_cpu_capacity,
             "total_memory_capacity": self.humanbytes(total_memory_capacity),
             "total_storage_capacity": self.humanbytes(total_storage_capacity),
             "total_pods": total_pods,
             "total_nodes": total_nodes,
         }
+        # only present when more than one kubeconfig is configured
+        failover = self.get_failover_stats()
+        if failover:
+            stats["kubeconfig"] = failover
+        return stats
 
+    @with_failover
     def get_pod_exec_stream(self, pod, container, start_script=None):
         if start_script is None:
             start_script = 'if [ -x /bin/bash ]; then exec /bin/bash; else exec /bin/sh; fi'

--- a/doc/multi-kubeconfig-failover-design.md
+++ b/doc/multi-kubeconfig-failover-design.md
@@ -1,0 +1,481 @@
+# Design: Multi-kubeconfig failover for the Kubernetes controller
+
+> **Status: implemented.** `apps/config.py` (`K8S_CONFIGS`, `K8S_FLAP_THRESHOLD`),
+> `apps/controllers/kubernetes.py` (`_KubeEndpoint`, `with_failover`,
+> `_is_failover_error`/`_reason_for`, `_FailoverError`, client properties,
+> failover metrics + `get_statistics` block), `env-template`, and tests
+> (`tests/test_k8s_failover.py` plus fixture updates in
+> `tests/test_k8s_controller.py` / `tests/test_k8s_tape.py`). One
+> implementation refinement vs. this doc: the kubectl/best-effort helpers raise
+> a typed `_FailoverError` carrying the friendly message (so it survives
+> exhaustion), and `with_failover(default=...)` lets the delete/secret helpers
+> keep their historical "return False on total failure" contract.
+
+## Goal
+
+Let `K8sController` (`apps/controllers/kubernetes.py`) work against **several
+kubeconfig files** that are redundant access paths to the **same logical
+cluster** (HA endpoints / credentials). At any moment exactly one kubeconfig is
+*active*. When a call through the active kubeconfig fails for a **connectivity
+or auth** reason (timeout, connection refused, API server 5xx / unreachable, or
+`401`/`403` from an expired/invalid credential in that kubeconfig), the
+controller switches to the next kubeconfig and retries. It **sticks** with a
+working kubeconfig until that one fails, then circles to the next, wrapping
+around the list.
+
+### Decisions (locked in with the requester)
+
+| Question | Decision |
+|---|---|
+| Topology | **Same cluster (HA).** Kubeconfigs are interchangeable; state (pods/labs/nodes) is shared, so failover is transparent and no per-cluster ownership tracking is needed. |
+| Config format | **Comma-separated list of kubeconfig file paths** in the existing `K8S_CONFIG`/`KUBECONFIG` env var. |
+| Failover trigger | **Connectivity + auth.** Timeouts, connection errors, API status `0`/`None`, HTTP `5xx`, **and** auth failures (`401` Unauthorized / `403` Forbidden) — an HA path may carry an expired/invalid credential, so try the next one. Other API errors (`400/404/409/422/...`) mean the cluster answered a valid request → **no** failover, propagate as today. |
+| Failback | **None.** Sticky: stay on the current working kubeconfig until it fails. No background re-probe of the preferred one. |
+
+### Non-goals
+
+- No cross-cluster reconciliation (topology is single-cluster HA).
+- No automatic return to a "primary" kubeconfig (explicitly out of scope).
+- No change to the on-disk manifest / lab lifecycle logic.
+
+## Current state (what the change touches)
+
+The controller builds its clients **once** in `__init__`
+([kubernetes.py:32-52](../apps/controllers/kubernetes.py)):
+
+```python
+config.load_kube_config(config_file=app_config.K8S_CONFIG)
+self.v1_api        = client.CoreV1Api()
+self.apps_v1_api   = client.AppsV1Api()
+self.discovery_api = client.DiscoveryV1Api()
+self.k8s_client    = client.ApiClient()
+```
+
+Two API surfaces must be routed to the active kubeconfig:
+
+1. **python `kubernetes` client** — `self.v1_api`, `self.apps_v1_api`,
+   `self.discovery_api`, `self.k8s_client`, and the exec `stream()` in
+   `get_pod_exec_stream`. Used in ~40 call sites, always with
+   `_request_timeout=self.request_timeout`.
+2. **`kubectl` subprocess** — `get_k8s_resource`, `create_k8s_resource`
+   (fallback branch), `delete_k8s_resource`. These currently pass **no**
+   `--kubeconfig` and rely on the ambient `~/.kube/config`. They must be
+   pinned to the active kubeconfig too, or they'd silently target a different
+   endpoint than the python client.
+
+Runtime shape that constrains the design:
+
+- **Process model:** gunicorn `-w 1 --worker-class gevent --threads 128`
+  (`docker-entrypoint.sh`). One process, one shared singleton controller
+  (`_LazyProxy` in `apps/controllers/__init__.py`), many concurrent greenlets.
+  The active-kubeconfig switch is **shared mutable state** → needs a lock and a
+  compare-and-swap rotation to avoid a thundering herd skipping past healthy
+  endpoints.
+- **Disabled state:** when `K8S_NAMESPACE` is empty or no kubeconfig loads,
+  today `self.v1_api is None` and callers short-circuit
+  (`if not self.v1_api:` in `get_labs_by_user`). This must be preserved.
+- **Tests:** `tests/test_k8s_controller.py` assigns mocks directly onto the
+  client object (`ctrl.v1_api.read_namespaced_pod = MagicMock(...)`) and later
+  reads `ctrl.v1_api.list_namespaced_pod.call_args`. So `self.v1_api` **must
+  keep returning a stable, real client object** — a "magic attribute proxy"
+  that rewrites every attribute access would break these. This is the key
+  constraint that selects the design below.
+
+## Design
+
+### 1. Configuration
+
+`apps/config.py`:
+
+```python
+# unchanged env var; now parsed as a comma-separated list
+_raw = os.getenv("KUBECONFIG", "~/.kube/config")
+K8S_CONFIGS = [
+    os.path.expanduser(p.strip()) for p in _raw.split(",") if p.strip()
+]
+# backward-compat alias: first entry, still a single path
+K8S_CONFIG = K8S_CONFIGS[0] if K8S_CONFIGS else ""
+```
+
+- A single path (today's usage) → one-element list → behaves exactly as before
+  (loop of length 1, failover never triggers). **Fully backward compatible.**
+- Comma is the separator (not `:`), because the python `kubernetes` library and
+  `kubectl` treat a **colon**-separated `KUBECONFIG` as *files to merge into one
+  config* — the opposite of what we want (we want them kept separate and tried
+  one at a time). Documented in `env-template`.
+
+### 2. A `_KubeEndpoint` per kubeconfig
+
+Encapsulate one kubeconfig and its (lazily built) clients. Each endpoint owns an
+**isolated** `client.Configuration` so switching never mutates a global/default
+config shared with another endpoint:
+
+```python
+class _KubeEndpoint:
+    def __init__(self, path):
+        self.path = path
+        self._built = False
+        self.v1_api = self.apps_v1_api = self.discovery_api = self.k8s_client = None
+
+    def build(self):                 # called under the controller lock
+        if self._built:
+            return
+        cfg = client.Configuration()
+        config.load_kube_config(config_file=self.path, client_configuration=cfg)
+        api = client.ApiClient(configuration=cfg)
+        self.v1_api        = client.CoreV1Api(api)
+        self.apps_v1_api   = client.AppsV1Api(api)
+        self.discovery_api = client.DiscoveryV1Api(api)
+        self.k8s_client    = api
+        self._built = True
+```
+
+- **Lazy build:** standby kubeconfigs aren't loaded until first used, so a
+  broken/absent standby file doesn't cost anything at startup and only surfaces
+  when we actually fail over to it.
+- Endpoints whose `build()` raises at startup are still kept in the list
+  (they may recover); a build failure during failover is treated as a
+  connectivity failure and we move to the next endpoint.
+
+### 3. Active-endpoint selection + `self.v1_api` as properties
+
+The controller keeps the ordered list and an active index, guarded by a lock
+(`threading.Lock`; gevent monkeypatches `threading`, so it's cooperative):
+
+```python
+self._endpoints  = [_KubeEndpoint(p) for p in app_config.K8S_CONFIGS]
+self._active_idx = 0
+self._lock       = threading.Lock()
+```
+
+The four client attributes become **read-only properties** that return the
+**active** endpoint's real client (or `None` when disabled). Call sites stay
+byte-for-byte unchanged (`self.v1_api.list_namespaced_pod(...)`), and because a
+property returns the same underlying client object for a given active endpoint,
+the existing tests' `ctrl.v1_api.method = MagicMock()` / `.call_args` pattern
+keeps working:
+
+```python
+@property
+def v1_api(self):
+    ep = self._active_endpoint()      # None if disabled → `if not self.v1_api` still works
+    return ep.v1_api if ep else None
+# ...same for apps_v1_api, discovery_api, k8s_client
+
+def _active_endpoint(self):
+    if not self._endpoints:
+        return None
+    ep = self._endpoints[self._active_idx]
+    if not ep._built:
+        with self._lock:
+            ep.build()
+    return ep
+```
+
+> **Disabled state:** if `K8S_NAMESPACE` is empty or `K8S_CONFIGS` is empty, we
+> leave `self._endpoints = []` so every property returns `None` — identical to
+> today's `self.v1_api = None`.
+
+### 4. Failover: rotate + retry
+
+A decorator wraps the controller methods that talk to the cluster. On a
+**failover error** (connectivity or auth, per §6) it advances the active
+endpoint (compare-and-swap) and re-invokes the method against the new active
+endpoint. It stops after trying each endpoint at most once and re-raises the
+last error if all fail:
+
+```python
+def with_failover(method):
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        attempts = max(1, len(self._endpoints))
+        last_exc = None
+        for _ in range(attempts):
+            ep = self._active_endpoint()
+            try:
+                return method(self, *args, **kwargs)
+            except Exception as exc:
+                if not _is_failover_error(exc):
+                    raise                      # valid API error → propagate as today
+                last_exc = exc
+                self._record_failover(ep, exc)  # metric + WARNING log (see §8)
+                self._rotate_from(ep)           # sticky advance, CAS-guarded
+        raise last_exc
+    return wrapper
+
+def _rotate_from(self, failed_ep):
+    with self._lock:
+        # only advance if nobody else already moved us off the failed endpoint
+        if self._endpoints[self._active_idx] is failed_ep:
+            self._active_idx = (self._active_idx + 1) % len(self._endpoints)
+```
+
+**Where the decorator goes — granularity matters:**
+
+- **Idempotent reads** (`list_pods`, `list_deployments`, `list_services`,
+  `get_lab_resources`, `get_labs_by_user`, `update_nodes`, the `*_by_name`
+  getters): decorate freely. A mid-way failover just repeats read work against
+  the sibling endpoint — harmless.
+- **Single-resource writes** — decorate the **innermost** call, not the
+  orchestration. Decorate `create_k8s_resource`, `delete_k8s_resource`,
+  `get_k8s_resource`, `create_registry_secret`, and the individual
+  `delete_*_by_name`. **Do NOT** decorate `create_lab`: it loops creating many
+  docs; if endpoint A dies after creating docs #1–#2, retrying the *whole*
+  `create_lab` on endpoint B (same cluster) would hit `409 AlreadyExists` on
+  those docs. By decorating `create_k8s_resource` instead, only the failing doc
+  is retried on B and the loop continues — the lab still completes. A `409` on
+  retry is *not* a failover error, so it propagates into `create_lab`'s
+  existing rollback path (`delete_resources_by_name` + `_wait_gone`) — safe
+  either way.
+
+**Sticky semantics:** the decorator never resets `_active_idx` to 0. Once
+endpoint _k_ works, it stays active for all subsequent calls until _k_ itself
+throws a connectivity error. That is exactly "stay on the one that worked until
+it fails, then circle."
+
+**Thundering herd:** under gevent, many greenlets can fail on endpoint _k_ at
+once. `_rotate_from` only advances when the active endpoint is *still* the one
+that failed, so the fleet advances **exactly one** step to _k+1_ regardless of
+how many callers observed the failure — they don't skip past healthy endpoints.
+
+### 5. `kubectl` subprocess routing
+
+Centralize the three kubectl call sites through one helper that (a) injects
+`--kubeconfig <active path>` and (b) does the same connectivity-vs-command-error
+classification, so kubectl fails over in lockstep with the python client:
+
+```python
+def _run_kubectl(self, args, **run_kwargs):
+    ep = self._active_endpoint()
+    cmd = ["kubectl", "--kubeconfig", ep.path, *args]
+    return subprocess.run(cmd, timeout=self.request_timeout, **run_kwargs)
+```
+
+`get_k8s_resource` / `create_k8s_resource` / `delete_k8s_resource` call
+`_run_kubectl(...)` and are wrapped with `@with_failover`. Classification for
+kubectl:
+
+- **Connectivity → failover:** `subprocess.TimeoutExpired`, or
+  `CalledProcessError` whose stderr matches `Unable to connect to the server`,
+  `connection refused`, `i/o timeout`, `TLS handshake timeout`,
+  `no route to host`, `EOF`.
+- **Command error → propagate:** `NotFound`, `AlreadyExists`, validation
+  errors, etc. (raised/returned exactly as today).
+
+`_is_failover_error` handles both worlds (python-client exceptions and the
+kubectl exceptions surfaced by these helpers).
+
+### 6. `_is_failover_error` (connectivity + auth)
+
+The classifier fails over on both transport-level failures **and** auth
+failures (`401`/`403`) — these HA paths can carry different credentials, so an
+expired/invalid token on one path is a reason to try the next. Every other
+`ApiException` (a valid request the cluster answered: `400/404/409/422/...`)
+propagates unchanged:
+
+```python
+_AUTH_STATUSES = (401, 403)
+
+def _is_failover_error(exc):
+    import socket, urllib3, subprocess
+    from kubernetes.client.exceptions import ApiException
+    if isinstance(exc, ApiException):
+        status = exc.status or 0
+        return status in (0,) or status in _AUTH_STATUSES or status >= 500
+    if isinstance(exc, subprocess.TimeoutExpired):
+        return True
+    if isinstance(exc, subprocess.CalledProcessError):
+        return _kubectl_stderr_is_failover(exc.stderr)   # connectivity OR auth
+    return isinstance(exc, (
+        urllib3.exceptions.MaxRetryError,
+        urllib3.exceptions.ReadTimeoutError,
+        urllib3.exceptions.ConnectTimeoutError,
+        urllib3.exceptions.ProtocolError,
+        socket.timeout, TimeoutError, ConnectionError,
+    ))
+```
+
+- `_kubectl_stderr_is_failover` matches the connectivity strings from §5 **plus**
+  auth strings kubectl emits: `Unauthorized`, `error: You must be logged in`,
+  `the server has asked for the client to provide credentials`, `forbidden`.
+- The classifier is named `_is_failover_error` throughout (not
+  `_is_connectivity_error`) to reflect that auth is a first-class trigger.
+
+> **Guarding against auth-flap loops:** if *all* kubeconfigs return `401`
+> (e.g. a cluster-wide RBAC change), every endpoint is tried once per operation
+> and the last `ApiException` is re-raised — same bounded behavior as an
+> all-endpoints-down connectivity failure. No infinite retry.
+
+### 7. `get_pod_exec_stream` (websocket)
+
+This uses `stream(self.v1_api.connect_get_namespaced_pod_exec, ...)` and returns
+a long-lived websocket — mid-stream failover isn't meaningful. Wrap only the
+**initial connection** with the same rotate-and-retry (build the stream against
+the active endpoint; on a connectivity error, rotate once and rebuild). Failures
+after the stream is established surface to the caller as today.
+
+## Concurrency summary
+
+- `threading.Lock` (gevent-cooperative) guards: lazy `endpoint.build()` and the
+  compare-and-swap in `_rotate_from`. Both are short critical sections.
+- Reading `_active_idx` for a call is a plain int read (atomic enough under
+  gevent's cooperative scheduling; the CAS in `_rotate_from` is the only
+  writer and is locked).
+- Node cache (`update_nodes`, 60s TTL) needs **no** invalidation on failover:
+  same cluster ⇒ identical node list across endpoints.
+
+## Observability — failover metrics / counters
+
+Ships **now** (not deferred). There is no Prometheus/statsd stack in this app
+today, so the counters live **in-process on the controller** and are surfaced
+through the existing `get_statistics()` path (already rendered on the dashboard,
+`apps/home/routes.py:57`) and structured logs. A `/metrics`-style export is
+noted as an easy future add-on, not built here.
+
+### State
+
+Per-endpoint counters plus a small ring of recent events, all mutated under the
+same `self._lock`:
+
+```python
+self._failover_stats = {
+    "active_path":   None,        # kubeconfig currently in use
+    "active_since":  0.0,         # epoch when it became active
+    "total_failovers": 0,         # rotations since process start
+    "per_endpoint": {             # keyed by kubeconfig path
+        path: {"failovers": 0, "last_error": None, "last_failover_ts": 0.0}
+        for path in app_config.K8S_CONFIGS
+    },
+    "recent": deque(maxlen=20),   # [{ts, from_path, to_path, status, reason}]
+}
+```
+
+`_record_failover(ep, exc)` (called by the decorator before `_rotate_from`):
+
+- increments `total_failovers` and `per_endpoint[ep.path]["failovers"]`;
+- stores a compact `last_error` (exception class + HTTP status, no bodies);
+- appends a `recent` entry with `from`/`to` paths and a `reason`
+  (`"timeout" | "conn_refused" | "auth_401" | "auth_403" | "server_5xx"`);
+- emits a **`WARNING`** log:
+  `k8s failover: <from_path> -> <to_path> reason=<reason> (<exc>)`.
+
+`_set_active(idx)` updates `active_path`/`active_since` and logs an **`INFO`**
+line once when an endpoint first becomes active.
+
+### Flapping detection (why ops notice)
+
+"Flapping" = repeated rotations in a short window. Expose a derived **rate**, not
+just a lifetime total, so a brief blip is distinguishable from an endpoint that
+keeps dropping:
+
+- `failovers_last_5m` — count of `recent` entries within the last 300 s.
+- `is_flapping` — `True` when `failovers_last_5m >= K8S_FLAP_THRESHOLD`
+  (new env var, default `3`). When it flips to `True` the controller logs a
+  single **`ERROR`**: `k8s endpoints flapping: N failovers in last 5m`
+  (edge-triggered — logged on the transition, not every rotation, to avoid log
+  spam).
+
+### Surface
+
+`get_statistics()` gains a `"kubeconfig"` block (only when
+`len(self._endpoints) > 1`, so single-config deployments are unchanged):
+
+```python
+"kubeconfig": {
+    "active": active_path,
+    "active_since": active_since,
+    "total_failovers": total_failovers,
+    "failovers_last_5m": n,
+    "is_flapping": bool,
+    "endpoints": [
+        {"path": p, "failovers": c, "last_error": e, "active": p == active_path}
+        for p, ... in per_endpoint
+    ],
+}
+```
+
+The dashboard stats view renders it; ops see the active kubeconfig, lifetime and
+recent failover counts, and a flapping badge. A read-only
+`get_failover_stats()` accessor returns the same dict for a future
+`/metrics`/health endpoint or alerting scrape.
+
+> **Reset semantics:** counters are process-lifetime (reset on restart) — matches
+> the single-worker gunicorn model where the controller singleton lives for the
+> worker's lifetime. `recent`/`last_5m` naturally age out via the deque + window.
+
+## Backward compatibility
+
+- Single-path `K8S_CONFIG` → one endpoint → decorator loop length 1 → no
+  behavior change.
+- `self.v1_api` et al. remain attribute-accessible and return real client
+  objects; disabled state still yields `None`.
+- kubectl now always passes `--kubeconfig`; with one endpoint this points at the
+  same file the ambient config resolved to (set `K8S_CONFIG` explicitly if you
+  previously relied on `$KUBECONFIG`/`~/.kube/config` implicitly — documented).
+
+## Testing plan
+
+Update `tests/test_k8s_controller.py` fixture: `client.CoreV1Api` etc. now take
+an `api_client` arg → change stubs to `lambda *a, **k: MagicMock()`. The
+property-based `self.v1_api` keeps the existing `ctrl.v1_api.method = MagicMock`
+assertions valid (single endpoint ⇒ stable object).
+
+New cases:
+
+1. **Failover on timeout:** two endpoints; first `v1_api.list_*` raises
+   `urllib3.ReadTimeoutError` → assert the call is retried on endpoint #2 and
+   returns its result.
+2. **Sticky:** after failing over to #2, a subsequent call uses #2 directly
+   (no reset to #0).
+3. **Circle / wrap:** with #0 active and failing, rotation goes #0→#1→…→#0.
+4. **Failover on auth:** `ApiException(status=401)` **and** `status=403` each
+   rotate to the next endpoint and succeed there; assert `reason` is
+   `auth_401`/`auth_403` in the recorded stats.
+5. **No failover on valid API error:** `ApiException(status=404)` (and `409`,
+   `400`) propagate without rotating (`_active_idx` unchanged).
+6. **All endpoints down / all-auth-fail:** failover error on every endpoint ⇒
+   last exception re-raised after exactly `len(endpoints)` attempts (covers both
+   connectivity-everywhere and 401-everywhere — no infinite loop).
+7. **Thundering herd:** two "greenlets" both observe a failure on #0 ⇒
+   `_active_idx` advances by exactly one (to #1), not two.
+8. **kubectl failover:** `TimeoutExpired` and a `CalledProcessError` with an
+   `Unauthorized` stderr each rotate and retry with `--kubeconfig` pointing at
+   the next path; `CalledProcessError` with a `NotFound` stderr propagates.
+9. **create_lab granularity:** connectivity failure on the 3rd
+   `create_k8s_resource` is retried on the sibling endpoint and the lab
+   completes (the whole `create_lab` is not restarted).
+10. **Metrics counters:** each failover increments `total_failovers` and the
+    per-endpoint counter, records a `recent` entry, and populates the
+    `"kubeconfig"` block in `get_statistics()`; a valid-API-error path leaves all
+    counters at zero.
+11. **Flapping flag:** `K8S_FLAP_THRESHOLD` failovers within 5 min flips
+    `is_flapping` true and logs the edge-triggered `ERROR` exactly once.
+12. **Backward compat:** single-path config behaves as today, `get_statistics()`
+    has **no** `"kubeconfig"` block, disabled state (`v1_api is None`) preserved.
+
+## Files touched
+
+- `apps/config.py` — `K8S_CONFIGS` parsing (+ `K8S_CONFIG` alias),
+  `K8S_FLAP_THRESHOLD` (default `3`).
+- `apps/controllers/kubernetes.py` — `_KubeEndpoint`, `with_failover`,
+  `_is_failover_error`, `_kubectl_stderr_is_failover`, `_run_kubectl`,
+  `_rotate_from`, `_active_endpoint`, `_set_active`, `_record_failover`,
+  `get_failover_stats`, properties for the four clients; decorate
+  read/write/kubectl/exec methods; extend `get_statistics()` with the
+  `"kubeconfig"` block.
+- `env-template` + `doc/INSTALL.md` — document comma-separated `KUBECONFIG` and
+  `K8S_FLAP_THRESHOLD`.
+- `tests/test_k8s_controller.py` (+ `tests/test_k8s_tape.py` if it constructs
+  clients) — fixture tweak + new failover & metrics cases.
+- (optional) dashboard stats template — render the `"kubeconfig"` block /
+  flapping badge.
+
+## Open questions / follow-ups
+
+1. **Per-endpoint `request_timeout`?** Today one global `K8S_REQUEST_TIMEOUT`.
+   Fine to keep global; note if any endpoint is known-slower.
+2. **`/metrics` (Prometheus) export** — `get_failover_stats()` is shaped to be
+   scrape-friendly; wiring an actual endpoint/exporter is a later add-on, not in
+   this change.
+3. **Alerting on `is_flapping`** — the `ERROR` log is the current signal; hook it
+   into whatever log-based alerting ops already run.

--- a/env-template
+++ b/env-template
@@ -6,6 +6,16 @@ export OAUTH_DOMAIN=cilogon.org
 #export OAUTH_DOMAIN=orcid.org
 
 export K8S_NAMESPACE=xxx
+# KUBECONFIG may list several kubeconfig files separated by COMMAS. They are
+# treated as redundant (HA) access paths to the SAME cluster: one is used at a
+# time and, on a connectivity/auth failure (timeout, connection refused, 5xx,
+# 401/403), the controller fails over to the next one and stays there until it
+# also fails. A single path behaves exactly as before. (Use commas, not colons:
+# a colon-separated KUBECONFIG is interpreted as files to *merge*.)
+#export KUBECONFIG=~/.kube/config-a,~/.kube/config-b
+# Number of failovers within a 5-minute window that flags the set as "flapping"
+# (surfaced in the dashboard statistics and logged once as an ERROR).
+#export K8S_FLAP_THRESHOLD=3
 export SECRET_KEY=xxx
 # change to DEBUG=False when running in production
 export DEBUG=True

--- a/tests/test_k8s_controller.py
+++ b/tests/test_k8s_controller.py
@@ -76,10 +76,11 @@ def ctrl(monkeypatch):
     monkeypatch.setattr(k8s_module.app_config, "K8S_NAMESPACE", "test-ns")
     monkeypatch.setattr(k8s_module.app_config, "K8S_REQUEST_TIMEOUT", TEST_TIMEOUT)
     monkeypatch.setattr(k8s_module.config, "load_kube_config", lambda **k: None)
-    monkeypatch.setattr(k8s_module.client, "CoreV1Api", lambda: MagicMock())
-    monkeypatch.setattr(k8s_module.client, "AppsV1Api", lambda: MagicMock())
-    monkeypatch.setattr(k8s_module.client, "DiscoveryV1Api", lambda: MagicMock())
-    monkeypatch.setattr(k8s_module.client, "ApiClient", lambda: MagicMock())
+    monkeypatch.setattr(k8s_module.client, "Configuration", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(k8s_module.client, "CoreV1Api", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(k8s_module.client, "AppsV1Api", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(k8s_module.client, "DiscoveryV1Api", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(k8s_module.client, "ApiClient", lambda *a, **k: MagicMock())
     controller = K8sController()
     return controller
 

--- a/tests/test_k8s_failover.py
+++ b/tests/test_k8s_failover.py
@@ -1,0 +1,297 @@
+"""Pytest suite for the multi-kubeconfig failover in apps/controllers/kubernetes.py.
+
+Builds a K8sController wired to two (or three) fake kubeconfig "endpoints",
+each with its own mocked kubernetes client, and drives the @with_failover
+machinery: connectivity/auth failures rotate to the next kubeconfig, valid API
+errors do not, the choice is sticky and circular, kubectl calls fail over too,
+and the failover counters / get_statistics() block are populated.
+
+Usage:
+    pip install -r requirements-dev.txt
+    pytest tests/test_k8s_failover.py -v
+"""
+
+import importlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# --- isolate the test run from any real data --------------------------------
+TEST_DATA_DIR = tempfile.mkdtemp(prefix="hackinsdn_test_")
+os.environ["DATA_DIR"] = TEST_DATA_DIR
+os.environ.setdefault("OPTIONAL_MODULES", "")
+
+# stub the clabernetes controller (needs a 'clabverter' binary at import time)
+_fake_clabernetes = types.ModuleType("apps.controllers.clabernetes")
+
+
+class _StubC9sController:
+    def __getattr__(self, name):
+        raise NotImplementedError("clabernetes stub - not needed for these tests")
+
+
+_fake_clabernetes.C9sController = _StubC9sController
+sys.modules["apps.controllers.clabernetes"] = _fake_clabernetes
+
+from run import app as flask_app  # noqa: E402
+
+k8s_module = importlib.import_module("apps.controllers.kubernetes")
+K8sController = k8s_module.K8sController
+ApiException = k8s_module.ApiException
+
+flask_app.config["TESTING"] = True
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_temp_data_dir():
+    yield
+    import shutil
+
+    shutil.rmtree(TEST_DATA_DIR, ignore_errors=True)
+
+
+@pytest.fixture(autouse=True)
+def _app_context():
+    with flask_app.app_context():
+        yield
+
+
+@pytest.fixture()
+def make_ctrl(monkeypatch):
+    """Factory building a controller with N fake, fully-built kubeconfigs."""
+
+    def _make(paths):
+        monkeypatch.setattr(k8s_module.app_config, "K8S_NAMESPACE", "test-ns")
+        monkeypatch.setattr(k8s_module.app_config, "K8S_REQUEST_TIMEOUT", 7.0)
+        monkeypatch.setattr(k8s_module.app_config, "K8S_CONFIGS", list(paths))
+        monkeypatch.setattr(k8s_module.app_config, "K8S_FLAP_THRESHOLD", 3)
+        monkeypatch.setattr(k8s_module.config, "load_kube_config", lambda **k: None)
+        monkeypatch.setattr(k8s_module.client, "Configuration", lambda *a, **k: MagicMock())
+        monkeypatch.setattr(k8s_module.client, "ApiClient", lambda *a, **k: MagicMock())
+        monkeypatch.setattr(k8s_module.client, "CoreV1Api", lambda *a, **k: MagicMock())
+        monkeypatch.setattr(k8s_module.client, "AppsV1Api", lambda *a, **k: MagicMock())
+        monkeypatch.setattr(k8s_module.client, "DiscoveryV1Api", lambda *a, **k: MagicMock())
+        ctrl = K8sController()
+        # materialise each endpoint's (distinct) mock clients up front
+        for ep in ctrl._endpoints:
+            ep.ensure_built(ctrl._lock)
+        return ctrl
+
+    return _make
+
+
+def _fake_pod(phase="Running"):
+    pod = MagicMock()
+    pod.to_dict.return_value = {}
+    pod.status.phase = phase
+    return pod
+
+
+# --- rotation / stickiness ----------------------------------------------
+class TestRotation:
+    def test_failover_on_timeout(self, make_ctrl):
+        ctrl = make_ctrl(["/a", "/b"])
+        ctrl._endpoints[0].v1_api.read_namespaced_pod.side_effect = TimeoutError("stalled")
+        ctrl._endpoints[1].v1_api.read_namespaced_pod.return_value = _fake_pod()
+
+        result = ctrl.get_pod_by_name({"name": "p1"})
+
+        assert result["is_ok"] is True
+        assert ctrl._active_idx == 1  # moved to the working kubeconfig
+        assert ctrl._failover_stats["total_failovers"] == 1
+
+    def test_sticky_stays_on_working_endpoint(self, make_ctrl):
+        ctrl = make_ctrl(["/a", "/b"])
+        ctrl._endpoints[0].v1_api.read_namespaced_pod.side_effect = ConnectionError("down")
+        ctrl._endpoints[1].v1_api.read_namespaced_pod.return_value = _fake_pod()
+
+        ctrl.get_pod_by_name({"name": "p1"})  # fails over 0 -> 1
+        ctrl._endpoints[0].v1_api.read_namespaced_pod.reset_mock()
+        ctrl.get_pod_by_name({"name": "p2"})  # should use 1 directly
+
+        assert ctrl._active_idx == 1
+        ctrl._endpoints[0].v1_api.read_namespaced_pod.assert_not_called()
+
+    def test_circle_wraps_around(self, make_ctrl):
+        ctrl = make_ctrl(["/a", "/b"])
+        # start on 1 (as if a previous failover happened)
+        ctrl._active_idx = 1
+        ctrl._endpoints[1].v1_api.read_namespaced_pod.side_effect = TimeoutError("stalled")
+        ctrl._endpoints[0].v1_api.read_namespaced_pod.return_value = _fake_pod()
+
+        result = ctrl.get_pod_by_name({"name": "p1"})
+
+        assert result["is_ok"] is True
+        assert ctrl._active_idx == 0  # wrapped 1 -> 0
+
+    def test_auth_401_and_403_trigger_failover(self, make_ctrl):
+        for status in (401, 403):
+            ctrl = make_ctrl(["/a", "/b"])
+            ctrl._endpoints[0].v1_api.read_namespaced_pod.side_effect = ApiException(status=status)
+            ctrl._endpoints[1].v1_api.read_namespaced_pod.return_value = _fake_pod()
+
+            result = ctrl.get_pod_by_name({"name": "p1"})
+
+            assert result["is_ok"] is True
+            assert ctrl._active_idx == 1
+            assert ctrl._failover_stats["recent"][-1]["reason"] == f"auth_{status}"
+
+    def test_no_failover_on_valid_api_error(self, make_ctrl):
+        ctrl = make_ctrl(["/a", "/b"])
+        ctrl._endpoints[0].v1_api.read_namespaced_pod.side_effect = ApiException(status=404)
+
+        with pytest.raises(ApiException):
+            ctrl.get_pod_by_name({"name": "missing"})
+
+        assert ctrl._active_idx == 0  # unchanged
+        assert ctrl._failover_stats["total_failovers"] == 0
+        ctrl._endpoints[1].v1_api.read_namespaced_pod.assert_not_called()
+
+    def test_all_endpoints_down_reraises_after_len_attempts(self, make_ctrl):
+        ctrl = make_ctrl(["/a", "/b", "/c"])
+        for ep in ctrl._endpoints:
+            ep.v1_api.read_namespaced_pod.side_effect = TimeoutError("down")
+
+        with pytest.raises(TimeoutError):
+            ctrl.get_pod_by_name({"name": "p1"})
+
+        # exactly one attempt per endpoint
+        assert ctrl._failover_stats["total_failovers"] == 3
+
+    def test_all_auth_fail_does_not_loop_forever(self, make_ctrl):
+        ctrl = make_ctrl(["/a", "/b"])
+        for ep in ctrl._endpoints:
+            ep.v1_api.read_namespaced_pod.side_effect = ApiException(status=401)
+
+        with pytest.raises(ApiException):
+            ctrl.get_pod_by_name({"name": "p1"})
+        assert ctrl._failover_stats["total_failovers"] == 2
+
+
+# --- concurrency (compare-and-swap rotation) ----------------------------
+class TestThunderingHerd:
+    def test_rotate_from_advances_exactly_once(self, make_ctrl):
+        ctrl = make_ctrl(["/a", "/b", "/c"])
+        ep0 = ctrl._endpoints[0]
+
+        ctrl._rotate_from(ep0)  # 0 -> 1
+        assert ctrl._active_idx == 1
+        # a second greenlet that also observed ep0 failing must NOT advance again
+        ctrl._rotate_from(ep0)
+        assert ctrl._active_idx == 1
+
+
+# --- kubectl failover ----------------------------------------------------
+class TestKubectlFailover:
+    def test_get_k8s_resource_fails_over(self, make_ctrl, monkeypatch):
+        ctrl = make_ctrl(["/a", "/b"])
+
+        class _Completed:
+            def __init__(self, stdout):
+                self.stdout = stdout
+
+        def fake_run(cmd, *a, **k):
+            if "--kubeconfig" in cmd and "/a" in cmd:
+                raise subprocess.TimeoutExpired(cmd="kubectl", timeout=7)
+            return _Completed(json.dumps({"kind": "Foo", "metadata": {"name": "f1"}}))
+
+        monkeypatch.setattr(k8s_module.subprocess, "run", fake_run)
+        result = ctrl.get_k8s_resource({"kind": "Foo", "name": "f1"})
+
+        assert result["is_ok"] is True
+        assert ctrl._active_idx == 1
+
+    def test_kubectl_notfound_propagates_without_failover(self, make_ctrl, monkeypatch):
+        ctrl = make_ctrl(["/a", "/b"])
+
+        def fake_run(cmd, *a, **k):
+            raise subprocess.CalledProcessError(1, cmd, stderr='Error: resource "x" not found')
+
+        monkeypatch.setattr(k8s_module.subprocess, "run", fake_run)
+        with pytest.raises(Exception, match="Failed to get k8s resource"):
+            ctrl.get_k8s_resource({"kind": "Foo", "name": "f1"})
+        assert ctrl._active_idx == 0  # a valid "not found" must not rotate
+
+    def test_kubectl_unauthorized_fails_over(self, make_ctrl, monkeypatch):
+        ctrl = make_ctrl(["/a", "/b"])
+
+        class _Completed:
+            def __init__(self, stdout):
+                self.stdout = stdout
+
+        def fake_run(cmd, *a, **k):
+            if "--kubeconfig" in cmd and "/a" in cmd:
+                raise subprocess.CalledProcessError(1, cmd, stderr="error: You must be logged in to the server (Unauthorized)")
+            return _Completed(json.dumps({"kind": "Foo", "metadata": {"name": "f1"}}))
+
+        monkeypatch.setattr(k8s_module.subprocess, "run", fake_run)
+        result = ctrl.get_k8s_resource({"kind": "Foo", "name": "f1"})
+        assert result["is_ok"] is True
+        assert ctrl._active_idx == 1
+
+
+# --- metrics / observability --------------------------------------------
+class TestMetrics:
+    def test_get_failover_stats_none_for_single_config(self, make_ctrl):
+        ctrl = make_ctrl(["/only"])
+        assert ctrl.get_failover_stats() is None
+
+    def test_statistics_has_no_kubeconfig_block_for_single_config(self, make_ctrl):
+        ctrl = make_ctrl(["/only"])
+        ctrl._endpoints[0].v1_api.list_node.return_value = SimpleNamespace(items=[])
+        assert "kubeconfig" not in ctrl.get_statistics()
+
+    def test_statistics_reports_failover_block(self, make_ctrl):
+        ctrl = make_ctrl(["/a", "/b"])
+        ctrl._endpoints[0].v1_api.read_namespaced_pod.side_effect = TimeoutError("down")
+        ctrl._endpoints[1].v1_api.read_namespaced_pod.return_value = _fake_pod()
+        ctrl._endpoints[0].v1_api.list_node.return_value = SimpleNamespace(items=[])
+        ctrl._endpoints[1].v1_api.list_node.return_value = SimpleNamespace(items=[])
+
+        ctrl.get_pod_by_name({"name": "p1"})  # one failover 0 -> 1
+        stats = ctrl.get_statistics()
+
+        assert "kubeconfig" in stats
+        block = stats["kubeconfig"]
+        assert block["active"] == "/b"
+        assert block["total_failovers"] == 1
+        assert block["endpoints"][0]["failovers"] == 1
+        assert block["endpoints"][1]["active"] is True
+
+    def test_flapping_is_edge_triggered(self, make_ctrl):
+        ctrl = make_ctrl(["/a", "/b"])
+        ep0 = ctrl._endpoints[0]
+        # three failovers within the window crosses the default threshold of 3
+        for _ in range(3):
+            ctrl._record_failover(ep0, TimeoutError("down"))
+
+        assert ctrl._flap_logged is True
+        assert ctrl.get_failover_stats()["is_flapping"] is True
+
+
+# --- backward compatibility ---------------------------------------------
+class TestBackwardCompat:
+    def test_single_config_never_fails_over(self, make_ctrl):
+        ctrl = make_ctrl(["/only"])
+        ctrl._endpoints[0].v1_api.read_namespaced_pod.side_effect = ApiException(status=500)
+        # only one endpoint -> one attempt, then the error propagates
+        with pytest.raises(ApiException):
+            ctrl.get_pod_by_name({"name": "p1"})
+        assert ctrl._active_idx == 0
+
+    def test_disabled_controller_returns_none_clients(self, monkeypatch):
+        monkeypatch.setattr(k8s_module.app_config, "K8S_NAMESPACE", "")
+        ctrl = K8sController()
+        assert ctrl._endpoints == []
+        assert ctrl.v1_api is None
+        assert ctrl.get_labs_by_user("u1") == []

--- a/tests/test_k8s_tape.py
+++ b/tests/test_k8s_tape.py
@@ -155,10 +155,11 @@ def ctrl(monkeypatch):
     monkeypatch.setattr(k8s_module.app_config, "K8S_NAMESPACE", NAMESPACE)
     monkeypatch.setattr(k8s_module.app_config, "K8S_REQUEST_TIMEOUT", REQUEST_TIMEOUT)
     monkeypatch.setattr(k8s_module.config, "load_kube_config", lambda **k: None)
-    monkeypatch.setattr(k8s_module.client, "CoreV1Api", lambda: MagicMock())
-    monkeypatch.setattr(k8s_module.client, "AppsV1Api", lambda: MagicMock())
-    monkeypatch.setattr(k8s_module.client, "DiscoveryV1Api", lambda: MagicMock())
-    monkeypatch.setattr(k8s_module.client, "ApiClient", lambda: MagicMock())
+    monkeypatch.setattr(k8s_module.client, "Configuration", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(k8s_module.client, "CoreV1Api", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(k8s_module.client, "AppsV1Api", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(k8s_module.client, "DiscoveryV1Api", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(k8s_module.client, "ApiClient", lambda *a, **k: MagicMock())
     controller = K8sController()
     controller.k8s_avoid_nodes = set()
     return controller
@@ -601,5 +602,5 @@ class TestGetLabsByUser:
 
     def test_returns_empty_without_api(self, ctrl):
         """No configured API client -> an empty list, no calls attempted."""
-        ctrl.v1_api = None
+        ctrl._endpoints = []  # simulate a disabled controller (v1_api -> None)
         assert ctrl.get_labs_by_user(USER_UID) == []


### PR DESCRIPTION
## What & why

Adds multi-kubeconfig **failover** to `K8sController`. `KUBECONFIG` may now list several kubeconfig files (comma-separated) that are redundant **HA access paths to the same cluster**. One is used at a time; on a **connectivity or auth** failure the controller fails over to the next and **stays there until it also fails**, circling through the list. A single path behaves exactly as before.

> Stacked on top of #292 (`feat/kubernetes-timeout`) — this PR's base is that branch so the diff shows only the failover work. Retarget to `main` once #292 merges.

## How it works

- **Config** ([apps/config.py](../blob/feat/kubeconfig-failover/apps/config.py)): `KUBECONFIG` parsed comma-separated into `K8S_CONFIGS` (`K8S_CONFIG` kept as an alias); new `K8S_FLAP_THRESHOLD` (default 3). Comma, not colon — a colon-separated `KUBECONFIG` means *merge* to kubectl/the client lib.
- **Controller** ([apps/controllers/kubernetes.py](../blob/feat/kubeconfig-failover/apps/controllers/kubernetes.py)):
  - `_KubeEndpoint` per kubeconfig with an isolated `client.Configuration` and lazily-built clients.
  - `v1_api` / `apps_v1_api` / `discovery_api` / `k8s_client` become **properties** pointing at the active endpoint (call sites unchanged; disabled state still yields `None`).
  - `with_failover` decorator: sticky + circular, compare-and-swap rotation (a burst of concurrent gevent failures advances exactly one step).
  - `kubectl` calls are pinned to the active kubeconfig via `--kubeconfig` and fail over in lockstep.
  - `create_lab` is deliberately **not** decorated — failover is at `create_k8s_resource`, so a mid-manifest failure retries only the failing doc.
- **Failover triggers**: timeouts, connection errors, API status 0/5xx, and **401/403 auth**. Valid API errors (404/409/…) propagate unchanged. `_FailoverError` preserves friendly messages through exhaustion; `with_failover(default=...)` keeps the best-effort delete/secret helpers returning `False` on total failure.
- **Metrics / observability**: per-endpoint failover counters, a recent-events ring, `failovers_last_5m`, edge-triggered `is_flapping` ERROR log, and a `"kubeconfig"` block in `get_statistics()` (only when >1 config is set). `get_failover_stats()` accessor for a future `/metrics` scrape.

## Tests

- New [tests/test_k8s_failover.py](../blob/feat/kubeconfig-failover/tests/test_k8s_failover.py) — 17 cases: rotation, stickiness, wrap-around, 401/403, no-failover-on-404, bounded all-down / all-auth-fail, CAS thundering-herd, kubectl failover + NotFound propagation, metrics block, flapping, and backward-compat.
- Fixture updates in `tests/test_k8s_controller.py` / `tests/test_k8s_tape.py` for the client constructor signature and disabled-state handling.
- Full suite: **589 passed**.

## Compatibility

Single-kubeconfig deployments are unchanged: no `"kubeconfig"` stats block, delete-on-timeout still returns `False`, get/create still raise the same friendly "Timeout while …" messages.

Design notes: [doc/multi-kubeconfig-failover-design.md](../blob/feat/kubeconfig-failover/doc/multi-kubeconfig-failover-design.md).
